### PR TITLE
Show SSH auth banners during authentication

### DIFF
--- a/rootshell/Core/Terminal/TerminalSessionController.swift
+++ b/rootshell/Core/Terminal/TerminalSessionController.swift
@@ -853,6 +853,12 @@ final class TerminalSessionController {
 
         let newSession = try createReconnectSession()
         adopt(newSession, pty: pty)
+        // Let the pane re-subscribe its session-scoped observers (the SSH
+        // auth-banner card in particular) BEFORE start() begins authenticating
+        // — a Tailscale check-mode re-auth banner arrives during this very
+        // reconnect attempt, and the old subscription points at the replaced
+        // session.
+        host.terminalNotifySessionDidChange()
         try await newSession.start()
 
         // Cancellation is cooperative: "Cancel Recovery" (or pause on

--- a/rootshell/Features/LocalShell/LocalShellSession+EmbeddedSessions.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+EmbeddedSessions.swift
@@ -566,9 +566,19 @@ extension LocalShellSession {
         // Also guard if we're already in password prompt mode (fallback already happened)
         if case .passwordPrompt = sessionMode { return }
 
+        // Preserve the auth-banner card across teardown: Tailscale-style
+        // rejection reasons arrive as auth banners immediately before the
+        // failure, and stop() plus the session-property didSet would erase
+        // the only copy. Restored below; replaced when the next connection
+        // attempt starts (its stream replays nil) or the shell tears down.
+        let failureBanner = (embeddedSSHSession as? SSHAuthBannerCardProviding)?
+            .authBannerCardState ?? authBannerCardModel.current
+
         embeddedSSHSession?.stop()
         embeddedSSHSession = nil
         activeEmbeddedSSHConfig = nil
+
+        if let failureBanner { authBannerCardModel.relay(failureBanner) }
 
         // Check if this is an auth failure we can retry with password
         // Only offer password fallback if:
@@ -1798,10 +1808,16 @@ extension LocalShellSession {
         // Also guard if we're already in password prompt mode (fallback already happened)
         if case .moshPasswordPrompt = sessionMode { return }
 
+        // Preserve the auth-banner card across teardown (see handleSSHSessionError).
+        let failureBanner = embeddedMoshSession?.authBannerCardState
+            ?? authBannerCardModel.current
+
         embeddedMoshSession?.stop()
         embeddedMoshSession = nil
         activeEmbeddedMoshConfig = nil
         NotificationCenter.default.post(name: .ghosttyEmbeddedMoshSessionDidChange, object: self)
+
+        if let failureBanner { authBannerCardModel.relay(failureBanner) }
 
         // Check if this is an auth failure we can retry with password
         if attemptPasswordFallback(
@@ -2121,10 +2137,16 @@ extension LocalShellSession {
         // the restored scrollback with no failure UI.
         onEmbeddedTrzszFailedBeforeRunning?()
 
+        // Preserve the auth-banner card across teardown (see handleSSHSessionError).
+        let failureBanner = embeddedTrzszSession?.authBannerCardState
+            ?? authBannerCardModel.current
+
         embeddedTrzszSession?.stop()
         embeddedTrzszSession = nil
         activeEmbeddedTrzszConfig = nil
         NotificationCenter.default.post(name: .ghosttyEmbeddedTrzszSessionDidChange, object: self)
+
+        if let failureBanner { authBannerCardModel.relay(failureBanner) }
 
         // Check if this is an auth failure we can retry with password
         if attemptPasswordFallback(

--- a/rootshell/Features/LocalShell/LocalShellSession.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession.swift
@@ -119,11 +119,42 @@ final class LocalShellSession: TerminalSession, EmbeddedConnectionConfigProvidin
         }
     }
 
-    var embeddedSSHSession: TerminalSession?
+    var embeddedSSHSession: TerminalSession? {
+        didSet { updateAuthBannerCardForwarding() }
+    }
     var embeddedSCPTransfer: SCPTransfer?
     var embeddedSFTPSession: SFTPSession?
-    var embeddedMoshSession: MoshSession?
-    var embeddedTrzszSession: TrzszSession?
+    var embeddedMoshSession: MoshSession? {
+        didSet { updateAuthBannerCardForwarding() }
+    }
+    var embeddedTrzszSession: TrzszSession? {
+        didSet { updateAuthBannerCardForwarding() }
+    }
+
+    /// Relays the active embedded session's auth-banner card state through
+    /// this session's own model, so the pane's single observation (of this
+    /// LocalShellSession) sees banners from whichever embedded SSH/Mosh/Trzsz
+    /// session is currently authenticating.
+    let authBannerCardModel = SSHAuthBannerCardModel()
+    private var authBannerCardForwardingTask: Task<Void, Never>?
+
+    private func updateAuthBannerCardForwarding() {
+        authBannerCardForwardingTask?.cancel()
+        authBannerCardForwardingTask = nil
+        let provider = (embeddedSSHSession as? SSHAuthBannerCardProviding)
+            ?? (embeddedMoshSession as SSHAuthBannerCardProviding?)
+            ?? (embeddedTrzszSession as SSHAuthBannerCardProviding?)
+        guard let provider else {
+            authBannerCardModel.clear()
+            return
+        }
+        authBannerCardForwardingTask = Task { [weak self] in
+            for await state in provider.authBannerCardStates() {
+                guard let self, !Task.isCancelled else { return }
+                self.authBannerCardModel.relay(state)
+            }
+        }
+    }
     var embeddedConnectionStartTask: Task<Void, Never>?
     var embeddedConnectionStartTaskID: UUID?
     var activePingCommand: PingCommand?
@@ -1683,6 +1714,18 @@ final class LocalShellSession: TerminalSession, EmbeddedConnectionConfigProvidin
     deinit {
         // Cancel shell task
         shellTask?.cancel()
+    }
+}
+
+// MARK: - Auth banner card
+
+extension LocalShellSession: SSHAuthBannerCardProviding {
+    var authBannerCardState: SSHAuthBannerCardState? {
+        authBannerCardModel.current
+    }
+
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
+        authBannerCardModel.states()
     }
 }
 

--- a/rootshell/Features/Mosh/Session/MoshServerSpawner.swift
+++ b/rootshell/Features/Mosh/Session/MoshServerSpawner.swift
@@ -87,6 +87,13 @@ final class MoshServerSpawner {
     /// `SpawnResult` once spawning completes.
     private let authBannerBuffer = AuthBannerBuffer()
 
+    /// Installs a live observer on the banner buffer so the owning session can
+    /// mirror banners into the auth-banner card while spawn auth is pending.
+    /// Set before `spawn` is called.
+    func setAuthBannerObserver(_ handler: (@Sendable (AuthBannerBuffer.Event) -> Void)?) {
+        authBannerBuffer.setObserver(handler)
+    }
+
     /// Logger
     private nonisolated static let logger = Logger(
         subsystem: "com.kk2.rootshell",
@@ -313,8 +320,8 @@ final class MoshServerSpawner {
             jumpSettings.algorithms = .all
             jumpSettings.loginTimeout = SSHTimeoutConfig.citadelLoginTimeout
             jumpSettings.protocolOptions = SSHConnectionHelper.hostCertificateProtocolOptions(forHost: jumpHost.host)
-            jumpSettings.onUserAuthBanner = { [authBannerBuffer = self.authBannerBuffer] message, _ in
-                authBannerBuffer.append(message)
+            jumpSettings.onUserAuthBanner = { [authBannerBuffer = self.authBannerBuffer, jumpHostName = jumpHost.host] message, _ in
+                authBannerBuffer.append(message, source: jumpHostName)
             }
             let jumpClientConnection: SSHClient
             do {

--- a/rootshell/Features/Mosh/Session/MoshSession.swift
+++ b/rootshell/Features/Mosh/Session/MoshSession.swift
@@ -128,9 +128,22 @@ final class MoshSession: TerminalSession {
     /// Current session state
     private(set) var state: MoshSessionState = .initial {
         didSet {
+            // Clear the auth-banner card on user-initiated teardown
+            // (stop/terminate set .disconnected) — but NOT on .failed:
+            // Tailscale SSH sends its rejection reason as an auth banner
+            // immediately before disconnecting, so on bootstrap-auth failure
+            // the card is the only surface holding the explanation and must
+            // outlive the failure.
+            if case .disconnected = state {
+                authBannerCardModel.clear()
+            }
             onStateChange?(state)
         }
     }
+
+    /// Mirrors bootstrap SSH auth banners into the nonmodal per-pane card
+    /// while mosh-server spawn authentication is pending.
+    let authBannerCardModel = SSHAuthBannerCardModel()
 
     /// Current roam banner state for SwiftUI overlay
     /// nil when banner should not be visible
@@ -805,6 +818,11 @@ final class MoshSession: TerminalSession {
             spawner.delegate = self
             spawner.onKeyboardInteractiveChallenge = onKeyboardInteractiveChallenge
             spawner.onHostKeyValidation = onHostKeyValidation
+            // Live card during bootstrap auth; the spawn-success drain fires
+            // `.reset` and removes it once the SSH phase completes.
+            spawner.setAuthBannerObserver(
+                authBannerCardModel.makeBufferObserver(hostLabel: config.sshConfig.host)
+            )
             self.spawner = spawner
 
             let spawnResult = try await spawner.spawn(resolvedHost: connectionHost)
@@ -2120,5 +2138,17 @@ extension MoshSession {
         }
 
         return false
+    }
+}
+
+// MARK: - Auth banner card
+
+extension MoshSession: SSHAuthBannerCardProviding {
+    var authBannerCardState: SSHAuthBannerCardState? {
+        authBannerCardModel.current
+    }
+
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
+        authBannerCardModel.states()
     }
 }

--- a/rootshell/Features/SSH/Session/CitadelSSHSession.swift
+++ b/rootshell/Features/SSH/Session/CitadelSSHSession.swift
@@ -127,6 +127,11 @@ final class CitadelSSHSession: SSHTerminalSession {
     /// main actor at the `.running` emit site.
     private let authBannerBuffer = AuthBannerBuffer()
 
+    /// Mirrors auth banners into the nonmodal per-pane card as they arrive,
+    /// so the user can act on them (e.g. Tailscale check-mode re-auth URLs)
+    /// while authentication is still pending.
+    let authBannerCardModel = SSHAuthBannerCardModel()
+
     func consumeAuthBanners() -> [String] { authBannerBuffer.drain() }
 
     var onOutput: (@Sendable (String) -> Void)? {
@@ -206,6 +211,13 @@ final class CitadelSSHSession: SSHTerminalSession {
 
     /// Transitions to a new state and notifies the callback
     private func transition(to state: SSHSessionState) {
+        // Deliberately NO card clear on .failed/.disconnected: Tailscale SSH
+        // sends its rejection reason ("tailnet policy does not permit you to
+        // SSH as user …", "tailscale: access denied") as an auth banner
+        // immediately before disconnecting, so on auth failure the card is the
+        // only surface holding the explanation and must outlive the failure.
+        // Teardown still clears it: stop() clears the buffer (firing .reset),
+        // and a replacement session's observer replays nil on re-subscribe.
         onStateChange?(state)
     }
 
@@ -218,6 +230,9 @@ final class CitadelSSHSession: SSHTerminalSession {
     init(pty: TerminalPTY, config: SSHConfig) {
         self.pty = pty
         self.config = config
+        authBannerBuffer.setObserver(
+            authBannerCardModel.makeBufferObserver(hostLabel: config.host)
+        )
         wireEscapeFilter()
     }
 
@@ -437,6 +452,12 @@ final class CitadelSSHSession: SSHTerminalSession {
     /// the generous fixed `SSHTimeoutConfig.citadelLoginTimeout` (5 min) — the
     /// same budget every other Citadel call site in the app uses.
     private func performInitialConnect(timeout: TimeAmount) async throws -> SSHClient {
+        // Fresh per attempt: drop any auth banners a prior failed attempt
+        // buffered so the `.running` flush and the auth-banner card reflect
+        // only this connection (mirrors TrzszSpawnHelper.createSSHClient).
+        // The clear fires `.reset`, resetting the card between attempts.
+        authBannerBuffer.clear()
+
         // Per-attempt cleanup: a previous attempt may have partially populated
         // self.jumpClient before the target connect failed. Close it before
         // retrying so we don't leak event-loop threads parked on a dead socket.
@@ -522,8 +543,8 @@ final class CitadelSSHSession: SSHTerminalSession {
             // The per-attempt `timeout` bounds only TCP connect (above).
             jumpSettings.loginTimeout = SSHTimeoutConfig.citadelLoginTimeout
             jumpSettings.protocolOptions = SSHConnectionHelper.hostCertificateProtocolOptions(forHost: jumpConfig.host)
-            jumpSettings.onUserAuthBanner = { [authBannerBuffer = self.authBannerBuffer] message, _ in
-                authBannerBuffer.append(message)
+            jumpSettings.onUserAuthBanner = { [authBannerBuffer = self.authBannerBuffer, jumpHost = jumpConfig.host] message, _ in
+                authBannerBuffer.append(message, source: jumpHost)
             }
             let jumpChannelBox = CancellationChannelBox(jumpChannel)
             let jumpClientConnection: SSHClient
@@ -2025,3 +2046,15 @@ final class CitadelHostKeyValidatorDelegate: NIOSSHClientServerAuthenticationDel
 
 // CancellationChannelBox and CancellationSSHClientBox live in
 // SSHCancellationBoxes.swift — shared with SSHConnectionHelper.
+
+// MARK: - Auth banner card
+
+extension CitadelSSHSession: SSHAuthBannerCardProviding {
+    var authBannerCardState: SSHAuthBannerCardState? {
+        authBannerCardModel.current
+    }
+
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
+        authBannerCardModel.states()
+    }
+}

--- a/rootshell/Features/SSH/Session/SSHAuthBannerCard.swift
+++ b/rootshell/Features/SSH/Session/SSHAuthBannerCard.swift
@@ -1,0 +1,150 @@
+//
+//  SSHAuthBannerCard.swift
+//  rootshell
+//
+//  Live state for the native SSH auth-banner card (issue #290).
+//
+//  `SSH_MSG_USERAUTH_BANNER` can only arrive during the SSH authentication
+//  phase (RFC 4252 §5.4). The inline scrollback flush necessarily waits until
+//  `.running` (spinner cleanup would wipe earlier writes), which is too late
+//  for banners that tell the user how to authenticate — e.g. Tailscale SSH
+//  "check" mode sending its re-auth URL. This model mirrors banners into a
+//  nonmodal per-pane card the moment they arrive, and tears the card down
+//  when the auth phase ends (the buffer's drain/clear both signal `.reset`).
+//
+
+import Foundation
+
+/// One sanitized banner message shown in the card, in arrival order.
+struct SSHAuthBannerItem: Equatable, Sendable, Identifiable {
+    /// Arrival index within the current auth phase.
+    let id: Int
+    /// Plain text (already through `SSHBanner.plainText`), non-empty.
+    let text: String
+    /// http/https URLs extracted from `text`, for explicit open/copy actions.
+    let urls: [URL]
+    /// Host that sent this banner when it is NOT the card's target host
+    /// (i.e. a jump hop). Rendered so a jump host's re-auth URL is never
+    /// misattributed to the target. Nil for target-host banners.
+    let sourceLabel: String?
+}
+
+/// Everything the card needs to render for one authentication phase.
+struct SSHAuthBannerCardState: Equatable, Sendable {
+    /// Label identifying the connection the banners belong to (target host).
+    var hostLabel: String
+    var items: [SSHAuthBannerItem]
+}
+
+/// Sessions that can surface live auth banners for the pane card.
+@MainActor protocol SSHAuthBannerCardProviding: AnyObject {
+    var authBannerCardState: SSHAuthBannerCardState? { get }
+
+    /// A fresh stream of card-state updates. Each call registers an
+    /// independent subscriber; the current value is replayed as the first
+    /// element, so late subscribers (a pane observing after banners arrived,
+    /// the keyboard-interactive sheet) still see pending banners. The stream
+    /// ends when the consuming task is cancelled or the session deallocates.
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?>
+}
+
+/// Main-actor accumulator each session owns: bridges `AuthBannerBuffer`
+/// events (fired on the NIO event loop) to replaying per-subscriber streams.
+@MainActor final class SSHAuthBannerCardModel {
+    private(set) var current: SSHAuthBannerCardState?
+
+    private typealias BannerEvent = (hostLabel: String, event: AuthBannerBuffer.Event)
+
+    /// Ordered channel from the buffer observer (any thread) to the
+    /// main-actor pump. Continuation yields preserve FIFO order — banners
+    /// must aggregate in arrival order, and unstructured `Task { @MainActor }`
+    /// hops do not guarantee that.
+    private let eventChannel: AsyncStream<BannerEvent>
+    private let eventContinuation: AsyncStream<BannerEvent>.Continuation
+    private var pumpTask: Task<Void, Never>?
+
+    private var subscribers: [UUID: AsyncStream<SSHAuthBannerCardState?>.Continuation] = [:]
+    private var nextID = 0
+
+    init() {
+        (eventChannel, eventContinuation) = AsyncStream.makeStream(of: BannerEvent.self)
+        pumpTask = Task { [weak self, eventChannel] in
+            for await (hostLabel, event) in eventChannel {
+                guard let self else { return }
+                self.handle(event, hostLabel: hostLabel)
+            }
+        }
+    }
+
+    deinit {
+        pumpTask?.cancel()
+        eventContinuation.finish()
+        for continuation in subscribers.values {
+            continuation.finish()
+        }
+    }
+
+    /// Returns a buffer observer bound to this model, suitable for
+    /// `AuthBannerBuffer.setObserver`. Captures only the channel continuation,
+    /// so an observer left on a buffer never retains the session.
+    nonisolated func makeBufferObserver(
+        hostLabel: String
+    ) -> @Sendable (AuthBannerBuffer.Event) -> Void {
+        { [eventContinuation] event in
+            eventContinuation.yield((hostLabel: hostLabel, event: event))
+        }
+    }
+
+    /// Registers a new subscriber stream; replays the current value first.
+    func states() -> AsyncStream<SSHAuthBannerCardState?> {
+        let (stream, continuation) = AsyncStream.makeStream(of: SSHAuthBannerCardState?.self)
+        let id = UUID()
+        continuation.yield(current)
+        subscribers[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.subscribers[id] = nil
+            }
+        }
+        return stream
+    }
+
+    /// Removes the card immediately (auth ended, session torn down/replaced).
+    func clear() {
+        if current != nil { broadcast(nil) }
+    }
+
+    /// Directly relays an already-built state. Used by forwarding wrappers
+    /// (LocalShellSession) that mirror an embedded session's card state.
+    func relay(_ state: SSHAuthBannerCardState?) {
+        broadcast(state)
+    }
+
+    private func handle(_ event: AuthBannerBuffer.Event, hostLabel: String) {
+        switch event {
+        case .appended(let raw, let source):
+            let text = SSHBanner.plainText(raw)
+            guard !text.isEmpty else { return }
+            let item = SSHAuthBannerItem(
+                id: nextID,
+                text: text,
+                urls: SSHBanner.extractHTTPURLs(from: text),
+                sourceLabel: source
+            )
+            nextID += 1
+            var state = current ?? SSHAuthBannerCardState(hostLabel: hostLabel, items: [])
+            state.items.append(item)
+            broadcast(state)
+        case .reset:
+            clear()
+        }
+    }
+
+    private func broadcast(_ state: SSHAuthBannerCardState?) {
+        current = state
+        for continuation in subscribers.values {
+            continuation.yield(state)
+        }
+    }
+}

--- a/rootshell/Features/SSH/Session/SSHBanner.swift
+++ b/rootshell/Features/SSH/Session/SSHBanner.swift
@@ -50,6 +50,91 @@ nonisolated enum SSHBanner {
         return lines.joined(separator: "\r\n") + "\r\n"
     }
 
+    /// Sanitizes a server auth banner for native (non-terminal) display, such
+    /// as the auth-banner card. Unlike `renderAuthBanner`, ALL escape
+    /// sequences are stripped — including SGR — because native views render
+    /// plain text. Keeps printable Unicode and TAB, drops C0/C1 controls and
+    /// DEL, normalizes line endings to `\n`, and trims surrounding whitespace.
+    static func plainText(_ raw: String) -> String {
+        guard !raw.isEmpty else { return "" }
+        var normalized = raw.replacingOccurrences(of: "\r\n", with: "\n")
+        normalized = normalized.replacingOccurrences(of: "\r", with: "\n")
+        let lines = normalized.components(separatedBy: "\n").map { line in
+            let scalars = Array(line.unicodeScalars)
+            var out = String.UnicodeScalarView()
+            var i = 0
+            while i < scalars.count {
+                let v = scalars[i].value
+                if v == 0x1b {
+                    // ESC — consume the whole sequence, emit nothing (no SGR
+                    // survives; native text has no use for it).
+                    i = scanEscapeSequence(scalars, from: i).next
+                } else if v == 0x09 {  // TAB
+                    out.append(scalars[i]); i += 1
+                } else if v < 0x20 || (v >= 0x7f && v <= 0x9f) {
+                    i += 1  // C0 controls, DEL, C1 range
+                } else {
+                    out.append(scalars[i]); i += 1
+                }
+            }
+            return String(out)
+        }
+        return lines.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Extracts http/https URLs from sanitized plain text (the output of
+    /// `plainText`), in order of first appearance, deduplicated, capped at 8.
+    /// A deliberate manual scan rather than NSDataDetector: only explicit
+    /// `http://` / `https://` prefixes qualify, so custom schemes and schemeless
+    /// hosts in server-controlled pre-auth text never become tappable actions.
+    static func extractHTTPURLs(from plainText: String) -> [URL] {
+        let maxURLs = 8
+        // Characters that end a URL token beyond whitespace: common banner
+        // delimiters like <...>, quotes, and backticks.
+        let terminators = Set<Character>(["<", ">", "\"", "'", "`"])
+        // Trailing punctuation that is far more likely prose than URL.
+        let trailing = Set<Character>([".", ",", ";", ":", "!", "?", ")", "]", "}", ">", "'", "\""])
+
+        var urls: [URL] = []
+        var seen = Set<String>()
+        var searchStart = plainText.startIndex
+        while urls.count < maxURLs,
+              let range = plainText.range(
+                of: "http", options: [.caseInsensitive],
+                range: searchStart..<plainText.endIndex
+              ) {
+            let candidateStart = range.lowerBound
+            let rest = plainText[candidateStart...]
+            guard rest.range(of: "http://", options: [.caseInsensitive, .anchored]) != nil
+                || rest.range(of: "https://", options: [.caseInsensitive, .anchored]) != nil
+            else {
+                searchStart = plainText.index(after: candidateStart)
+                continue
+            }
+            var end = candidateStart
+            while end < plainText.endIndex {
+                let c = plainText[end]
+                if c.isWhitespace || c.isNewline || terminators.contains(c) { break }
+                end = plainText.index(after: end)
+            }
+            var token = String(plainText[candidateStart..<end])
+            while let last = token.last, trailing.contains(last) {
+                token.removeLast()
+            }
+            searchStart = end
+            guard let url = URL(string: token),
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https",
+                  let host = url.host, !host.isEmpty
+            else { continue }
+            if seen.insert(url.absoluteString).inserted {
+                urls.append(url)
+            }
+        }
+        return urls
+    }
+
     /// Filters a banner line to printable text plus a safe subset of ANSI: only
     /// SGR color/style sequences (`ESC[…m` with standard params) survive. Every
     /// other escape sequence is stripped — CSI cursor moves / erase / device
@@ -287,38 +372,70 @@ nonisolated final class AuthBannerBuffer: @unchecked Sendable {
     /// `SSH_MSG_USERAUTH_BANNER` repeatedly before authentication completes.
     private static let maxTotalBytes = 64 * 1024
 
+    /// Live buffer activity, for observers that mirror banners into native UI
+    /// (the auth-banner card) as they arrive rather than waiting for the
+    /// `.running` drain.
+    enum Event: Sendable {
+        /// A banner was accepted into the buffer (post-truncation text).
+        /// `source` names the host that sent it when it is NOT the target
+        /// host (i.e. a jump hop) — a jump host's re-auth URL must not be
+        /// attributed to the target for a security-sensitive action.
+        case appended(String, source: String?)
+        /// The buffer was drained or cleared — the auth phase ended one way
+        /// or another, so any mirrored display should be torn down.
+        case reset
+    }
+
     private let lock = NSLock()
     private var banners: [String] = []
     private var totalBytes = 0
+    private var observer: (@Sendable (Event) -> Void)?
 
-    func append(_ banner: String) {
+    /// Sets the live observer. Invoked outside the lock on the caller's thread
+    /// (the NIO event loop for `append`; any thread for `drain`/`clear`).
+    /// Set before the connection starts.
+    func setObserver(_ handler: (@Sendable (Event) -> Void)?) {
+        lock.lock()
+        observer = handler
+        lock.unlock()
+    }
+
+    func append(_ banner: String, source: String? = nil) {
         var text = banner
         if text.utf8.count > Self.maxBannerBytes {
             text = String(decoding: text.utf8.prefix(Self.maxBannerBytes), as: UTF8.self)
         }
         let cost = text.utf8.count
         lock.lock()
-        defer { lock.unlock() }
-        guard totalBytes + cost <= Self.maxTotalBytes else { return }
-        banners.append(text)
-        totalBytes += cost
+        let accepted = totalBytes + cost <= Self.maxTotalBytes
+        if accepted {
+            banners.append(text)
+            totalBytes += cost
+        }
+        let handler = observer
+        lock.unlock()
+        if accepted { handler?(.appended(text, source: source)) }
     }
 
     /// Returns and clears all buffered banners.
     func drain() -> [String] {
         lock.lock()
-        defer { lock.unlock() }
         let result = banners
         banners.removeAll()
         totalBytes = 0
+        let handler = observer
+        lock.unlock()
+        handler?(.reset)
         return result
     }
 
     /// Discards any buffered banners without returning them (failure/teardown).
     func clear() {
         lock.lock()
-        defer { lock.unlock() }
         banners.removeAll()
         totalBytes = 0
+        let handler = observer
+        lock.unlock()
+        handler?(.reset)
     }
 }

--- a/rootshell/Features/SSH/Views/KeyboardInteractivePromptView.swift
+++ b/rootshell/Features/SSH/Views/KeyboardInteractivePromptView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Modal for answering a keyboard-interactive (RFC 4256) SSH challenge: the
 /// server supplies a name/instruction and one or more prompts (each marked echo
@@ -9,21 +10,29 @@ struct KeyboardInteractivePromptView: View {
     let sessionLabel: String
     let onSubmit: ([String]) -> Void
     let onCancel: () -> Void
+    /// Factory for the session's live auth-banner state stream, shown
+    /// display-only above the prompts. The sheet covers the pane's
+    /// auth-banner card on iPhone, so OTP-style banner instructions (and
+    /// their URLs) must appear here too.
+    let authBannerStates: (@MainActor () -> AsyncStream<SSHAuthBannerCardState?>)?
 
     @Environment(\.sheetThemeColors) private var sheetThemeColors
     @State private var responses: [String]
+    @State private var bannerState: SSHAuthBannerCardState?
     @FocusState private var focusedIndex: Int?
 
     init(
         challenge: KeyboardInteractiveChallenge,
         sessionLabel: String,
         onSubmit: @escaping ([String]) -> Void,
-        onCancel: @escaping () -> Void
+        onCancel: @escaping () -> Void,
+        authBannerStates: (@MainActor () -> AsyncStream<SSHAuthBannerCardState?>)? = nil
     ) {
         self.challenge = challenge
         self.sessionLabel = sessionLabel
         self.onSubmit = onSubmit
         self.onCancel = onCancel
+        self.authBannerStates = authBannerStates
         _responses = State(initialValue: Array(repeating: "", count: challenge.prompts.count))
     }
 
@@ -50,6 +59,26 @@ struct KeyboardInteractivePromptView: View {
                 } footer: {
                     if !challenge.instruction.isEmpty {
                         Text(challenge.instruction)
+                    }
+                }
+
+                if let bannerState {
+                    Section {
+                        SSHAuthBannerContentView(
+                            state: bannerState,
+                            onOpenURL: { url in
+                                UIApplication.shared.open(url)
+                            },
+                            onCopyURL: { url in
+                                UIPasteboard.general.string = url.absoluteString
+                                ClipboardHistoryManager.shared.record(
+                                    url.absoluteString, source: .copyLink
+                                )
+                            }
+                        )
+                        .themedRow()
+                    } header: {
+                        Text("Server Message")
                     }
                 }
 
@@ -88,6 +117,12 @@ struct KeyboardInteractivePromptView: View {
                 guard !challenge.prompts.isEmpty else { return }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     focusedIndex = 0
+                }
+            }
+            .task {
+                guard let authBannerStates else { return }
+                for await state in authBannerStates() {
+                    bannerState = state
                 }
             }
         }

--- a/rootshell/Features/SSH/Views/SSHAuthBannerCardHostView.swift
+++ b/rootshell/Features/SSH/Views/SSHAuthBannerCardHostView.swift
@@ -1,0 +1,176 @@
+//
+//  SSHAuthBannerCardHostView.swift
+//  rootshell
+//
+//  UIKit wrapper hosting the SwiftUI SSH auth-banner card inside the
+//  UIKit-based TerminalScrollView. Modeled on MoshRoamBannerHostView, but
+//  interactive (open/copy/collapse actions) and re-homeable so a mid-auth
+//  window transfer keeps the child view controller chain valid.
+//
+
+import SwiftUI
+import UIKit
+
+@MainActor
+final class SSHAuthBannerCardHostView: UIView {
+
+    // MARK: - Properties
+
+    private var hostingController: UIHostingController<SSHAuthBannerCardView>?
+    private weak var parentViewController: UIViewController?
+
+    /// Current card state (readable for stacking/cleanup checks).
+    private(set) var currentState: SSHAuthBannerCardState?
+
+    /// Collapse lives here, not in SwiftUI @State: the rootView is replaced on
+    /// every state update, which would silently reset view-local state.
+    private var isCollapsed = false
+
+    /// Opens a banner URL. Injected so the host stays testable/preview-safe;
+    /// defaults to the platform browser via UIApplication.
+    var onOpenURL: (URL) -> Void = { url in
+        UIApplication.shared.open(url)
+    }
+
+    /// Copies a banner URL, recording it in clipboard history like the
+    /// terminal's own Copy Link action.
+    var onCopyURL: (URL) -> Void = { url in
+        UIPasteboard.general.string = url.absoluteString
+        ClipboardHistoryManager.shared.record(url.absoluteString, source: .copyLink)
+    }
+
+    // MARK: - Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isUserInteractionEnabled = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public Methods
+
+    /// Updates the card with new state; nil hides and tears down.
+    func update(state: SSHAuthBannerCardState?) {
+        if state == currentState { return }
+        // New banner content must be seen: force-expand when items grow.
+        if let state, state.items.count > (currentState?.items.count ?? 0), isCollapsed {
+            isCollapsed = false
+        }
+        currentState = state
+
+        if let state {
+            showCard(with: state)
+            UIAccessibility.post(notification: .layoutChanged, argument: hostingController?.view)
+        } else {
+            isCollapsed = false
+            hideCard()
+        }
+    }
+
+    /// Sets (or re-homes to) the parent view controller. Unlike the Mosh
+    /// template, an existing hosting controller is moved to the new parent so
+    /// a window transfer mid-auth doesn't strand the child VC.
+    func setParentViewController(_ viewController: UIViewController?) {
+        guard parentViewController !== viewController else { return }
+        parentViewController = viewController
+        guard let hc = hostingController else { return }
+        hc.willMove(toParent: nil)
+        hc.removeFromParent()
+        if let parent = viewController {
+            parent.addChild(hc)
+            hc.didMove(toParent: parent)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func rootView(for state: SSHAuthBannerCardState) -> SSHAuthBannerCardView {
+        SSHAuthBannerCardView(
+            state: state,
+            isCollapsed: isCollapsed,
+            onToggleCollapse: { [weak self] in
+                guard let self else { return }
+                self.isCollapsed.toggle()
+                if let current = self.currentState {
+                    self.showCard(with: current)
+                }
+            },
+            onOpenURL: { [weak self] url in self?.onOpenURL(url) },
+            onCopyURL: { [weak self] url in self?.onCopyURL(url) }
+        )
+    }
+
+    private func showCard(with state: SSHAuthBannerCardState) {
+        if let hc = hostingController {
+            hc.rootView = rootView(for: state)
+            hc.view.invalidateIntrinsicContentSize()
+            // Reverse an in-flight hide: a reset followed immediately by a new
+            // banner (e.g. retry-attempt clear then a fresh banner) must leave
+            // the card visible. The hide completion checks currentState, so
+            // reanimating here also defuses its teardown.
+            if hc.view.alpha < 1 {
+                UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseOut, .beginFromCurrentState]) {
+                    hc.view.alpha = 1
+                    hc.view.transform = .identity
+                }
+            }
+        } else {
+            let hc = UIHostingController(rootView: rootView(for: state))
+            hc.view.backgroundColor = .clear
+            hc.view.translatesAutoresizingMaskIntoConstraints = false
+
+            if let parent = parentViewController {
+                parent.addChild(hc)
+                addSubview(hc.view)
+                hc.didMove(toParent: parent)
+            } else {
+                addSubview(hc.view)
+            }
+
+            NSLayoutConstraint.activate([
+                hc.view.topAnchor.constraint(equalTo: topAnchor),
+                hc.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+                hc.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+                hc.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            ])
+
+            hostingController = hc
+
+            hc.view.alpha = 0
+            let reduceMotion = UIAccessibility.isReduceMotionEnabled
+            if !reduceMotion {
+                hc.view.transform = CGAffineTransform(translationX: 0, y: -10)
+            }
+            UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
+                hc.view.alpha = 1
+                hc.view.transform = .identity
+            }
+        }
+    }
+
+    private func hideCard() {
+        guard let hc = hostingController else { return }
+        let reduceMotion = UIAccessibility.isReduceMotionEnabled
+        UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseIn]) {
+            hc.view.alpha = 0
+            if !reduceMotion {
+                hc.view.transform = CGAffineTransform(translationX: 0, y: -10)
+            }
+        } completion: { [weak self] _ in
+            // A new banner may have re-shown the card while the hide was
+            // animating; tear down only if this controller is still current
+            // AND the card is still meant to be hidden.
+            guard let self, self.hostingController === hc, self.currentState == nil else {
+                return
+            }
+            hc.willMove(toParent: nil)
+            hc.view.removeFromSuperview()
+            hc.removeFromParent()
+            self.hostingController = nil
+        }
+    }
+}

--- a/rootshell/Features/SSH/Views/SSHAuthBannerCardView.swift
+++ b/rootshell/Features/SSH/Views/SSHAuthBannerCardView.swift
@@ -1,0 +1,251 @@
+//
+//  SSHAuthBannerCardView.swift
+//  rootshell
+//
+//  Nonmodal card showing SSH_MSG_USERAUTH_BANNER text live during SSH
+//  authentication (issue #290), with explicit open/copy actions for
+//  server-provided http(s) URLs. Server content renders as selectable plain
+//  text only — never interpreted, never auto-opened.
+//
+
+import SwiftUI
+import UIKit
+
+/// The auth-banner card shown over a terminal pane during SSH authentication.
+/// Collapsible to a pill; never permanently dismissible while auth is pending
+/// (the state going nil removes it).
+struct SSHAuthBannerCardView: View {
+    let state: SSHAuthBannerCardState
+    let isCollapsed: Bool
+    let onToggleCollapse: () -> Void
+    let onOpenURL: (URL) -> Void
+    let onCopyURL: (URL) -> Void
+
+    private var transitionAnimation: Animation {
+        UIAccessibility.isReduceMotionEnabled
+            ? .easeInOut(duration: 0.2)
+            : .spring(response: 0.38, dampingFraction: 0.8)
+    }
+
+    var body: some View {
+        Group {
+            if isCollapsed {
+                collapsedPill
+            } else {
+                expandedCard
+            }
+        }
+        .animation(transitionAnimation, value: isCollapsed)
+    }
+
+    // MARK: - Collapsed pill
+
+    private var collapsedPill: some View {
+        Button(action: onToggleCollapse) {
+            HStack(spacing: 6) {
+                Image(systemName: "text.bubble")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Server message", comment: "Collapsed SSH auth banner pill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary)
+                if state.items.count > 1 {
+                    Text(verbatim: "\(state.items.count)")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(.secondary.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .bannerBackground()
+        .accessibilityLabel(Text(
+            "Server message during SSH authentication. Tap to expand.",
+            comment: "Accessibility label for collapsed SSH auth banner pill"
+        ))
+    }
+
+    // MARK: - Expanded card
+
+    private var expandedCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "text.bubble")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Server message", comment: "SSH auth banner card title")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(verbatim: state.hostLabel)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                Button(action: onToggleCollapse) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(4)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(
+                    "Collapse server message",
+                    comment: "Accessibility label for SSH auth banner collapse button"
+                ))
+            }
+
+            SSHAuthBannerContentView(
+                state: state,
+                onOpenURL: onOpenURL,
+                onCopyURL: onCopyURL
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: 420)
+        .bannerBackground()
+    }
+}
+
+/// Banner text plus per-URL action rows. Shared between the pane card and the
+/// keyboard-interactive prompt sheet (which covers the pane on iPhone exactly
+/// when OTP-style banners matter most).
+struct SSHAuthBannerContentView: View {
+    let state: SSHAuthBannerCardState
+    let onOpenURL: (URL) -> Void
+    let onCopyURL: (URL) -> Void
+
+    /// Items paired with their URLs, deduplicated across the card in
+    /// first-appearance order. URLs stay attached to the item that carried
+    /// them so a jump host's URL renders under the jump host's attribution,
+    /// never the target's.
+    private var renderedItems: [(item: SSHAuthBannerItem, urls: [URL])] {
+        var seen = Set<String>()
+        return state.items.map { item in
+            (item, item.urls.filter { seen.insert($0.absoluteString).inserted })
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(renderedItems, id: \.item.id) { entry in
+                VStack(alignment: .leading, spacing: 6) {
+                    if let source = entry.item.sourceLabel {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.triangle.branch")
+                                .font(.system(size: 9, weight: .semibold))
+                            Text("From jump host \(source)", comment: "SSH auth banner jump-host attribution")
+                                .font(.system(size: 10, weight: .semibold))
+                        }
+                        .foregroundStyle(.secondary)
+                    }
+                    SelectableBannerText(text: entry.item.text)
+                    ForEach(entry.urls, id: \.absoluteString) { url in
+                        urlRow(url)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func urlRow(_ url: URL) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(verbatim: url.absoluteString)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            HStack(spacing: 8) {
+                Button {
+                    onOpenURL(url)
+                } label: {
+                    Label {
+                        Text("Open in Browser", comment: "SSH auth banner URL action")
+                    } icon: {
+                        Image(systemName: "safari")
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel(Text(
+                    "Open \(url.host ?? url.absoluteString) in browser",
+                    comment: "Accessibility label for SSH auth banner open-URL button"
+                ))
+
+                Button {
+                    onCopyURL(url)
+                } label: {
+                    Label {
+                        Text("Copy Link", comment: "SSH auth banner URL action")
+                    } icon: {
+                        Image(systemName: "link")
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel(Text(
+                    "Copy link to \(url.host ?? url.absoluteString)",
+                    comment: "Accessibility label for SSH auth banner copy-URL button"
+                ))
+            }
+        }
+    }
+}
+
+/// Minimal selectable-text wrapper. SwiftUI's `.textSelection(.enabled)`
+/// doesn't support click-and-drag selection on Mac Catalyst, so banner text
+/// goes through a UITextView. Deliberately local (not the AIAgent
+/// `SelectableTextView`, which is excluded from the China build) and
+/// deliberately inert: not editable, no data detectors, so server-controlled
+/// text can never become a tappable link — URLs get explicit buttons instead.
+private struct SelectableBannerText: UIViewRepresentable {
+    let text: String
+
+    /// Cap before the text scrolls internally; the pane host also caps the
+    /// whole card at 60% of pane height.
+    private static let maxHeight: CGFloat = 200
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.isScrollEnabled = true
+        view.dataDetectorTypes = []
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        view.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        view.textColor = .label
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        if uiView.text != text {
+            uiView.text = text
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize, uiView: UITextView, context: Context
+    ) -> CGSize? {
+        let width = proposal.width ?? 396
+        let fitting = uiView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        return CGSize(width: width, height: min(fitting.height, Self.maxHeight))
+    }
+}

--- a/rootshell/Features/TSSH/Session/TSSHSession.swift
+++ b/rootshell/Features/TSSH/Session/TSSHSession.swift
@@ -147,9 +147,25 @@ final class TrzszSession: TerminalSession {
     /// Current session state
     private(set) var state: TrzszSessionState = .initial {
         didSet {
+            // Clear the auth-banner card on user-initiated or clean teardown
+            // (.disconnected / .serverShutdown) — but NOT on .failed:
+            // Tailscale SSH sends its rejection reason as an auth banner
+            // immediately before disconnecting, so on bootstrap-auth failure
+            // the card is the only surface holding the explanation and must
+            // outlive the failure.
+            switch state {
+            case .disconnected, .serverShutdown:
+                authBannerCardModel.clear()
+            default:
+                break
+            }
             onStateChange?(state)
         }
     }
+
+    /// Mirrors bootstrap SSH auth banners into the nonmodal per-pane card
+    /// while tsshd spawn authentication is pending.
+    let authBannerCardModel = SSHAuthBannerCardModel()
 
     /// Current latency in milliseconds
     var latencyMs: Int? {
@@ -873,7 +889,10 @@ final class TrzszSession: TerminalSession {
             config: config,
             resolvedHost: resolvedHost,
             onHostKeyValidation: onHostKeyValidation,
-            onKeyboardInteractiveChallenge: onKeyboardInteractiveChallenge
+            onKeyboardInteractiveChallenge: onKeyboardInteractiveChallenge,
+            authBannerObserver: authBannerCardModel.makeBufferObserver(
+                hostLabel: config.sshConfig.host
+            )
         )
 
         // Capture bootstrap SSH algorithms from spawn
@@ -2137,5 +2156,17 @@ extension TrzszSession {
 
         startPeriodicStateUpdates()
         onReady?()
+    }
+}
+
+// MARK: - Auth banner card
+
+extension TrzszSession: SSHAuthBannerCardProviding {
+    var authBannerCardState: SSHAuthBannerCardState? {
+        authBannerCardModel.current
+    }
+
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
+        authBannerCardModel.states()
     }
 }

--- a/rootshell/Features/TSSH/Session/TSSHSpawnHelper.swift
+++ b/rootshell/Features/TSSH/Session/TSSHSpawnHelper.swift
@@ -49,7 +49,8 @@ enum TrzszSpawnHelper {
         config: TrzszConfig,
         resolvedHost: String,
         onHostKeyValidation: ((HostKeyValidationRequest) async -> HostKeyValidationResult)?,
-        onKeyboardInteractiveChallenge: ((KeyboardInteractiveChallenge) async -> [String]?)? = nil
+        onKeyboardInteractiveChallenge: ((KeyboardInteractiveChallenge) async -> [String]?)? = nil,
+        authBannerObserver: (@Sendable (AuthBannerBuffer.Event) -> Void)? = nil
     ) async throws -> SpawnResult {
         let command = config.serverCommand()
         logger.info("Spawning tsshd: \(command)")
@@ -57,8 +58,10 @@ enum TrzszSpawnHelper {
         // Captures server auth banners (`SSH_MSG_USERAUTH_BANNER`) from the NIO
         // event loop during authentication. Cleared at the start of each connect
         // attempt (in `createSSHClient`) so only the successful attempt's banners
-        // remain after the retry loop.
+        // remain after the retry loop — the per-attempt clear also resets the
+        // live observer's card between attempts.
         let authBannerBuffer = AuthBannerBuffer()
+        authBannerBuffer.setObserver(authBannerObserver)
 
         // Connect SSH with bounded retry on transient connection failures.
         // The per-attempt `timeout` drives only the retry cadence here; the
@@ -233,8 +236,8 @@ enum TrzszSpawnHelper {
             jumpSettings.loginTimeout = loginTimeout
             jumpSettings.protocolOptions = SSHConnectionHelper.hostCertificateProtocolOptions(forHost: jumpHost.host)
             if let authBannerBuffer {
-                jumpSettings.onUserAuthBanner = { [authBannerBuffer] message, _ in
-                    authBannerBuffer.append(message)
+                jumpSettings.onUserAuthBanner = { [authBannerBuffer, jumpHostName = jumpHost.host] message, _ in
+                    authBannerBuffer.append(message, source: jumpHostName)
                 }
             }
             let jumpClient: SSHClient

--- a/rootshell/UI/Shell/MainView+Presentation.swift
+++ b/rootshell/UI/Shell/MainView+Presentation.swift
@@ -282,7 +282,8 @@ extension MainView {
                         },
                         onCancel: {
                             respondToKeyboardInteractive(nil)
-                        }
+                        },
+                        authBannerStates: entry.authBannerStates
                     )
                     // Force an explicit Submit/Cancel: a swipe-dismiss must still
                     // resume the continuation, so treat interactive dismissal as

--- a/rootshell/UI/Shell/MainView+SSHValidation.swift
+++ b/rootshell/UI/Shell/MainView+SSHValidation.swift
@@ -106,6 +106,14 @@ struct PendingKeyboardInteractiveChallenge: Identifiable {
     /// that session tears down before the user responds.
     let terminalID: ObjectIdentifier
     let continuation: CheckedContinuation<[String]?, Never>
+    /// Factory for the session's live auth-banner state stream, shown
+    /// display-only inside the prompt sheet. The sheet is modal, so on iPhone
+    /// it hides the pane's auth-banner card exactly when OTP-style banner
+    /// instructions matter — this carries them into the sheet. A factory
+    /// rather than a stream because each stream is single-consumption; the
+    /// view's `.task` makes a fresh one per appearance. Live: banners
+    /// arriving while the sheet is up still appear.
+    let authBannerStates: (@MainActor () -> AsyncStream<SSHAuthBannerCardState?>)?
 }
 
 extension MainView {
@@ -123,7 +131,9 @@ extension MainView {
                 challenge: challenge,
                 sessionLabel: label,
                 terminalID: ObjectIdentifier(terminalView),
-                continuation: continuation
+                continuation: continuation,
+                authBannerStates: (terminalView.session as? SSHAuthBannerCardProviding)
+                    .map { provider in { @MainActor in provider.authBannerCardStates() } }
             )
             keyboardInteractiveQueue.append(entry)
             if !showKeyboardInteractivePrompt {

--- a/rootshell/UI/Terminal/TerminalScrollView.swift
+++ b/rootshell/UI/Terminal/TerminalScrollView.swift
@@ -162,6 +162,18 @@ extension Ghostty {
     /// Attachment upload banner host view
     private var uploadBannerHostView: AttachmentUploadBannerHostView?
 
+    /// SSH auth-banner card host view (shows SSH_MSG_USERAUTH_BANNER live
+    /// during authentication)
+    private var authBannerCardHostView: SSHAuthBannerCardHostView?
+
+    /// The auth card's top constraint. Recomputed whenever any banner in the
+    /// stacking chain changes — anchoring only at creation goes stale when the
+    /// roam/upload banner above it appears or is removed.
+    private var authBannerCardTopConstraint: NSLayoutConstraint?
+
+    /// Task consuming the session's auth-banner card state stream
+    private var authBannerObserveTask: Task<Void, Never>?
+
     /// Cancellable for observing terminal session changes
     private var sessionObserverCancellable: AnyCancellable?
 
@@ -217,6 +229,7 @@ extension Ghostty {
 
     deinit {
         foregroundBannerGraceTask?.cancel()
+        authBannerObserveTask?.cancel()
         restoreNativeScrollIndicatorWorkItem?.cancel()
         selectionScrollIndicatorHoldWorkItem?.cancel()
         // Clean up notification observers
@@ -253,6 +266,10 @@ extension Ghostty {
             // slider/Reset button never see it). The brightness HUD is
             // cross-platform; the dimension overlay is iOS-only.
             if let hitView = brightnessHUDHitTest(point, with: event) {
+                return hitView
+            }
+
+            if let hitView = authBannerCardHitTest(point, with: event) {
                 return hitView
             }
 
@@ -303,6 +320,13 @@ extension Ghostty {
             return hitView
         }
 
+        // Same carve-out for the auth-banner card: it must stay tappable on
+        // Catalyst where the in-bounds check below would otherwise return
+        // terminalView for every click.
+        if let hitView = authBannerCardHitTest(point, with: event) {
+            return hitView
+        }
+
         let terminalPoint = convert(point, to: terminalView)
         if terminalView.bounds.contains(terminalPoint) {
             if let event {
@@ -330,6 +354,18 @@ extension Ghostty {
         }
         let hudPoint = convert(point, to: hudView)
         return hudView.hitTest(hudPoint, with: event)
+    }
+
+    /// If the SSH auth-banner card covers `point`, return the hit subview so
+    /// its open/copy/collapse controls receive the click/touch even during
+    /// mouse capture or under the Catalyst transparent-scroll-view routing.
+    private func authBannerCardHitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let cardView = authBannerCardHostView, cardView.superview != nil,
+              cardView.alpha > 0 else {
+            return nil
+        }
+        let cardPoint = convert(point, to: cardView)
+        return cardView.hitTest(cardPoint, with: event)
     }
 
     #if !targetEnvironment(macCatalyst)
@@ -864,6 +900,11 @@ extension Ghostty {
 
     /// Updates the roaming session observer when the terminal's session changes
     private func updateMoshSessionObserver() {
+        // The auth-banner card tracks the session through the exact same
+        // invalidation sites (initial setup, session adoption, embedded-mosh
+        // change, reconnect), so re-resolve it here too.
+        updateAuthBannerObserver()
+
         // Cancel existing observer
         roamBannerCancellable?.cancel()
         roamBannerCancellable = nil
@@ -904,6 +945,31 @@ extension Ghostty {
 
         // Not a roaming session - hide any existing banner
         updateRoamBanner(state: nil)
+    }
+
+    /// Re-resolves the auth-banner card subscription for the current session.
+    /// Invoked from the same sites as the roam-banner observer so it tracks
+    /// session adoption, reconnect replacement, and embedded-session changes.
+    /// LocalShellSession conforms to SSHAuthBannerCardProviding directly
+    /// (forwarding its embedded session's state), so one subscription per
+    /// session object covers all embedded transitions.
+    private func updateAuthBannerObserver() {
+        authBannerObserveTask?.cancel()
+        authBannerObserveTask = nil
+
+        guard let provider = terminalView.session as? SSHAuthBannerCardProviding else {
+            updateAuthBannerCard(state: nil)
+            return
+        }
+
+        // The stream replays the current value first, so banners that arrived
+        // before this pane observed the session still show.
+        authBannerObserveTask = Task { [weak self] in
+            for await state in provider.authBannerCardStates() {
+                guard let self, !Task.isCancelled else { return }
+                self.updateAuthBannerCard(state: state)
+            }
+        }
     }
 
     /// Observes a MoshSession's roamBannerState and updates the banner accordingly
@@ -980,6 +1046,7 @@ extension Ghostty {
         }
 
         roamBannerHostView?.update(state: state)
+        refreshAuthBannerCardTopConstraint()
 
         // Remove host view when state is nil (after animation completes)
         if state == nil {
@@ -988,6 +1055,7 @@ extension Ghostty {
                 guard self?.roamBannerHostView?.currentState == nil else { return }
                 self?.roamBannerHostView?.removeFromSuperview()
                 self?.roamBannerHostView = nil
+                self?.refreshAuthBannerCardTopConstraint()
             }
         }
     }
@@ -1062,14 +1130,90 @@ extension Ghostty {
         }
 
         uploadBannerHostView?.update(state: state)
+        refreshAuthBannerCardTopConstraint()
 
         if state == nil {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 guard self?.uploadBannerHostView?.currentState == nil else { return }
                 self?.uploadBannerHostView?.removeFromSuperview()
                 self?.uploadBannerHostView = nil
+                self?.refreshAuthBannerCardTopConstraint()
             }
         }
+    }
+
+    // MARK: - SSH Auth Banner Card Handling
+
+    /// Re-homes the auth-banner card's hosting controller under a new parent
+    /// view controller. Called from the pane's `prepareForAttachment` during
+    /// window transfer, before the split tree inserts the pane into the
+    /// destination hierarchy.
+    func refreshAuthBannerParentViewController(_ viewController: UIViewController?) {
+        authBannerCardHostView?.setParentViewController(viewController)
+    }
+
+    private func updateAuthBannerCard(state: SSHAuthBannerCardState?) {
+        if state != nil && authBannerCardHostView == nil {
+            let hostView = SSHAuthBannerCardHostView()
+            hostView.translatesAutoresizingMaskIntoConstraints = false
+
+            if let parentVC = findViewController() {
+                hostView.setParentViewController(parentVC)
+            }
+
+            addSubview(hostView)
+
+            NSLayoutConstraint.activate([
+                hostView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                hostView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 16),
+                hostView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+                // A hostile 64 KiB banner scrolls inside the card instead of
+                // covering the pane (and the auth prompts under it).
+                hostView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor, multiplier: 0.6)
+            ])
+
+            authBannerCardHostView = hostView
+        }
+
+        refreshAuthBannerCardTopConstraint()
+        authBannerCardHostView?.update(state: state)
+
+        if state == nil {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                guard self?.authBannerCardHostView?.currentState == nil else { return }
+                self?.authBannerCardHostView?.removeFromSuperview()
+                self?.authBannerCardHostView = nil
+            }
+        }
+    }
+
+    /// Re-anchors the auth card in the banner stacking chain: below the upload
+    /// banner, else below the roam banner, else at the top. Called whenever
+    /// the card or either banner above it changes, so the card never keeps a
+    /// constraint to a banner that has since disappeared (which would leave
+    /// its vertical position ambiguous) or overlaps one that appeared later.
+    private func refreshAuthBannerCardTopConstraint() {
+        guard let hostView = authBannerCardHostView, hostView.superview === self else { return }
+
+        let topAnchor: NSLayoutYAxisAnchor
+        let topConstant: CGFloat
+        if let uploadBanner = uploadBannerHostView, uploadBanner.superview === self,
+           uploadBanner.currentState != nil {
+            topAnchor = uploadBanner.bottomAnchor
+            topConstant = 4
+        } else if let roamBanner = roamBannerHostView, roamBanner.superview === self,
+                  roamBanner.currentState != nil {
+            topAnchor = roamBanner.bottomAnchor
+            topConstant = 4
+        } else {
+            topAnchor = self.topAnchor
+            topConstant = 8
+        }
+
+        authBannerCardTopConstraint?.isActive = false
+        let constraint = hostView.topAnchor.constraint(equalTo: topAnchor, constant: topConstant)
+        constraint.isActive = true
+        authBannerCardTopConstraint = constraint
     }
 
     // MARK: - Progress Bar Handling

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -1393,6 +1393,15 @@ extension Ghostty {
             cleanup(reason: .userClose)
         }
 
+        /// Re-home overlay child view controllers (the SSH auth-banner card)
+        /// under the destination window's controller before the split tree
+        /// inserts this pane — a live card mid-auth must not keep a child-VC
+        /// relationship with the old window after a tab transfer.
+        override func prepareForAttachment(to parentViewController: UIViewController?) -> Bool {
+            enclosingTerminalScrollView?.refreshAuthBannerParentViewController(parentViewController)
+            return true
+        }
+
         /// Explicitly cleanup resources before deallocation.
         /// Call this from MainView when closing a tab/split.
         func cleanup(reason: CleanupReason = .sceneTeardown) {


### PR DESCRIPTION
Add a nonmodal banner card with safe URL actions, propagate banners through SSH, Mosh, TSSH, and embedded sessions, and preserve failure messages across reconnect and password fallback.  Addresses #290 and has been tested end to end with Tailscale check mode including in `always` mode.