### PR TITLE
Reduce CPU use during active agent sessions

### DIFF
--- a/rootshell/UI/Shared/AttentionStatusViews.swift
+++ b/rootshell/UI/Shared/AttentionStatusViews.swift
@@ -10,6 +10,128 @@
 //
 
 import SwiftUI
+import UIKit
+
+/// A symbol whose opacity animation is owned by Core Animation rather than
+/// SwiftUI's ViewGraph. The render server can composite the breathing glyph
+/// without waking and re-laying out the app's entire SwiftUI scene each frame.
+private final class BreathingSymbolView: UIView {
+    private let imageView = UIImageView()
+    private var shouldBreathe = false
+    private var minimumOpacity: Float = 0.75
+    private var halfCycle: TimeInterval = 1.7
+    private var isBreathing = false
+    private var animationGeneration: UInt = 0
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        isAccessibilityElement = false
+        imageView.contentMode = .center
+        imageView.isUserInteractionEnabled = false
+        addSubview(imageView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        imageView.frame = bounds
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateAnimation()
+    }
+
+    func configure(
+        systemName: String,
+        pointSize: CGFloat,
+        color: UIColor,
+        breathes: Bool,
+        minimumOpacity: Float,
+        halfCycle: TimeInterval
+    ) {
+        let configuration = UIImage.SymbolConfiguration(
+            pointSize: pointSize,
+            weight: .semibold
+        )
+        imageView.image = UIImage(
+            systemName: systemName,
+            withConfiguration: configuration
+        )?.withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = color
+        shouldBreathe = breathes
+        self.minimumOpacity = minimumOpacity
+        self.halfCycle = halfCycle
+        updateAnimation()
+    }
+
+    private func updateAnimation() {
+        guard shouldBreathe, window != nil else {
+            stopAnimation()
+            return
+        }
+        guard !isBreathing else { return }
+
+        isBreathing = true
+        animationGeneration &+= 1
+        imageView.alpha = 1
+        animateStep(dimmed: true, generation: animationGeneration)
+    }
+
+    private func animateStep(dimmed: Bool, generation: UInt) {
+        UIView.animate(
+            withDuration: halfCycle,
+            delay: 0,
+            options: [.curveEaseInOut, .allowUserInteraction]
+        ) { [weak self] in
+            guard let self else { return }
+            imageView.alpha = dimmed ? CGFloat(minimumOpacity) : 1
+        } completion: { [weak self] finished in
+            guard let self,
+                  finished,
+                  isBreathing,
+                  animationGeneration == generation,
+                  shouldBreathe,
+                  window != nil else { return }
+            animateStep(dimmed: !dimmed, generation: generation)
+        }
+    }
+
+    private func stopAnimation() {
+        animationGeneration &+= 1
+        isBreathing = false
+        imageView.layer.removeAllAnimations()
+        imageView.alpha = 1
+    }
+}
+
+private struct CompositorBreathingSymbol: UIViewRepresentable {
+    let systemName: String
+    let pointSize: CGFloat
+    let color: Color
+    let breathes: Bool
+    let minimumOpacity: Float
+    let halfCycle: TimeInterval
+
+    func makeUIView(context: Context) -> BreathingSymbolView {
+        BreathingSymbolView()
+    }
+
+    func updateUIView(_ view: BreathingSymbolView, context: Context) {
+        view.configure(
+            systemName: systemName,
+            pointSize: pointSize,
+            color: UIColor(color),
+            breathes: breathes,
+            minimumOpacity: minimumOpacity,
+            halfCycle: halfCycle
+        )
+    }
+}
 
 extension AgentAttentionStatus {
     /// Status palette. Rollups use `worst(of:)`, so a dot tinted with
@@ -119,13 +241,12 @@ struct AgentStatusLabel: View {
     var fontSize: CGFloat = 12
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var dimmed = false
 
     /// Half a breathe: full opacity down to `breatheDim` and back is 3.4s.
     /// Easing settles the label at each end rather than pinging between
     /// them, so no explicit hold is needed.
     private static let breatheHalfCycle: TimeInterval = 1.7
-    private static let breatheDim: Double = 0.75
+    private static let breatheDim: Double = 0.45
 
     /// Only in-flight rows breathe. Decorative motion is the first thing to
     /// drop when the user has asked for less of it, or when the device is
@@ -137,31 +258,25 @@ struct AgentStatusLabel: View {
     }
 
     var body: some View {
-        if breathes {
-            label
-                .opacity(dimmed ? Self.breatheDim : 1)
-                .onAppear {
-                    withAnimation(
-                        .easeInOut(duration: Self.breatheHalfCycle)
-                            .repeatForever(autoreverses: true)
-                    ) {
-                        dimmed = true
-                    }
-                }
-                .onDisappear { dimmed = false }
-        } else {
-            label
-        }
+        label
     }
 
-    /// The status word, its glyph, and the live elapsed span. The breathe
-    /// covers all three together so the label reads as one element.
+    /// The status word, its glyph, and the live elapsed span. Only the glyph
+    /// breathes, allowing Core Animation to own the continuous compositing;
+    /// the SwiftUI label updates only when its actual data changes.
     private var label: some View {
         HStack(spacing: 4) {
             switch row.status {
             case .working:
-                Image(systemName: "circle.dashed")
-                    .font(.system(size: fontSize - 1, weight: .semibold))
+                CompositorBreathingSymbol(
+                    systemName: "circle.dashed",
+                    pointSize: fontSize - 1,
+                    color: labelColor,
+                    breathes: breathes,
+                    minimumOpacity: Float(Self.breatheDim),
+                    halfCycle: Self.breatheHalfCycle
+                )
+                .frame(width: fontSize, height: fontSize)
                 Text(row.status.displayLabel)
                     .fontWeight(.medium)
                 if row.backgroundAgentCount > 0 {

--- a/rootshell/UI/Tabs/TabsModel.swift
+++ b/rootshell/UI/Tabs/TabsModel.swift
@@ -421,6 +421,19 @@ final class TabModel: Identifiable {
     /// flush. Coalesced — only the most recent is kept.
     @ObservationIgnored private var deferredTitle: String?
 
+    /// High-rate OSC/tmux titles are presentation data, but `title` is an
+    /// observed property consumed by the window, top tabs, and sidebar. A
+    /// tmux agent spinner can otherwise invalidate that entire graph about ten
+    /// times per second. Preserve a responsive leading update and the newest
+    /// trailing value while limiting observed publication to 5 Hz. Codex and
+    /// Claude commonly animate their title spinners at about 10 Hz; publishing
+    /// every other frame keeps that motion legible without making SwiftUI
+    /// process every source update.
+    @ObservationIgnored private var pendingPublishedTitle: String?
+    @ObservationIgnored private var titlePublicationTimer: Timer?
+    @ObservationIgnored private var lastTitlePublicationUptime: TimeInterval = 0
+    private static let minimumTitlePublicationInterval: TimeInterval = 0.2
+
     private func markGroupingChanged<T: Equatable>(_ oldValue: T, _ newValue: T) {
         if oldValue != newValue {
             groupingRevision &+= 1
@@ -540,6 +553,7 @@ final class TabModel: Identifiable {
         // is safe here because the class is `@MainActor`-isolated and Swift
         // 6 deinit on a MainActor class runs on the main actor.
         observationCancellables.removeAll()
+        titlePublicationTimer?.invalidate()
     }
 
     // MARK: - Observation
@@ -555,6 +569,7 @@ final class TabModel: Identifiable {
     /// title (typically "ghostty").
     func startObserving(preserveExistingTitle: Bool = false) {
         observationCancellables.removeAll()
+        cancelPendingTitlePublication()
 
         // Resolve the focused pane first (not the terminal shim) so a focused
         // non-terminal pane isn't silently skipped in favor of a background
@@ -658,13 +673,15 @@ final class TabModel: Identifiable {
 
     func stopObserving() {
         observationCancellables.removeAll()
+        cancelPendingTitlePublication()
     }
 
     /// Apply a resolved tab title. During a tab-switch animation the write is
     /// deferred (coalesced to the latest value) and flushed on gate-close, so
     /// high-rate OSC/tmux title churn can't starve the selection spring with
-    /// TabBarItem re-renders. Outside the animation it's an immediate,
-    /// equality-guarded write — steady state is unchanged.
+    /// TabBarItem re-renders. Outside the animation, publication is
+    /// leading-and-trailing coalesced so frequently animated titles stay live
+    /// without driving the whole SwiftUI graph at spinner frequency.
     func applyResolvedTitle(_ resolved: String) {
         // An empty title means "no update", never "blank the tab". For tmux
         // window tabs the reconcile is the sole title writer, so a blank that
@@ -676,7 +693,7 @@ final class TabModel: Identifiable {
             return
         }
         deferredTitle = nil
-        if title != resolved { title = resolved }
+        scheduleTitlePublication(resolved)
     }
 
     /// Flush the most recent title deferred during the animation. Called from
@@ -684,7 +701,51 @@ final class TabModel: Identifiable {
     func flushDeferredTitle() {
         guard let pending = deferredTitle else { return }
         deferredTitle = nil
+        scheduleTitlePublication(pending)
+    }
+
+    private func scheduleTitlePublication(_ resolved: String) {
+        guard title != resolved || pendingPublishedTitle != nil else { return }
+        pendingPublishedTitle = resolved
+
+        let now = ProcessInfo.processInfo.systemUptime
+        let elapsed = now - lastTitlePublicationUptime
+        if lastTitlePublicationUptime == 0 || elapsed >= Self.minimumTitlePublicationInterval {
+            publishPendingTitle()
+            return
+        }
+
+        guard titlePublicationTimer == nil else { return }
+        let timer = Timer(
+            timeInterval: Self.minimumTitlePublicationInterval - elapsed,
+            repeats: false
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.publishPendingTitle()
+            }
+        }
+        titlePublicationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func publishPendingTitle() {
+        titlePublicationTimer?.invalidate()
+        titlePublicationTimer = nil
+        guard let pending = pendingPublishedTitle else { return }
+        pendingPublishedTitle = nil
+        lastTitlePublicationUptime = ProcessInfo.processInfo.systemUptime
         if title != pending { title = pending }
+    }
+
+    /// Drop titles captured from the previously observed pane. In particular,
+    /// a coalescing timer must not be allowed to overwrite the synchronous
+    /// initial title installed by `startObserving()` for a newly focused pane.
+    private func cancelPendingTitlePublication() {
+        titlePublicationTimer?.invalidate()
+        titlePublicationTimer = nil
+        pendingPublishedTitle = nil
+        deferredTitle = nil
+        lastTitlePublicationUptime = 0
     }
 
     /// Recompute `activeRoamProtocol` from the current split tree's session


### PR DESCRIPTION
- move the working indicator animation out of SwiftUI's ViewGraph
- coalesce high-frequency OSC and tmux title updates at 5 Hz
- discard queued titles when focused-pane observation changes