### PR TITLE
Normalize encrypted SSH keys for synced storage

### DIFF
--- a/rootshell/Core/Backup/BackupExporter.swift
+++ b/rootshell/Core/Backup/BackupExporter.swift
@@ -136,12 +136,31 @@ enum BackupExporter {
                 continue
             }
 
-            let passphrase = keychainManager.loadPassphrase(forKey: key.id.uuidString)
+            var exportKeyData = privateKeyData
+            var exportMetadata = key
+
+            // Legacy-encrypted blobs are exported normalized (decrypted); an
+            // encrypted entry without its passphrase could never restore.
+            if let keyString = String(data: privateKeyData, encoding: .utf8) {
+                let passphrase = keychainManager.loadPassphrase(forKey: key.id.uuidString)
+                do {
+                    switch try OpenSSHKeyNormalizer.normalize(keyString: keyString, passphrase: passphrase) {
+                    case .normalized(let text):
+                        exportKeyData = Data(text.utf8)
+                        exportMetadata.hasPassphrase = false
+                    case .alreadyPlaintext, .notOpenSSHContainer:
+                        exportMetadata.hasPassphrase = false
+                    }
+                } catch {
+                    logger.warning("Skipping key '\(key.name)': encrypted with no usable local passphrase")
+                    skippedNames.append(key.name)
+                    continue
+                }
+            }
 
             entries.append(SSHKeyBackupEntry(
-                metadata: key,
-                privateKeyData: privateKeyData,
-                passphrase: passphrase
+                metadata: exportMetadata,
+                privateKeyData: exportKeyData
             ))
         }
 

--- a/rootshell/Core/Backup/BackupModels.swift
+++ b/rootshell/Core/Backup/BackupModels.swift
@@ -112,7 +112,32 @@ struct SSHKeysBackup: Codable {
 struct SSHKeyBackupEntry: Codable {
     var metadata: SSHKey
     var privateKeyData: Data?
+    /// Read from legacy backups for restore; never written to new backups —
+    /// exported key data is normalized (decrypted) instead.
     var passphrase: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case metadata, privateKeyData, passphrase
+    }
+
+    init(metadata: SSHKey, privateKeyData: Data?, passphrase: String? = nil) {
+        self.metadata = metadata
+        self.privateKeyData = privateKeyData
+        self.passphrase = passphrase
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        metadata = try container.decode(SSHKey.self, forKey: .metadata)
+        privateKeyData = try container.decodeIfPresent(Data.self, forKey: .privateKeyData)
+        passphrase = try container.decodeIfPresent(String.self, forKey: .passphrase)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(metadata, forKey: .metadata)
+        try container.encodeIfPresent(privateKeyData, forKey: .privateKeyData)
+    }
 }
 
 // MARK: - SSH Passwords Backup

--- a/rootshell/Core/Security/KeychainManager.swift
+++ b/rootshell/Core/Security/KeychainManager.swift
@@ -369,14 +369,20 @@ class KeychainManager {
     ///   - keyData: The new private key data
     ///   - identifier: Unique identifier for the key
     /// - Throws: KeychainError if update fails
-    func updatePrivateKey(_ keyData: Data, identifier: String) throws {
-        let query: [String: Any] = [
+    /// Updates only `kSecValueData`, preserving accessibility, sync class,
+    /// and access control. Pass an authenticated `context` to update an
+    /// ACL-protected item without a second biometric prompt.
+    nonisolated func updatePrivateKey(_ keyData: Data, identifier: String, context: LAContext? = nil) throws {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: "com.ghostty.ssh.privatekey",
             kSecAttrAccount as String: identifier,
             kSecAttrAccessGroup as String: accessGroup,
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
+        if let context {
+            query[kSecUseAuthenticationContext as String] = context
+        }
 
         let attributes: [String: Any] = [
             kSecValueData as String: keyData

--- a/rootshell/Core/Terminal/Reconnect/InitialConnectRetry+AppErrors.swift
+++ b/rootshell/Core/Terminal/Reconnect/InitialConnectRetry+AppErrors.swift
@@ -20,6 +20,10 @@ extension InitialConnectRetry {
         // App-side host-key-rejection error (separate from Citadel's InvalidHostKey)
         if error is HostKeyRejectedError { return true }
 
+        // Legacy-encrypted key with no local passphrase — retry can't help;
+        // the user must unlock the key once in Settings → SSH Keys.
+        if case SSHKeyManager.LoadError.legacyKeyNeedsUnlock = error { return true }
+
         if let ssh = error as? SSHError, ssh.isAuthenticationRelated { return true }
 
         if let jump = error as? SSHJumpError {

--- a/rootshell/Core/Terminal/Reconnect/ReconnectionManager.swift
+++ b/rootshell/Core/Terminal/Reconnect/ReconnectionManager.swift
@@ -450,6 +450,9 @@ public final class ReconnectionManager: ObservableObject {
     }
 
     private func isPermanentFailure(_ error: Error) -> Bool {
+        // Legacy-encrypted key with no local passphrase — needs manual unlock
+        if case SSHKeyManager.LoadError.legacyKeyNeedsUnlock = error { return true }
+
         // Check for authentication-related errors that shouldn't be retried
         let errorDescription = error.localizedDescription.lowercased()
 

--- a/rootshell/Features/Profiles/ConnectionProfileManager.swift
+++ b/rootshell/Features/Profiles/ConnectionProfileManager.swift
@@ -893,6 +893,16 @@ final class ConnectionProfileManager {
             if KeychainManager.shared.sshPrivateKeyRequiresInteraction(keyID: keyID) {
                 return VPNSharedProfileAuth(method: .passwordRequired, keyID: nil)
             }
+
+            // Legacy-encrypted blob without its local passphrase (synced from
+            // another device) can't be decrypted in the extension. Check the
+            // blob header, not metadata — the two sync independently.
+            if let blob = try? KeychainManager.shared.loadPrivateKey(identifier: keyID.uuidString),
+               let keyString = String(data: blob, encoding: .utf8),
+               SSHKeyParser.isEncrypted(keyString: keyString),
+               KeychainManager.shared.loadPassphrase(forKey: keyID.uuidString) == nil {
+                return VPNSharedProfileAuth(method: .passwordRequired, keyID: nil)
+            }
             return VPNSharedProfileAuth(method: .key, keyID: keyID)
         case .password:
             return VPNSharedProfileAuth(method: .passwordRequired, keyID: nil)

--- a/rootshell/Features/SSH/Keys/OpenSSHKeyNormalizer.swift
+++ b/rootshell/Features/SSH/Keys/OpenSSHKeyNormalizer.swift
@@ -1,0 +1,232 @@
+//
+//  OpenSSHKeyNormalizer.swift
+//  rootshell
+//
+//  Converts passphrase-encrypted openssh-key-v1 containers into
+//  unencrypted containers so stored keys stay usable after iCloud sync
+//  (passphrases are device-local and never sync — #285). Pure
+//  String -> String: no Keychain access, no UI.
+//
+
+import Foundation
+import NIOCore
+import NIOFoundationCompat
+
+/// `openssh-key-v1` container serialization shared by key generation and
+/// normalization so both emit byte-identical layout. `nonisolated` because
+/// the build sets `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
+nonisolated enum OpenSSHContainer {
+
+    /// Wrap an SSH public-key blob + private section in the `openssh-key-v1`
+    /// container and PEM armor (cipher "none", KDF "none").
+    static func wrapUnencryptedPrivateKey(publicKeyBlob: ByteBuffer, privateSection: ByteBuffer) -> String {
+        var buffer = ByteBuffer()
+
+        // 1. AUTH_MAGIC = "openssh-key-v1\0"
+        buffer.writeString("openssh-key-v1")
+        buffer.writeInteger(UInt8(0))
+
+        // 2. Cipher name = "none" (unencrypted)
+        buffer.writeSSHString("none")
+
+        // 3. KDF name = "none" (no key derivation)
+        buffer.writeSSHString("none")
+
+        // 4. KDF options = empty string
+        buffer.writeSSHString("")
+
+        // 5. Number of keys = 1
+        buffer.writeInteger(UInt32(1))
+
+        // 6. Public key blob (SSH wire format)
+        buffer.writeSSHBuffer(publicKeyBlob)
+
+        // 7. Private section padded to 8-byte block boundary
+        let padded = padPrivateSection(privateSection, blockSize: 8)
+        buffer.writeSSHBuffer(padded)
+
+        let data = Data(buffer.readableBytesView)
+        let base64 = data.base64EncodedString()
+
+        var pemLines = ["-----BEGIN OPENSSH PRIVATE KEY-----"]
+        var remaining = base64
+        while !remaining.isEmpty {
+            let lineLength = min(70, remaining.count)
+            pemLines.append(String(remaining.prefix(lineLength)))
+            remaining = String(remaining.dropFirst(lineLength))
+        }
+        pemLines.append("-----END OPENSSH PRIVATE KEY-----")
+        return pemLines.joined(separator: "\n")
+    }
+
+    /// Pad the private section to a multiple of `blockSize` with the
+    /// OpenSSH-mandated 01,02,03,... filler. Only adds bytes when the
+    /// section isn't already aligned — always writing a full block on a
+    /// boundary is non-standard and produces PEMs that `ssh-keygen`
+    /// parses but flags.
+    static func padPrivateSection(_ section: ByteBuffer, blockSize: Int) -> ByteBuffer {
+        var padded = section
+        let paddingNeeded = (blockSize - (padded.readableBytes % blockSize)) % blockSize
+        for i in 0..<paddingNeeded {
+            padded.writeInteger(UInt8(i + 1))
+        }
+        return padded
+    }
+}
+
+nonisolated enum OpenSSHKeyNormalizer {
+
+    enum Result: Sendable, Equatable {
+        /// Container cipher is already "none" — store the original text as-is.
+        case alreadyPlaintext
+        /// Decrypted and re-armored as an unencrypted container.
+        case normalized(keyText: String)
+        /// Not an openssh-key-v1 armor (PEM/PKCS#8/other) — caller decides.
+        case notOpenSSHContainer
+    }
+
+    enum NormalizerError: Error, LocalizedError {
+        case passphraseRequired
+        case incorrectPassphrase
+        case malformedContainer(String)
+        case verificationFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .passphraseRequired:
+                return "This key is encrypted. Please provide the passphrase to decrypt it."
+            case .incorrectPassphrase:
+                return "Incorrect passphrase or corrupted key data."
+            case .malformedContainer(let message):
+                return "Malformed OpenSSH key container: \(message)"
+            case .verificationFailed(let message):
+                return "Normalized key failed verification: \(message)"
+            }
+        }
+    }
+
+    /// Decrypt an encrypted container and re-armor it with cipher/KDF "none".
+    /// All key fields and the comment are preserved byte-for-byte, and the
+    /// output is deterministic, so concurrent migration on two synced
+    /// devices converges to identical bytes.
+    static func normalize(keyString: String, passphrase: String?) throws -> Result {
+        let trimmed = keyString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.contains("BEGIN OPENSSH PRIVATE KEY") else {
+            return .notOpenSSHContainer
+        }
+
+        let base64Lines = trimmed.components(separatedBy: .newlines)
+            .filter { !$0.hasPrefix("-----") && !$0.isEmpty }
+        guard let keyData = Data(base64Encoded: base64Lines.joined()) else {
+            throw NormalizerError.malformedContainer("Invalid base64 encoding")
+        }
+
+        var buffer = ByteBuffer(data: keyData)
+        guard buffer.readString(length: "openssh-key-v1".count) == "openssh-key-v1",
+              buffer.readInteger(as: UInt8.self) == 0x00 else {
+            throw NormalizerError.malformedContainer("Invalid OpenSSH magic string")
+        }
+
+        let cipher: OpenSSH.Cipher
+        let kdf: OpenSSH.KDF
+        do {
+            cipher = try OpenSSH.Cipher(consuming: &buffer)
+            kdf = try OpenSSH.KDF(consuming: &buffer)
+        } catch {
+            throw NormalizerError.malformedContainer(error.localizedDescription)
+        }
+
+        guard cipher != .none else {
+            return .alreadyPlaintext
+        }
+        guard let passphraseData = passphrase?.data(using: .utf8) else {
+            throw NormalizerError.passphraseRequired
+        }
+
+        guard let numKeys = buffer.readInteger(as: UInt32.self), numKeys == 1 else {
+            throw NormalizerError.malformedContainer("Invalid or multiple keys not supported")
+        }
+        guard let publicKeyBlob = buffer.readSSHBuffer() else {
+            throw NormalizerError.malformedContainer("Missing public key")
+        }
+        guard var privateKeyBuffer = buffer.readSSHBuffer() else {
+            throw NormalizerError.malformedContainer("Missing private key")
+        }
+
+        do {
+            try kdf.withKeyAndIV(cipher: cipher, basedOnDecryptionKey: passphraseData) { key, iv in
+                try cipher.decryptBuffer(&privateKeyBuffer, key: key, iv: iv)
+            }
+        } catch OpenSSH.KeyError.invalidCheck {
+            throw NormalizerError.incorrectPassphrase
+        } catch {
+            throw NormalizerError.malformedContainer("Decryption failed: \(error.localizedDescription)")
+        }
+
+        let privateSection = try strippedPrivateSection(from: privateKeyBuffer, blockSize: cipher.blockSize)
+        let normalizedText = OpenSSHContainer.wrapUnencryptedPrivateKey(
+            publicKeyBlob: publicKeyBlob,
+            privateSection: privateSection
+        )
+
+        try verify(normalizedText: normalizedText, original: trimmed, passphrase: passphrase)
+        return .normalized(keyText: normalizedText)
+    }
+
+    /// Validate the decrypted private section and drop its trailing padding.
+    /// Container-generic: after the check integers, every field of every
+    /// supported algorithm is uint32-length-prefixed, so a greedy field walk
+    /// stops exactly at the padding — padding starts 01,02,03,… and is under
+    /// one cipher block, so its first 4 bytes decode as an impossible length.
+    private static func strippedPrivateSection(from decrypted: ByteBuffer, blockSize: Int) throws -> ByteBuffer {
+        var walker = decrypted
+
+        guard let check1 = walker.readInteger(as: UInt32.self),
+              let check2 = walker.readInteger(as: UInt32.self),
+              check1 == check2 else {
+            throw NormalizerError.incorrectPassphrase
+        }
+
+        while walker.readableBytes >= 4 {
+            guard let fieldLength = walker.getInteger(at: walker.readerIndex, as: UInt32.self),
+                  Int(fieldLength) <= walker.readableBytes - 4 else {
+                break
+            }
+            walker.moveReaderIndex(forwardBy: 4 + Int(fieldLength))
+        }
+
+        let paddingLength = walker.readableBytes
+        guard paddingLength < blockSize,
+              let paddingBytes = walker.readBytes(length: paddingLength) else {
+            throw NormalizerError.malformedContainer("Invalid private-section padding length")
+        }
+        for (index, byte) in paddingBytes.enumerated() where byte != UInt8(index + 1) {
+            throw NormalizerError.malformedContainer("Invalid private-section padding bytes")
+        }
+
+        guard let section = decrypted.getSlice(
+            at: decrypted.readerIndex,
+            length: decrypted.readableBytes - paddingLength
+        ) else {
+            throw NormalizerError.malformedContainer("Failed to slice private section")
+        }
+        return section
+    }
+
+    /// Reparse both representations and require the same key type and
+    /// fingerprint, so a miswalk can never corrupt a stored key.
+    private static func verify(normalizedText: String, original: String, passphrase: String?) throws {
+        let normalizedParsed: SSHKeyParser.ParsedKey
+        let originalParsed: SSHKeyParser.ParsedKey
+        do {
+            normalizedParsed = try SSHKeyParser.parse(keyString: normalizedText, passphrase: nil)
+            originalParsed = try SSHKeyParser.parse(keyString: original, passphrase: passphrase)
+        } catch {
+            throw NormalizerError.verificationFailed(error.localizedDescription)
+        }
+        guard normalizedParsed.keyType == originalParsed.keyType,
+              normalizedParsed.fingerprint == originalParsed.fingerprint else {
+            throw NormalizerError.verificationFailed("Key type or fingerprint mismatch after normalization")
+        }
+    }
+}

--- a/rootshell/Features/SSH/Keys/SSHKeyGenerator.swift
+++ b/rootshell/Features/SSH/Keys/SSHKeyGenerator.swift
@@ -648,60 +648,10 @@ nonisolated enum SSHKeyGenerator {
     }
 
     /// Wrap an SSH public-key blob + private section in the `openssh-key-v1`
-    /// container and PEM armor. Shared by every key-type generator so the
-    /// container layout, padding rules, and line wrapping live in one place.
+    /// container and PEM armor. Shared with encrypted-key normalization via
+    /// `OpenSSHContainer` so both paths emit byte-identical layout.
     private static func wrapOpenSSHPrivateKey(publicKeyBlob: ByteBuffer, privateSection: ByteBuffer) -> String {
-        var buffer = ByteBuffer()
-
-        // 1. AUTH_MAGIC = "openssh-key-v1\0"
-        buffer.writeString("openssh-key-v1")
-        buffer.writeInteger(UInt8(0))
-
-        // 2. Cipher name = "none" (unencrypted)
-        buffer.writeSSHString("none")
-
-        // 3. KDF name = "none" (no key derivation)
-        buffer.writeSSHString("none")
-
-        // 4. KDF options = empty string
-        buffer.writeSSHString("")
-
-        // 5. Number of keys = 1
-        buffer.writeInteger(UInt32(1))
-
-        // 6. Public key blob (SSH wire format)
-        buffer.writeSSHBuffer(publicKeyBlob)
-
-        // 7. Private section padded to 8-byte block boundary
-        let padded = padPrivateSection(privateSection, blockSize: 8)
-        buffer.writeSSHBuffer(padded)
-
-        let data = Data(buffer.readableBytesView)
-        let base64 = data.base64EncodedString()
-
-        var pemLines = ["-----BEGIN OPENSSH PRIVATE KEY-----"]
-        var remaining = base64
-        while !remaining.isEmpty {
-            let lineLength = min(70, remaining.count)
-            pemLines.append(String(remaining.prefix(lineLength)))
-            remaining = String(remaining.dropFirst(lineLength))
-        }
-        pemLines.append("-----END OPENSSH PRIVATE KEY-----")
-        return pemLines.joined(separator: "\n")
-    }
-
-    /// Pad the private section to a multiple of `blockSize` with the
-    /// OpenSSH-mandated 01,02,03,... filler. Only adds bytes when the
-    /// section isn't already aligned — the previous implementation always
-    /// padded on a boundary by writing a full block, which is non-standard
-    /// and would have produced PEMs that `ssh-keygen` parses but flags.
-    private static func padPrivateSection(_ section: ByteBuffer, blockSize: Int) -> ByteBuffer {
-        var padded = section
-        let paddingNeeded = (blockSize - (padded.readableBytes % blockSize)) % blockSize
-        for i in 0..<paddingNeeded {
-            padded.writeInteger(UInt8(i + 1))
-        }
-        return padded
+        OpenSSHContainer.wrapUnencryptedPrivateKey(publicKeyBlob: publicKeyBlob, privateSection: privateSection)
     }
 
     /// Format a single-line OpenSSH authorized_keys entry:

--- a/rootshell/Features/SSH/Keys/SSHKeyManager.swift
+++ b/rootshell/Features/SSH/Keys/SSHKeyManager.swift
@@ -84,6 +84,20 @@ class SSHKeyManager: ObservableObject {
     /// Publisher for key changes
     let keysDidChange = PassthroughSubject<Void, Never>()
 
+    /// Legacy-encrypted keys with no usable local passphrase; unusable on
+    /// this device until unlocked once via `unlockLegacyKey`.
+    @Published private(set) var keysNeedingUnlock: Set<UUID> = []
+
+    /// Single-flight guard for the background legacy-key migration scan.
+    private var legacyKeyMigrationTask: Task<Void, Never>?
+
+    /// Authenticated LAContexts from in-flight loads, reused by the
+    /// opportunistic legacy-key migration write.
+    private var authenticatedLoadContexts: [UUID: LAContext] = [:]
+
+    /// Keys with an opportunistic migration in flight (single-flight per key).
+    private var opportunisticMigrationsInFlight: Set<UUID> = []
+
     private let keychainManager: KeychainManager
 
     private init() {
@@ -105,6 +119,8 @@ class SSHKeyManager: ObservableObject {
         // ──────────────────────────────────────────────────────────────
         // Backfill cached public key blobs for existing keys that don't have them
         backfillPublicKeyBlobs()
+        // Normalize legacy passphrase-encrypted keys in place (#285)
+        scheduleLegacyKeyMigrationIfNeeded()
     }
 
     /// Throw-away one-shot migration; see init for context.
@@ -164,8 +180,29 @@ class SSHKeyManager: ObservableObject {
 
         Self.logger.info("Importing key '\(name)'")
 
+        // Store encrypted OpenSSH keys decrypted: passphrases are device-local
+        // and never sync, so an encrypted blob is unusable after iCloud sync.
+        let storedKeyString: String
+        do {
+            switch try OpenSSHKeyNormalizer.normalize(keyString: keyString, passphrase: passphrase) {
+            case .normalized(let normalizedText):
+                storedKeyString = normalizedText
+                Self.logger.info("Normalized encrypted key to unencrypted OpenSSH container")
+            case .alreadyPlaintext, .notOpenSSHContainer:
+                storedKeyString = keyString
+            }
+        } catch OpenSSHKeyNormalizer.NormalizerError.passphraseRequired {
+            throw SSHKeyParser.ParserError.encryptedKeyNeedsPassphrase
+        } catch OpenSSHKeyNormalizer.NormalizerError.incorrectPassphrase {
+            throw SSHKeyParser.ParserError.incorrectPassphrase
+        } catch {
+            // Fall back to legacy storage; the parse below decides usability.
+            Self.logger.warning("Key normalization failed, storing original: \(error.localizedDescription)")
+            storedKeyString = keyString
+        }
+
         // Parse the key
-        let parsedKey = try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
+        let parsedKey = try SSHKeyParser.parse(keyString: storedKeyString, passphrase: passphrase)
         Self.logger.info("Parsed as key type: \(parsedKey.keyType.rawValue)")
         Self.logger.info("Fingerprint: \(parsedKey.fingerprint)")
         Self.logger.info("Has NIO SSH key: \(parsedKey.nioSSHKey != nil)")
@@ -213,7 +250,7 @@ class SSHKeyManager: ObservableObject {
         Self.logger.info("Cached public key blob: \(sshKey.publicKeyBlob?.count ?? 0) bytes")
 
         // Store key data in Keychain with security configuration
-        guard let keyData = keyString.data(using: .utf8) else {
+        guard let keyData = storedKeyString.data(using: .utf8) else {
             throw ImportError.dataConversionFailed
         }
 
@@ -225,17 +262,30 @@ class SSHKeyManager: ObservableObject {
                 authRequirement: authRequirement
             )
 
-            // Store passphrase if provided
-            if let passphrase = passphrase {
+            // Retain the passphrase only when the stored blob still needs it.
+            if let passphrase = passphrase, parsedKey.isEncrypted {
                 try keychainManager.savePassphrase(passphrase, forKey: sshKey.id.uuidString)
             }
         } catch {
             throw ImportError.keychainError(error)
         }
 
+        // Roll back the key material if metadata persistence fails.
+        do {
+            let metadataData = try JSONEncoder().encode(sshKey)
+            try keychainManager.saveSSHKeyMetadata(
+                metadataData,
+                identifier: sshKey.id.uuidString,
+                storageLevel: storageLevel
+            )
+        } catch {
+            try? keychainManager.deletePrivateKey(identifier: sshKey.id.uuidString)
+            keychainManager.deletePassphrase(forKey: sshKey.id.uuidString)
+            throw ImportError.keychainError(error)
+        }
+
         // Add to saved keys
         savedKeys.append(sshKey)
-        saveKeys()
         keysDidChange.send()
 
         // Add as default if it's the first key
@@ -549,7 +599,14 @@ class SSHKeyManager: ObservableObject {
             // means the metadata changed into an unsupported reference form.
             throw LoadError.invalidKeyData
         }
-        let parsedKey = try SSHKeyParser.parse(keyString: prep.keyString, passphrase: prep.passphrase)
+        let parsedKey: SSHKeyParser.ParsedKey
+        do {
+            parsedKey = try SSHKeyParser.parse(keyString: prep.keyString, passphrase: prep.passphrase)
+        } catch SSHKeyParser.ParserError.encryptedKeyNeedsPassphrase,
+                SSHKeyParser.ParserError.incorrectPassphrase {
+            applyLegacyMigrationOutcome(.needsUnlock, keyID: id)
+            throw LoadError.legacyKeyNeedsUnlock(keyID: id, keyName: savedKey.name)
+        }
         return try Self.materializeParsedKey(parsedKey)
     }
 
@@ -587,9 +644,16 @@ class SSHKeyManager: ObservableObject {
         }
         let keyString = prep.keyString
         let passphrase = prep.passphrase
-        let parsedKey = try await Task.detached(priority: .userInitiated) {
-            try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
-        }.value
+        let parsedKey: SSHKeyParser.ParsedKey
+        do {
+            parsedKey = try await Task.detached(priority: .userInitiated) {
+                try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
+            }.value
+        } catch SSHKeyParser.ParserError.encryptedKeyNeedsPassphrase,
+                SSHKeyParser.ParserError.incorrectPassphrase {
+            applyLegacyMigrationOutcome(.needsUnlock, keyID: id)
+            throw LoadError.legacyKeyNeedsUnlock(keyID: id, keyName: savedKey.name)
+        }
         return try Self.materializeParsedKey(parsedKey)
     }
 
@@ -1073,6 +1137,9 @@ class SSHKeyManager: ObservableObject {
             // snapshots whenever the effective key set changes.
             ConnectionProfileManager.shared.refreshVPNSharedProfiles()
 
+            // Newly synced blobs may carry (or resolve) legacy encryption.
+            scheduleLegacyKeyMigrationIfNeeded()
+
             let keyCount = savedKeys.count
             Self.logger.info("SSH keys refreshed: \(keyCount) keys")
         } else if defaultsPruned {
@@ -1495,11 +1562,17 @@ class SSHKeyManager: ObservableObject {
 
                 // Load key data from Keychain with authentication
                 do {
-                    return try keychainManager.loadPrivateKey(
+                    let data = try keychainManager.loadPrivateKey(
                         identifier: id.uuidString,
                         authRequirement: savedKey.authRequirement,
                         context: context
                     )
+                    // Keep the authenticated context so the opportunistic
+                    // legacy-key migration can rewrite the item promptless.
+                    await MainActor.run {
+                        SSHKeyManager.shared.authenticatedLoadContexts[id] = context
+                    }
+                    return data
                 } catch let error as KeychainManager.KeychainError {
                     switch error {
                     case .authenticationCancelled:
@@ -1538,6 +1611,15 @@ class SSHKeyManager: ObservableObject {
 
         Self.logger.info("Loaded \(keyData.count) bytes from keychain")
 
+        // Clear the stored context on every exit unless a scheduled
+        // migration takes ownership of it.
+        var contextOwnedByMigration = false
+        defer {
+            if !contextOwnedByMigration {
+                authenticatedLoadContexts.removeValue(forKey: id)
+            }
+        }
+
         guard let keyString = String(data: keyData, encoding: .utf8) else {
             throw LoadError.dataConversionFailed
         }
@@ -1549,9 +1631,31 @@ class SSHKeyManager: ObservableObject {
         // expensive enough to introduce visible UI hangs every time a
         // biometric-gated key is used. The `keyString`/`passphrase`
         // are plain `String`s (Sendable), so the detached hop is free.
-        let parsedKey = try await Task.detached(priority: .userInitiated) {
-            try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
-        }.value
+        let parsedKey: SSHKeyParser.ParsedKey
+        do {
+            parsedKey = try await Task.detached(priority: .userInitiated) {
+                try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
+            }.value
+        } catch SSHKeyParser.ParserError.encryptedKeyNeedsPassphrase,
+                SSHKeyParser.ParserError.incorrectPassphrase {
+            // Legacy-encrypted blob without a usable local passphrase (the
+            // passphrase never syncs) — needs a one-time manual unlock.
+            applyLegacyMigrationOutcome(.needsUnlock, keyID: id)
+            throw LoadError.legacyKeyNeedsUnlock(keyID: id, keyName: savedKey.name)
+        }
+
+        // The key just decrypted: normalize the stored blob in place (#285).
+        // The stored context stays in place for the migration to consume —
+        // dedup waiters all pass through here, and only the first schedules.
+        if parsedKey.isEncrypted, let passphrase {
+            contextOwnedByMigration = true
+            scheduleOpportunisticLegacyMigration(
+                id: id,
+                keyString: keyString,
+                passphrase: passphrase,
+                expectedFingerprint: savedKey.fingerprint
+            )
+        }
 
         // Return the appropriate key type
         let keyVariant: SSHPrivateKeyVariant
@@ -2234,6 +2338,270 @@ class SSHKeyManager: ObservableObject {
         }
     }
 
+    // MARK: - Legacy Encrypted-Key Migration (#285)
+
+    private enum LegacyMigrationOutcome: Sendable {
+        case migrated
+        case alreadyNormalized
+        case clean                // no legacy state; only clear stale markers
+        case needsUnlock          // encrypted, no usable local passphrase
+        case skipped              // transient; retry on a later scan
+    }
+
+    /// Normalize one stored legacy blob in place. The blob header, not the
+    /// metadata flag, is authoritative (sync can deliver either first).
+    /// Never shows UI; callers must only pass interaction-free items.
+    private nonisolated static func runInteractionFreeLegacyMigration(
+        identifier: String,
+        expectedFingerprint: String,
+        hasPassphraseHint: Bool
+    ) -> LegacyMigrationOutcome {
+        let km = KeychainManager.shared
+        let storedPassphrase = km.loadPassphrase(forKey: identifier)
+
+        // Always inspect the blob: normalized metadata can sync before the
+        // still-encrypted blob, so the flag alone proves nothing.
+        guard let blob = try? km.loadPrivateKey(identifier: identifier),
+              let keyString = String(data: blob, encoding: .utf8) else {
+            return .skipped
+        }
+
+        do {
+            switch try OpenSSHKeyNormalizer.normalize(keyString: keyString, passphrase: storedPassphrase) {
+            case .alreadyPlaintext, .notOpenSSHContainer:
+                return (hasPassphraseHint || storedPassphrase != nil) ? .alreadyNormalized : .clean
+            case .normalized(let normalizedText):
+                guard let normalizedData = normalizedText.data(using: .utf8),
+                      let parsed = try? SSHKeyParser.parse(keyString: normalizedText, passphrase: nil),
+                      parsed.fingerprint == expectedFingerprint else {
+                    return .skipped
+                }
+                // Re-read so a newer synced blob is never clobbered.
+                guard let current = try? km.loadPrivateKey(identifier: identifier),
+                      current == blob else {
+                    return .skipped
+                }
+                do {
+                    try km.updatePrivateKey(normalizedData, identifier: identifier)
+                } catch {
+                    logger.warning("Legacy key migration write failed for \(identifier): \(error.localizedDescription)")
+                    return .skipped
+                }
+                return .migrated
+            }
+        } catch OpenSSHKeyNormalizer.NormalizerError.passphraseRequired,
+                OpenSSHKeyNormalizer.NormalizerError.incorrectPassphrase {
+            return .needsUnlock
+        } catch {
+            logger.warning("Legacy key migration failed for \(identifier): \(error.localizedDescription)")
+            return .skipped
+        }
+    }
+
+    /// Metadata first, passphrase deletion last — re-runnable after a crash
+    /// at any boundary.
+    private func applyLegacyMigrationOutcome(_ outcome: LegacyMigrationOutcome, keyID: UUID) {
+        switch outcome {
+        case .migrated, .alreadyNormalized:
+            var changed = false
+            if let index = savedKeys.firstIndex(where: { $0.id == keyID }),
+               savedKeys[index].hasPassphrase {
+                savedKeys[index].hasPassphrase = false
+                saveKeys()
+                changed = true
+            }
+            keychainManager.deletePassphrase(forKey: keyID.uuidString)
+            if keysNeedingUnlock.remove(keyID) != nil { changed = true }
+            if case .migrated = outcome {
+                Self.logger.info("Normalized legacy encrypted key \(keyID.uuidString) in place")
+            }
+            if changed { keysDidChange.send() }
+        case .clean:
+            if keysNeedingUnlock.remove(keyID) != nil {
+                keysDidChange.send()
+            }
+        case .needsUnlock:
+            if !keysNeedingUnlock.contains(keyID) {
+                keysNeedingUnlock.insert(keyID)
+                Self.logger.warning("Legacy encrypted key \(keyID.uuidString) has no usable local passphrase; manual unlock required")
+                keysDidChange.send()
+            }
+        case .skipped:
+            break
+        }
+    }
+
+    /// Background-migrates keys whose items are readable without interaction:
+    /// `authRequirement == .none` plus `.iCloudSync` (synced items carry no
+    /// SecAccessControl; the app-level gate covers key *use* only).
+    /// ACL-protected keys migrate during their next authenticated load.
+    func scheduleLegacyKeyMigrationIfNeeded() {
+        guard legacyKeyMigrationTask == nil else { return }
+
+        struct Candidate: Sendable {
+            let id: UUID
+            let fingerprint: String
+            let hasPassphrase: Bool
+        }
+        let candidates: [Candidate] = savedKeys.compactMap { key in
+            guard key.yubiKeyInfo == nil,
+                  key.appleFIDO2Info == nil,
+                  key.secureEnclaveInfo == nil,
+                  key.externalAgentInfo == nil,
+                  key.authRequirement == .none || key.storageLevel == .iCloudSync else {
+                return nil
+            }
+            return Candidate(id: key.id, fingerprint: key.fingerprint, hasPassphrase: key.hasPassphrase)
+        }
+        guard !candidates.isEmpty else { return }
+
+        legacyKeyMigrationTask = Task { @MainActor [weak self] in
+            for candidate in candidates {
+                let outcome = await Task.detached(priority: .utility) {
+                    Self.runInteractionFreeLegacyMigration(
+                        identifier: candidate.id.uuidString,
+                        expectedFingerprint: candidate.fingerprint,
+                        hasPassphraseHint: candidate.hasPassphrase
+                    )
+                }.value
+                guard let self else { return }
+                self.applyLegacyMigrationOutcome(outcome, keyID: candidate.id)
+            }
+            self?.legacyKeyMigrationTask = nil
+        }
+    }
+
+    /// Normalizes an already-decrypted legacy key after an authenticated
+    /// load, reusing that load's stored LAContext so the ACL-protected
+    /// re-read and write need no second prompt. Single-flight per key;
+    /// Keychain calls stay on the main actor to keep the context in one
+    /// isolation region.
+    private func scheduleOpportunisticLegacyMigration(
+        id: UUID,
+        keyString: String,
+        passphrase: String,
+        expectedFingerprint: String
+    ) {
+        guard opportunisticMigrationsInFlight.insert(id).inserted else { return }
+        Task { @MainActor [weak self] in
+            let normalizedData: Data? = await Task.detached(priority: .utility) {
+                guard case .normalized(let text) = try? OpenSSHKeyNormalizer.normalize(
+                    keyString: keyString,
+                    passphrase: passphrase
+                ),
+                      let parsed = try? SSHKeyParser.parse(keyString: text, passphrase: nil),
+                      parsed.fingerprint == expectedFingerprint else {
+                    return nil
+                }
+                return text.data(using: .utf8)
+            }.value
+
+            guard let self else { return }
+            defer {
+                self.opportunisticMigrationsInFlight.remove(id)
+                self.authenticatedLoadContexts.removeValue(forKey: id)
+            }
+            guard let normalizedData else { return }
+
+            let identifier = id.uuidString
+            let context = self.authenticatedLoadContexts[id]
+            // Authenticated re-read (ACL items would otherwise re-prompt):
+            // bail if the blob changed since this load decrypted it.
+            guard let currentKey = self.savedKeys.first(where: { $0.id == id }),
+                  let current = try? self.keychainManager.loadPrivateKey(
+                    identifier: identifier,
+                    authRequirement: currentKey.authRequirement,
+                    context: context
+                  ),
+                  String(data: current, encoding: .utf8) == keyString else {
+                return
+            }
+            do {
+                try self.keychainManager.updatePrivateKey(normalizedData, identifier: identifier, context: context)
+            } catch {
+                Self.logger.warning("Opportunistic legacy key migration failed for \(identifier): \(error.localizedDescription)")
+                return
+            }
+            self.applyLegacyMigrationOutcome(.migrated, keyID: id)
+        }
+    }
+
+    /// One-time manual repair for a legacy-encrypted key with no local
+    /// passphrase (typically synced from another device). Authenticates per
+    /// the key's policy, normalizes, and rewrites the blob in place.
+    func unlockLegacyKey(id: UUID, passphrase: String) async throws {
+        guard let savedKey = savedKeys.first(where: { $0.id == id }) else {
+            throw LoadError.keyNotFound
+        }
+        let identifier = id.uuidString
+
+        var context: LAContext?
+        if savedKey.authRequirement != .none {
+            let reason = "Authenticate to unlock '\(savedKey.name)'"
+            let ctx = SSHKeyAuthManager.shared.createContext(for: savedKey, reason: reason)
+            if savedKey.storageLevel == .iCloudSync {
+                try await Self.evaluateDeviceOwnerAuthentication(on: ctx, reason: reason)
+            }
+            context = ctx
+        }
+
+        let keyData: Data
+        do {
+            keyData = try keychainManager.loadPrivateKey(
+                identifier: identifier,
+                authRequirement: savedKey.authRequirement,
+                context: context
+            )
+        } catch let error as KeychainManager.KeychainError {
+            switch error {
+            case .authenticationCancelled: throw LoadError.authenticationCancelled
+            case .authenticationFailed: throw LoadError.authenticationFailed
+            default: throw error
+            }
+        }
+        guard let keyString = String(data: keyData, encoding: .utf8) else {
+            throw LoadError.dataConversionFailed
+        }
+
+        let expectedFingerprint = savedKey.fingerprint
+        let normalizedData: Data? = try await Task.detached(priority: .userInitiated) {
+            switch try OpenSSHKeyNormalizer.normalize(keyString: keyString, passphrase: passphrase) {
+            case .normalized(let text):
+                guard let parsed = try? SSHKeyParser.parse(keyString: text, passphrase: nil),
+                      parsed.fingerprint == expectedFingerprint,
+                      let data = text.data(using: .utf8) else {
+                    throw OpenSSHKeyNormalizer.NormalizerError.verificationFailed("Fingerprint mismatch")
+                }
+                return data
+            case .alreadyPlaintext, .notOpenSSHContainer:
+                return nil
+            }
+        }.value
+
+        if let normalizedData {
+            // Authenticated re-read: don't clobber a blob that changed since
+            // we loaded it, and don't re-prompt for ACL-protected items.
+            let current: Data
+            do {
+                current = try keychainManager.loadPrivateKey(
+                    identifier: identifier,
+                    authRequirement: savedKey.authRequirement,
+                    context: context
+                )
+            } catch {
+                throw MigrationError.keychainError(error)
+            }
+            guard current == keyData else {
+                throw MigrationError.keyChangedDuringAuthentication
+            }
+            try keychainManager.updatePrivateKey(normalizedData, identifier: identifier, context: context)
+            applyLegacyMigrationOutcome(.migrated, keyID: id)
+        } else {
+            applyLegacyMigrationOutcome(.alreadyNormalized, keyID: id)
+        }
+        scheduleLegacyKeyMigrationIfNeeded()
+    }
+
     // MARK: - Error Types
 
     enum ImportError: LocalizedError {
@@ -2279,6 +2647,7 @@ class SSHKeyManager: ObservableObject {
         case authenticationUnavailable
         case authenticationFailed
         case externalAgentUnavailable
+        case legacyKeyNeedsUnlock(keyID: UUID, keyName: String)
 
         var errorDescription: String? {
             switch self {
@@ -2298,6 +2667,8 @@ class SSHKeyManager: ObservableObject {
                 return "Authentication failed. Please try again."
             case .externalAgentUnavailable:
                 return "This key is served by an SSH agent on a Mac and can't be used on this device."
+            case .legacyKeyNeedsUnlock(_, let keyName):
+                return "'\(keyName)' was imported with a passphrase on another device, and passphrases don't sync. Open Settings → SSH Keys → \(keyName) and unlock it once with its passphrase."
             }
         }
     }

--- a/rootshell/Features/SSH/Keys/SSHKeyParser.swift
+++ b/rootshell/Features/SSH/Keys/SSHKeyParser.swift
@@ -25,6 +25,7 @@ nonisolated final class SSHKeyParser {
         case invalidFormat
         case unsupportedKeyType(String)
         case encryptedKeyNeedsPassphrase
+        case unsupportedEncryptedPEM
         case incorrectPassphrase
         case parseError(String)
 
@@ -36,6 +37,8 @@ nonisolated final class SSHKeyParser {
                 return "Unsupported key type: \(type). Supported types: RSA, Ed25519, ECDSA (P-256, P-384, P-521)."
             case .encryptedKeyNeedsPassphrase:
                 return "This key is encrypted. Please provide the passphrase to decrypt it."
+            case .unsupportedEncryptedPEM:
+                return "Encrypted PEM keys in this format aren't supported. Convert the key to the OpenSSH format first with: ssh-keygen -p -o -f <keyfile>"
             case .incorrectPassphrase:
                 return "Incorrect passphrase or corrupted key data."
             case .parseError(let message):
@@ -158,6 +161,15 @@ nonisolated final class SSHKeyParser {
         // Try to parse as OpenSSH format first (more common for modern keys)
         if trimmed.contains("BEGIN OPENSSH PRIVATE KEY") {
             return try parseOpenSSHFormat(keyString: trimmed, passphrase: passphrase)
+        }
+
+        // Encrypted non-OpenSSH PEM (PKCS#8 "BEGIN ENCRYPTED PRIVATE KEY" or
+        // legacy PKCS#1 with Proc-Type/DEK-Info headers) can't be decrypted
+        // here — fail with an actionable message instead of silently ignoring
+        // the passphrase and reporting a generic format error.
+        if trimmed.contains("BEGIN ENCRYPTED PRIVATE KEY") ||
+           trimmed.contains("Proc-Type: 4,ENCRYPTED") {
+            throw ParserError.unsupportedEncryptedPEM
         }
 
         // Fall back to PEM format

--- a/rootshell/Features/SSH/Keys/YubiKey/YubiKeyKeyImporter.swift
+++ b/rootshell/Features/SSH/Keys/YubiKey/YubiKeyKeyImporter.swift
@@ -170,7 +170,15 @@ final class YubiKeyKeyImporter {
         let passphrase = keychainManager.loadPassphrase(forKey: keyID.uuidString)
 
         // 3. Parse the key to get raw material
-        let parsedKey = try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
+        let parsedKey: SSHKeyParser.ParsedKey
+        do {
+            parsedKey = try SSHKeyParser.parse(keyString: keyString, passphrase: passphrase)
+        } catch SSHKeyParser.ParserError.encryptedKeyNeedsPassphrase,
+                SSHKeyParser.ParserError.incorrectPassphrase {
+            throw YubiKeyError.importFailed(
+                "This key is encrypted and its passphrase isn't on this device. Unlock it once in Settings → SSH Keys, then retry."
+            )
+        }
 
         // 4. Get PIV session and authenticate
         let session = try await connectionManager.getPIVSession()

--- a/rootshell/Features/SSH/Settings/OpenSSHImportView.swift
+++ b/rootshell/Features/SSH/Settings/OpenSSHImportView.swift
@@ -440,6 +440,9 @@ private struct OpenSSHImportPreviewSheet: View {
                     .padding(8)
                     .background(Color.secondary.opacity(0.08))
                     .cornerRadius(6)
+                Text("Used once to decrypt the key during import; never stored.")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
         }
     }

--- a/rootshell/Features/SSH/Settings/SSHKeyDetailView.swift
+++ b/rootshell/Features/SSH/Settings/SSHKeyDetailView.swift
@@ -28,6 +28,11 @@ struct SSHKeyDetailView: View {
     // Install on server
     @State private var showingCopyIDSheet = false
 
+    // Legacy key unlock
+    @State private var showingUnlockAlert = false
+    @State private var unlockPassphrase = ""
+    @State private var isUnlocking = false
+
     // OpenPGP public key export
     @State private var showingGPGExportSheet = false
 
@@ -92,8 +97,30 @@ struct SSHKeyDetailView: View {
                 }
                 LabeledRow(label: "Created", value: formattedDate)
                     .themedRow()
-                LabeledRow(label: "Encrypted", value: key.hasPassphrase ? "Yes" : "No")
+                if isSoftwareKey {
+                    HStack {
+                        Text("Key Material")
+                        Spacer()
+                        if keyNeedsUnlock {
+                            Label("Unlock Required", systemImage: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                        } else {
+                            Text(currentKey.hasPassphrase ? "Migration Pending" : "Keychain Protected")
+                                .foregroundColor(.secondary)
+                        }
+                    }
                     .themedRow()
+                    if keyNeedsUnlock {
+                        Button {
+                            unlockPassphrase = ""
+                            showingUnlockAlert = true
+                        } label: {
+                            Label("Unlock Legacy Key", systemImage: "lock.open")
+                        }
+                        .disabled(isUnlocking)
+                        .themedRow()
+                    }
+                }
             }
 
             // Fingerprint section
@@ -640,6 +667,17 @@ struct SSHKeyDetailView: View {
         } message: {
             Text("Remove the certificate from '\(currentKey.name)'? The key itself is not affected; connections will use the plain key.")
         }
+        .alert("Unlock Legacy Key", isPresented: $showingUnlockAlert) {
+            SecureField("Passphrase", text: $unlockPassphrase)
+            Button("Cancel", role: .cancel) {
+                unlockPassphrase = ""
+            }
+            Button("Unlock") {
+                unlockLegacyKey()
+            }
+        } message: {
+            Text("This key was imported with a passphrase on another device. Enter it once to decrypt the key; it will then be protected by the Keychain and won't need the passphrase again.")
+        }
         .alert("Rename Key", isPresented: $showingRenameAlert) {
             TextField("Key name", text: $newKeyName)
             Button("Cancel", role: .cancel) {
@@ -665,6 +703,34 @@ struct SSHKeyDetailView: View {
 
     private var isDefault: Bool {
         sshKeyManager.isDefault(id: key.id)
+    }
+
+    /// Keys backed by software material in the Keychain (not hardware/agent references)
+    private var isSoftwareKey: Bool {
+        currentKey.yubiKeyInfo == nil &&
+        currentKey.appleFIDO2Info == nil &&
+        currentKey.secureEnclaveInfo == nil &&
+        currentKey.externalAgentInfo == nil
+    }
+
+    private var keyNeedsUnlock: Bool {
+        sshKeyManager.keysNeedingUnlock.contains(key.id)
+    }
+
+    private func unlockLegacyKey() {
+        let passphrase = unlockPassphrase
+        unlockPassphrase = ""
+        guard !passphrase.isEmpty else { return }
+        isUnlocking = true
+        Task {
+            defer { isUnlocking = false }
+            do {
+                try await sshKeyManager.unlockLegacyKey(id: key.id, passphrase: passphrase)
+            } catch {
+                errorMessage = error.localizedDescription
+                showingError = true
+            }
+        }
     }
 
     /// Server auth attempts the default keys consume: certified keys count twice

--- a/rootshell/Features/SSH/Settings/SSHKeyImportView.swift
+++ b/rootshell/Features/SSH/Settings/SSHKeyImportView.swift
@@ -115,7 +115,7 @@ struct SSHKeyImportView: View {
                     } header: {
                         Text("Passphrase")
                     } footer: {
-                        Text("This key appears to be encrypted. The passphrase will be stored securely in the Keychain.")
+                        Text("This key appears to be encrypted. The passphrase is used once to decrypt the key during import and is never stored.")
                     }
                 }
 
@@ -230,7 +230,7 @@ struct SSHKeyImportView: View {
                             .font(.caption.bold())
                             .foregroundColor(.green)
 
-                        Text("Your passphrase will be stored securely in the Keychain")
+                        Text("The passphrase is used once to decrypt the key during import and is never stored; the imported key is protected by the Keychain")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }

--- a/rootshell/Features/SSH/Settings/SSHKeyManagementView.swift
+++ b/rootshell/Features/SSH/Settings/SSHKeyManagementView.swift
@@ -38,7 +38,11 @@ struct SSHKeyManagementView: View {
                         NavigationLink {
                             SSHKeyDetailView(key: key)
                         } label: {
-                            SSHKeyRow(key: key, defaultPriority: sshKeyManager.defaultPriority(for: key.id))
+                            SSHKeyRow(
+                                key: key,
+                                defaultPriority: sshKeyManager.defaultPriority(for: key.id),
+                                needsUnlock: sshKeyManager.keysNeedingUnlock.contains(key.id)
+                            )
                         }
                     }.onDelete(perform: deleteKeys).themedRow()
                 }
@@ -155,6 +159,8 @@ struct SSHKeyRow: View {
     let key: SSHKey
     /// Priority in the default keys list (0 = highest priority, nil = not a default)
     let defaultPriority: Int?
+    /// Legacy-encrypted key that needs a one-time manual unlock on this device
+    let needsUnlock: Bool
 
     /// Fixed width for badge alignment (accommodates "ED25519")
     private static let badgeWidth: CGFloat = 62
@@ -163,11 +169,13 @@ struct SSHKeyRow: View {
     init(key: SSHKey, isDefault: Bool) {
         self.key = key
         self.defaultPriority = isDefault ? 0 : nil
+        self.needsUnlock = false
     }
 
-    init(key: SSHKey, defaultPriority: Int?) {
+    init(key: SSHKey, defaultPriority: Int?, needsUnlock: Bool = false) {
         self.key = key
         self.defaultPriority = defaultPriority
+        self.needsUnlock = needsUnlock
     }
 
     var body: some View {
@@ -200,6 +208,12 @@ struct SSHKeyRow: View {
                         Image(systemName: cert.isExpired ? "xmark.seal.fill" : "checkmark.seal.fill").font(.caption2).foregroundColor(
                             certificateBadgeColor(cert)
                         ).padding(.horizontal, 4).padding(.vertical, 2).background(certificateBadgeColor(cert).opacity(0.2)).cornerRadius(4)
+                    }
+
+                    if needsUnlock {
+                        Image(systemName: "exclamationmark.triangle.fill").font(.caption2).foregroundColor(.orange).padding(
+                            .horizontal, 4
+                        ).padding(.vertical, 2).background(Color.orange.opacity(0.2)).cornerRadius(4)
                     }
                 }
 


### PR DESCRIPTION
- decrypt encrypted OpenSSH keys during import instead of storing passphrases
- migrate legacy keys and provide one-time unlock handling
- export normalized keys without passphrases in backups
- surface migration status and guidance in SSH key settings

Fixes #285