### PR TITLE
Tab Exposé: page between groups like the regular tab swipe

### DIFF
--- a/rootshell/UI/Shell/MainView+Lifecycle.swift
+++ b/rootshell/UI/Shell/MainView+Lifecycle.swift
@@ -453,8 +453,11 @@ extension MainView {
             preserveIDs.insert(swipe.sourceTabID)
             preserveIDs.insert(swipe.targetTabID)
         }
-        // Tab exposé mirrors every scope tab live; they must render while it's up.
-        let exposeVisibleIDs: Set<UUID> = tabExpose.isActive ? Set(tabExpose.tabIDs) : []
+        // Tab exposé mirrors every scope tab live (plus a neighbor scope being
+        // swiped in); they must render while it's up.
+        let exposeVisibleIDs: Set<UUID> = tabExpose.isActive
+            ? Set(tabExpose.tabIDs).union(tabExpose.previewTabIDs)
+            : []
 
         for tab in terminals {
             if tab.id == selectedID || exposeVisibleIDs.contains(tab.id) {

--- a/rootshell/UI/Shell/MainView+TabExpose.swift
+++ b/rootshell/UI/Shell/MainView+TabExpose.swift
@@ -96,6 +96,12 @@ extension MainView {
             reassertSelectedTabVisibility(reason: "tabExpose")
         }
         tabExpose.onNavigateScope = { delta in navigateScope(by: delta) }
+        tabExpose.onScopePreviewChanged = { ids in
+            // A group swipe drags the neighbor's live mirrors in: wake them;
+            // the reconcile re-occludes a preview that was replaced or ended.
+            for id in ids { setTabOcclusion(tabID: id, visible: true) }
+            reconcileSurfaceOcclusion(reason: "tabExposePreview")
+        }
         tabExpose.onScopeDidChange = { ids in
             // Newcomers must render live; the reconcile re-occludes leavers
             // (it treats the controller's current scope as visible).
@@ -120,8 +126,8 @@ extension MainView {
     }
 
     /// Switch the active group / project by `delta` (wraps). Lands on the
-    /// scope's first navigable tab; no-op in flat mode or with one scope.
-    /// While the exposé is up it stays up and re-scopes (see controller).
+    /// scope's remembered (else first navigable) tab; no-op in flat mode or
+    /// with one scope. While the exposé is up it stays up and pages over.
     func navigateScope(by delta: Int) {
         guard let id = tabsModel.firstTabIDInNeighborScope(offset: delta) else { return }
         if tabExpose.isActive { tabExpose.pendingScopeTransition = delta }

--- a/rootshell/UI/Tabs/TabExposeController.swift
+++ b/rootshell/UI/Tabs/TabExposeController.swift
@@ -48,8 +48,15 @@ final class TabExposeController {
     /// The tab whose full-size live picture slides in/out with the tray.
     private(set) var heroTabID: UUID?
     var highlightedTabID: UUID? {
-        didSet { if highlightedTabID != oldValue { observer?.tabExposeDidChangeCells(self) } }
+        didSet {
+            guard highlightedTabID != oldValue else { return }
+            // Inside refreshScope the single announce at its end delivers this.
+            if isRefreshingScope { highlightChangedDuringRefresh = true } else { observer?.tabExposeDidChangeCells(self) }
+        }
     }
+    /// Tabs of the neighbor scope being previewed by an in-flight group swipe
+    /// (the host keeps their renderers live; empty when no preview).
+    @ObservationIgnored private(set) var previewTabIDs: [UUID] = []
     var isActive: Bool { phase != .hidden }
     /// Grouped/project mode with more than one scope to move between.
     var canNavigateScope: Bool {
@@ -80,9 +87,12 @@ final class TabExposeController {
     /// Move to the previous (-1) / next (+1) group or project. The host
     /// switches the selection; the exposé stays up and re-scopes.
     @ObservationIgnored var onNavigateScope: ((Int) -> Void)?
-    /// Direction of an in-flight scope switch, for the view's slide; consumed
-    /// by `takeScopeTransition()`.
+    /// `previewTabIDs` changed: wake the newcomers, re-occlude the leavers.
+    @ObservationIgnored var onScopePreviewChanged: (([UUID]) -> Void)?
+    /// Direction of a scope switch in flight; published as `scopeTransition`
+    /// with the scope-changed announce so the view pages in that direction.
     @ObservationIgnored var pendingScopeTransition: Int?
+    @ObservationIgnored private var scopeTransition: Int?
     /// The terminal carrying `presentedOverlayKeyHandler` while presented.
     @ObservationIgnored weak var keyHandlerTerminal: Ghostty.TerminalView?
     /// No terminal to hook keys on (VNC pane focused): the view takes first
@@ -100,6 +110,8 @@ final class TabExposeController {
     @ObservationIgnored private var hideDeadline: CFTimeInterval = 0
     @ObservationIgnored private var pendingSelectedTabID: UUID?
     @ObservationIgnored private var scopeObservationArmed = false
+    @ObservationIgnored private var isRefreshingScope = false
+    @ObservationIgnored private var highlightChangedDuringRefresh = false
 
     // MARK: - Interactive reveal / dismiss
 
@@ -203,10 +215,23 @@ final class TabExposeController {
         onNavigateScope?(delta)
     }
 
-    /// The view consumes the slide direction of a scope switch, if any.
+    /// The view consumes the page direction of the scope switch this
+    /// `tabExposeDidChangeCells` announces, if it is one.
     func takeScopeTransition() -> Int? {
-        defer { pendingScopeTransition = nil }
-        return pendingScopeTransition
+        defer { scopeTransition = nil }
+        return scopeTransition
+    }
+
+    /// The neighbor scope a swipe would land on (nil: flat mode / one scope).
+    func neighborScope(offset: Int) -> TabsModel.ScopeInfo? {
+        tabsModel?.neighborScope(offset: offset)
+    }
+
+    /// The view is previewing `ids` (a neighbor scope dragged in); empty ends it.
+    func setScopePreview(_ ids: [UUID]) {
+        guard ids != previewTabIDs else { return }
+        previewTabIDs = ids
+        onScopePreviewChanged?(ids)
     }
 
     /// Immediate teardown (scene background, scope emptied).
@@ -315,10 +340,8 @@ final class TabExposeController {
     }
 
     private func stepSpring(toward target: CGFloat, dt: CGFloat) {
-        let omega = 2 * CGFloat.pi / max(springResponse, 0.05)
-        let accel = -omega * omega * (progress - target) - 2 * springDamping * omega * velocity
-        velocity += accel * dt
-        progress += velocity * dt
+        ExposeSpring.step(value: &progress, velocity: &velocity, target: target,
+                          response: springResponse, damping: springDamping, dt: dt)
     }
 
     // MARK: - Internals
@@ -367,6 +390,9 @@ final class TabExposeController {
         pendingSelectedTabID = nil
         hideDeadline = 0
         scopeObservationArmed = false
+        pendingScopeTransition = nil
+        scopeTransition = nil
+        previewTabIDs = []
         observer?.tabExposeDidChangeActivity(self)
         onDidDismiss?()
     }
@@ -390,6 +416,11 @@ final class TabExposeController {
         }()
         let scopeChanged = ids != tabIDs
         let changed = scopeChanged || title != scopeTitle || scoped != isScoped
+        // Only a real scope change pages; a stale direction must not leak
+        // into a later announce.
+        let transition = pendingScopeTransition
+        pendingScopeTransition = nil
+        let previousIDs = tabIDs
         tabIDs = ids
         scopeTitle = title
         isScoped = scoped
@@ -399,6 +430,9 @@ final class TabExposeController {
             forceHide(reason: "scopeEmpty")
             return
         }
+        isRefreshingScope = true
+        highlightChangedDuringRefresh = false
+        defer { isRefreshingScope = false }
         if let selected = tabsModel.selectedTabID, selected != heroTabID, ids.contains(selected) {
             if scopeChanged || phase == .settling(target: 0) {
                 // The selection moved to another scope (group swipe, ⌘⌥[ ],
@@ -407,6 +441,7 @@ final class TabExposeController {
                 highlightedTabID = selected
             } else if phase == .presented || phase == .interactive {
                 // Selection changed within the scope (⌘N, sidebar): ride it out as a select.
+                isRefreshingScope = false
                 select(selected)
                 return
             } else {
@@ -418,9 +453,17 @@ final class TabExposeController {
         if let h = highlightedTabID, !ids.contains(h) {
             highlightedTabID = ids.first
         }
-        if changed, announce {
-            onScopeDidChange?(ids)
+        scopeTransition = scopeChanged ? transition : nil
+        if scopeTransition != nil {
+            // The old scope's page slides out: its renderers stay live through
+            // the host's reconcile until the view drops it (`setScopePreview([])`).
+            previewTabIDs = previousIDs
+        }
+        if announce, changed || highlightChangedDuringRefresh {
+            if changed { onScopeDidChange?(ids) }
             observer?.tabExposeDidChangeCells(self)
+        } else {
+            scopeTransition = nil
         }
     }
 

--- a/rootshell/UI/Tabs/TabExposeLayout.swift
+++ b/rootshell/UI/Tabs/TabExposeLayout.swift
@@ -10,6 +10,17 @@
 import CoreGraphics
 import Foundation
 
+/// Damped spring step shared by the reveal progress and the page shift.
+nonisolated struct ExposeSpring {
+    static func step(value: inout CGFloat, velocity: inout CGFloat, target: CGFloat,
+                     response: CGFloat, damping: CGFloat, dt: CGFloat) {
+        let omega = 2 * CGFloat.pi / max(response, 0.05)
+        let accel = -omega * omega * (value - target) - 2 * damping * omega * velocity
+        velocity += accel * dt
+        value += velocity * dt
+    }
+}
+
 nonisolated struct TabExposeLayout {
     struct Metrics: Equatable {
         var margin: CGFloat

--- a/rootshell/UI/Tabs/TabExposeTrayView.swift
+++ b/rootshell/UI/Tabs/TabExposeTrayView.swift
@@ -1,0 +1,181 @@
+//
+//  TabExposeTrayView.swift
+//  rootshell
+//
+//  One scope's page of the tab exposé: the scope header plus a grid of live
+//  tab previews, scrolling vertically when the grid doesn't fit. The exposé
+//  view holds one for the active scope and, while a group swipe or ⌘⌥[ ] is
+//  in flight, a second for the neighbor scope sliding in beside it.
+//
+
+import UIKit
+
+@MainActor
+final class TabExposeTrayView: UIScrollView {
+    private(set) var tabIDs: [UUID] = []
+    private(set) var cells: [TabExposeCellView] = []
+    private(set) var layoutResult = TabExposeLayout.Result.empty
+
+    private let header = UIView()
+    private let headerIcon = UIImageView()
+    private let headerLabel = UILabel()
+    private var appearance = TabExposeView.Appearance()
+
+    init() {
+        super.init(frame: .zero)
+        showsHorizontalScrollIndicator = false
+        alwaysBounceVertical = false
+        contentInsetAdjustmentBehavior = .never
+        delaysContentTouches = false
+        // UIKit 26 applies an automatic glass "scroll edge effect" to scroll
+        // views it considers under a bar; on Catalyst the window titlebar
+        // qualifies and the effect blurs/tints the whole tray. The tray is a
+        // live preview grid, never bar-adjacent content: opt out entirely.
+        if #available(iOS 26.0, macCatalyst 26.0, visionOS 26.0, *) {
+            topEdgeEffect.isHidden = true
+            bottomEdgeEffect.isHidden = true
+            leftEdgeEffect.isHidden = true
+            rightEdgeEffect.isHidden = true
+        }
+
+        headerIcon.contentMode = .scaleAspectFit
+        headerLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        headerLabel.lineBreakMode = .byTruncatingTail
+        header.addSubview(headerIcon)
+        header.addSubview(headerLabel)
+        header.isUserInteractionEnabled = false
+        addSubview(header)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: - Cells
+
+    /// Rebuild for `tabIDs`, reusing cells by tab id; stale cells are removed.
+    /// Returns the cells created by this rebuild.
+    @discardableResult
+    func rebuildCells(
+        tabIDs ids: [UUID],
+        scopeTitle: String?,
+        scoped: Bool,
+        tabsModel: TabsModel,
+        selectedID: UUID?,
+        highlightedID: UUID?,
+        appearance: TabExposeView.Appearance
+    ) -> [TabExposeCellView] {
+        self.appearance = appearance
+        var byID = Dictionary(uniqueKeysWithValues: cells.map { ($0.tabID, $0) })
+        var ordered: [TabExposeCellView] = []
+        var entering: [TabExposeCellView] = []
+        for (index, id) in ids.enumerated() {
+            guard let tab = tabsModel.tab(withID: id) else { continue }
+            let cell: TabExposeCellView
+            if let existing = byID.removeValue(forKey: id) {
+                cell = existing
+            } else {
+                cell = TabExposeCellView(tabID: id)
+                addSubview(cell)
+                entering.append(cell)
+            }
+            cell.mirror.tab = tab
+            cell.isCurrent = id == selectedID
+            cell.isHighlighted = id == highlightedID
+            // Captions only re-host when the cell's position changes (hover
+            // highlight churn must not rebuild SwiftUI per cell).
+            if cell.captionIndex != index {
+                cell.captionIndex = index
+                cell.setCaption(appearance.showsCaptions ? appearance.captionProvider?(tab, index) : nil)
+            }
+            ordered.append(cell)
+        }
+        for (_, stale) in byID { stale.removeFromSuperview() }
+        cells = ordered
+        tabIDs = ids
+
+        header.isHidden = !scoped
+        if scoped {
+            headerLabel.text = [scopeTitle, "\(ids.count)"]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+            let symbol = tabsModel.isProjectGroupingActive ? "folder" : "square.grid.2x2"
+            headerIcon.image = UIImage(systemName: symbol)
+        }
+        applyAppearance(appearance)
+        return entering
+    }
+
+    func removeAllCells() {
+        for cell in cells { cell.removeFromSuperview() }
+        cells.removeAll()
+        tabIDs.removeAll()
+    }
+
+    func applyAppearance(_ appearance: TabExposeView.Appearance) {
+        self.appearance = appearance
+        headerLabel.textColor = appearance.textColor.withAlphaComponent(0.85)
+        headerIcon.tintColor = appearance.textColor.withAlphaComponent(0.7)
+        for cell in cells {
+            cell.previewBackgroundColor = appearance.backgroundColor
+            cell.accentColor = appearance.accentColor
+            cell.currentRingColor = appearance.textColor.withAlphaComponent(0.3)
+        }
+    }
+
+    // MARK: - Layout
+
+    /// Lay the header and grid out for a tray of `size` (the hero area).
+    func layoutGrid(size: CGSize, aspect: CGFloat, metrics: TabExposeLayout.Metrics, cornerRadius: CGFloat) {
+        layoutResult = TabExposeLayout.grid(
+            in: CGRect(origin: .zero, size: size),
+            count: cells.count,
+            aspect: aspect,
+            metrics: metrics
+        )
+        contentSize = CGSize(width: size.width, height: max(layoutResult.contentHeight, size.height))
+        isScrollEnabled = !layoutResult.fits
+
+        header.frame = layoutResult.headerFrame
+        let iconSide = max(0, min(16, header.bounds.height))
+        headerIcon.frame = CGRect(x: 0, y: (header.bounds.height - iconSide) / 2, width: iconSide, height: iconSide)
+        headerLabel.frame = CGRect(x: iconSide + 6, y: 0, width: header.bounds.width - iconSide - 6, height: header.bounds.height)
+
+        for (index, cell) in cells.enumerated() where index < layoutResult.frames.count {
+            // bounds/center, not frame: highlighted cells carry a scale transform.
+            let frame = layoutResult.frames[index]
+            cell.bounds = CGRect(origin: .zero, size: frame.size)
+            cell.center = CGPoint(x: frame.midX, y: frame.midY)
+            cell.layoutContent(previewSize: layoutResult.cellSize, cornerRadius: cornerRadius)
+        }
+    }
+
+    func setChrome(captionAlpha: CGFloat, ringAlpha: CGFloat) {
+        header.alpha = captionAlpha
+        for cell in cells {
+            cell.captionAlpha = captionAlpha
+            cell.ringAlpha = ringAlpha
+        }
+    }
+
+    // MARK: - Per frame
+
+    /// Refresh the mirrors of on-screen cells only.
+    func syncVisibleMirrors() {
+        let visible = bounds
+        for cell in cells where cell.frame.intersects(visible) {
+            cell.mirror.sync()
+        }
+    }
+
+    // MARK: - Hit testing / scrolling
+
+    func cell(at pointInTray: CGPoint) -> TabExposeCellView? {
+        cells.first { $0.frame.contains(pointInTray) }
+    }
+
+    func scrollCellIntoView(id: UUID?, animated: Bool) {
+        guard isScrollEnabled, let id,
+              let cell = cells.first(where: { $0.tabID == id }) else { return }
+        scrollRectToVisible(cell.frame.insetBy(dx: 0, dy: -12), animated: animated)
+    }
+}

--- a/rootshell/UI/Tabs/TabExposeView.swift
+++ b/rootshell/UI/Tabs/TabExposeView.swift
@@ -9,6 +9,10 @@
 //  the controller's spring and refreshes the mirrors. Hosted as the top layer
 //  of the terminal content area (`TabExposeHost`).
 //
+//  Group navigation pages horizontally like the regular tab swipe: the active
+//  scope's tray follows the finger at `pageShift` while the neighbor scope's
+//  tray sits one page over; release springs to commit or cancel.
+//
 
 import UIKit
 import SwiftUI
@@ -46,15 +50,28 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
 
     private let backdrop = UIView()
     private let hero = TabPreviewMirrorView()
-    private let tray = UIScrollView()
-    private let header = UIView()
-    private let headerIcon = UIImageView()
-    private let headerLabel = UILabel()
-    private var cells: [TabExposeCellView] = []
-    private var layoutResult = TabExposeLayout.Result.empty
+    /// The active scope's page.
+    private var primary = TabExposeTrayView()
+    /// A neighbor scope's page while a swipe / ⌘⌥[ ] is in flight.
+    private var companion: TabExposeTrayView?
+    /// +1: companion sits one page right of the primary; -1: left.
+    private var companionSide = 0
+    /// Primary's horizontal offset in points (companion at `pageShift + side * W`).
+    private var pageShift: CGFloat = 0
+    private var pageVelocity: CGFloat = 0
+    /// Spring target for `pageShift`; nil while finger-driven or at rest.
+    private var pageTarget: CGFloat?
+    private var pageSpringFast = false
+    private var lastPageTick: CFTimeInterval = 0
+    private var scopeSwipeActive = false
+    private var scopeSwipeBase: CGFloat = 0
+    /// A committed swipe waits for the scope-changed announce until this.
+    private var scopeCommitDeadline: CFTimeInterval = 0
+
     private var heroRect: CGRect = .zero
     private var displayLink: CADisplayLink?
     private var lastAppliedProgress: CGFloat = -1
+    private var lastAppliedShift: CGFloat = 0
     private lazy var edgePan: InteractiveEdgePanRecognizer = makeEdgePan()
     private lazy var scopePan: InteractiveEdgePanRecognizer = makeScopePan()
 
@@ -68,30 +85,7 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
 
         backdrop.isUserInteractionEnabled = false
         addSubview(backdrop)
-
-        tray.showsHorizontalScrollIndicator = false
-        tray.alwaysBounceVertical = false
-        tray.contentInsetAdjustmentBehavior = .never
-        tray.delaysContentTouches = false
-        // UIKit 26 applies an automatic glass "scroll edge effect" to scroll
-        // views it considers under a bar; on Catalyst the window titlebar
-        // qualifies and the effect blurs/tints the whole tray. The tray is a
-        // live preview grid, never bar-adjacent content: opt out entirely.
-        if #available(iOS 26.0, macCatalyst 26.0, visionOS 26.0, *) {
-            tray.topEdgeEffect.isHidden = true
-            tray.bottomEdgeEffect.isHidden = true
-            tray.leftEdgeEffect.isHidden = true
-            tray.rightEdgeEffect.isHidden = true
-        }
-        addSubview(tray)
-
-        headerIcon.contentMode = .scaleAspectFit
-        headerLabel.font = .systemFont(ofSize: 13, weight: .semibold)
-        headerLabel.lineBreakMode = .byTruncatingTail
-        header.addSubview(headerIcon)
-        header.addSubview(headerLabel)
-        header.isUserInteractionEnabled = false
-        tray.addSubview(header)
+        addSubview(primary)
 
         hero.isUserInteractionEnabled = false
         addSubview(hero)
@@ -134,10 +128,11 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
         if controller.isActive {
             isHidden = false
             lastAppliedProgress = -1
-            rebuildCells()
+            resetPage()
+            rebuildPrimary()
             setNeedsLayout()
             layoutIfNeeded()
-            scrollHighlightedCellIntoView(animated: false)
+            primary.scrollCellIntoView(id: controller.highlightedTabID, animated: false)
             startDisplayLink()
             if controller.wantsFirstResponderFallback {
                 becomeFirstResponder()
@@ -147,8 +142,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             if isFirstResponder { resignFirstResponder() }
             isHidden = true
             hero.tab = nil
-            for cell in cells { cell.removeFromSuperview() }
-            cells.removeAll()
+            resetPage()
+            primary.removeAllCells()
         }
     }
 
@@ -181,109 +176,49 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
 
     func tabExposeDidChangeCells(_ controller: TabExposeController) {
         guard controller.isActive else { return }
-        let transition = controller.takeScopeTransition()
-        let entering = rebuildCells(slideOutDirection: transition)
-        setNeedsLayout()
-        if let transition, !controller.reduceMotion() {
-            layoutIfNeeded()
-            slideIn(entering, from: transition)
-        }
-        scrollHighlightedCellIntoView(animated: true)
-    }
-
-    /// Scope switch: the old grid slides out toward `-direction`, the new one
-    /// slides in from `+direction` (swipe left = next = content comes from the right).
-    private func slideIn(_ entering: [TabExposeCellView], from direction: Int) {
-        let dx = CGFloat(direction) * 48
-        for cell in entering {
-            cell.alpha = 0
-            cell.transform = CGAffineTransform(translationX: dx, y: 0)
-        }
-        UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 0,
-                       options: [.beginFromCurrentState, .allowUserInteraction]) {
-            for cell in entering {
-                cell.alpha = 1
-                cell.transform = cell.isHighlighted ? CGAffineTransform(scaleX: 1.02, y: 1.02) : .identity
+        if let direction = controller.takeScopeTransition() {
+            if controller.reduceMotion() {
+                resetPage()
+                rebuildPrimary()
+            } else {
+                pageToNewScope(direction: direction)
             }
+        } else {
+            rebuildPrimary()
         }
+        setNeedsLayout()
+        primary.scrollCellIntoView(id: controller.highlightedTabID, animated: true)
     }
 
     // MARK: - Cells
 
-    /// Returns the cells created by this rebuild. With `slideOutDirection`,
-    /// stale cells animate out instead of vanishing.
-    @discardableResult
-    private func rebuildCells(slideOutDirection: Int? = nil) -> [TabExposeCellView] {
-        guard let tabsModel = controller.tabsModel else { return [] }
-        var byID = Dictionary(uniqueKeysWithValues: cells.map { ($0.tabID, $0) })
-        var ordered: [TabExposeCellView] = []
-        var entering: [TabExposeCellView] = []
-        for (index, id) in controller.tabIDs.enumerated() {
-            guard let tab = tabsModel.tab(withID: id) else { continue }
-            let cell: TabExposeCellView
-            if let existing = byID.removeValue(forKey: id) {
-                cell = existing
-            } else {
-                cell = makeCell(for: tab)
-                entering.append(cell)
-            }
-            cell.mirror.tab = tab
-            cell.isCurrent = id == tabsModel.selectedTabID
-            cell.isHighlighted = id == controller.highlightedTabID
-            // Captions only re-host when the cell's position changes (hover
-            // highlight churn must not rebuild SwiftUI per cell).
-            if cell.captionIndex != index {
-                cell.captionIndex = index
-                cell.setCaption(appearance.showsCaptions ? appearance.captionProvider?(tab, index) : nil)
-            }
-            ordered.append(cell)
-        }
-        if let slideOutDirection, !controller.reduceMotion(), !byID.isEmpty {
-            let dx = CGFloat(-slideOutDirection) * 48
-            let leaving = Array(byID.values)
-            UIView.animate(withDuration: 0.2, delay: 0, options: [.beginFromCurrentState, .curveEaseIn]) {
-                for cell in leaving {
-                    cell.alpha = 0
-                    cell.transform = CGAffineTransform(translationX: dx, y: 0)
-                }
-            } completion: { _ in
-                for cell in leaving { cell.removeFromSuperview() }
-            }
-        } else {
-            for (_, stale) in byID { stale.removeFromSuperview() }
-        }
-        cells = ordered
+    private func rebuildPrimary() {
+        guard let tabsModel = controller.tabsModel else { return }
+        primary.rebuildCells(
+            tabIDs: controller.tabIDs,
+            scopeTitle: controller.scopeTitle,
+            scoped: controller.isScoped,
+            tabsModel: tabsModel,
+            selectedID: tabsModel.selectedTabID,
+            highlightedID: controller.highlightedTabID,
+            appearance: appearance
+        )
         hero.tab = controller.heroTabID.flatMap { tabsModel.tab(withID: $0) }
-
-        let scoped = controller.isScoped
-        header.isHidden = !scoped
-        if scoped {
-            headerLabel.text = [controller.scopeTitle, "\(controller.tabIDs.count)"]
-                .compactMap { $0 }
-                .joined(separator: " · ")
-            let symbol = tabsModel.isProjectGroupingActive ? "folder" : "square.grid.2x2"
-            headerIcon.image = UIImage(systemName: symbol)
-        }
         applyAppearance()
-        return entering
     }
 
-    private func makeCell(for tab: TabModel) -> TabExposeCellView {
-        let cell = TabExposeCellView(tabID: tab.id)
-        tray.addSubview(cell)
-        return cell
+    private func makeTray(interactive: Bool) -> TabExposeTrayView {
+        let tray = TabExposeTrayView()
+        tray.isUserInteractionEnabled = interactive
+        insertSubview(tray, belowSubview: hero)
+        return tray
     }
 
     private func applyAppearance() {
         backdrop.backgroundColor = appearance.backgroundColor
         hero.backgroundColor = appearance.backgroundColor
-        headerLabel.textColor = appearance.textColor.withAlphaComponent(0.85)
-        headerIcon.tintColor = appearance.textColor.withAlphaComponent(0.7)
-        for cell in cells {
-            cell.previewBackgroundColor = appearance.backgroundColor
-            cell.accentColor = appearance.accentColor
-            cell.currentRingColor = appearance.textColor.withAlphaComponent(0.3)
-        }
+        primary.applyAppearance(appearance)
+        companion?.applyAppearance(appearance)
     }
 
     // MARK: - Layout
@@ -291,6 +226,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
     private var isCompact: Bool {
         UIDevice.current.userInterfaceIdiom == .phone || bounds.width < 500
     }
+
+    private var pageWidth: CGFloat { max(heroRect.width, 1) }
 
     private func currentHeroRect() -> CGRect {
         guard let hero = controller.heroTabID ?? controller.tabsModel?.selectedTabID,
@@ -322,64 +259,55 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             compact: isCompact, mac: mac, vision: vision,
             showsCaptions: appearance.showsCaptions, hasHeader: controller.isScoped
         )
-        layoutResult = TabExposeLayout.grid(
-            in: CGRect(origin: .zero, size: heroRect.size),
-            count: cells.count,
-            aspect: heroRect.width / H,
-            metrics: metrics
-        )
-        controller.columns = layoutResult.columns
+        let radius: CGFloat = vision ? 16 : (isCompact ? 8 : 10)
+        let aspect = heroRect.width / H
+        for tray in [primary, companion].compactMap({ $0 }) {
+            tray.layoutGrid(size: heroRect.size, aspect: aspect, metrics: metrics, cornerRadius: radius)
+            // bounds/center, not frame: trays carry the reveal/page transform.
+            // A scroll view's bounds origin is its content offset; keep it.
+            var b = tray.bounds
+            b.size = heroRect.size
+            tray.bounds = b
+            tray.center = CGPoint(x: heroRect.midX, y: heroRect.midY)
+        }
+        controller.columns = primary.layoutResult.columns
 
         backdrop.frame = heroRect
         hero.transform = .identity
         hero.frame = heroRect
-        tray.transform = .identity
-        tray.frame = heroRect
-        tray.contentSize = CGSize(width: heroRect.width, height: max(layoutResult.contentHeight, heroRect.height))
-        tray.isScrollEnabled = !layoutResult.fits
-
-        header.frame = layoutResult.headerFrame
-        let iconSide = max(0, min(16, header.bounds.height))
-        headerIcon.frame = CGRect(x: 0, y: (header.bounds.height - iconSide) / 2, width: iconSide, height: iconSide)
-        headerLabel.frame = CGRect(x: iconSide + 6, y: 0, width: header.bounds.width - iconSide - 6, height: header.bounds.height)
-
-        let radius: CGFloat = vision ? 16 : (isCompact ? 8 : 10)
-        for (index, cell) in cells.enumerated() where index < layoutResult.frames.count {
-            // bounds/center, not frame: highlighted cells carry a scale transform.
-            let frame = layoutResult.frames[index]
-            cell.bounds = CGRect(origin: .zero, size: frame.size)
-            cell.center = CGPoint(x: frame.midX, y: frame.midY)
-            cell.layoutContent(previewSize: layoutResult.cellSize, cornerRadius: radius)
-        }
         lastAppliedProgress = -1
         applyProgress()
     }
 
-    /// Everything visual derives from `controller.progress` (0 hidden … 1 presented).
+    /// Everything visual derives from `controller.progress` (0 hidden … 1
+    /// presented) and `pageShift` (horizontal paging between scopes).
     private func applyProgress() {
         let p = controller.progress
-        guard p != lastAppliedProgress else { return }
+        guard p != lastAppliedProgress || pageShift != lastAppliedShift else { return }
         lastAppliedProgress = p
+        lastAppliedShift = pageShift
         let H = max(heroRect.height, 1)
         let clamped = min(max(p, 0), 1)
+        let y = -(1 - clamped) * H
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         hero.transform = CGAffineTransform(translationX: 0, y: clamped * H)
         hero.isHidden = clamped >= 1
-        tray.transform = CGAffineTransform(translationX: 0, y: -(1 - clamped) * H)
+        var primaryTransform = CGAffineTransform(translationX: pageShift, y: y)
+        var companionTransform = CGAffineTransform(translationX: pageShift + CGFloat(companionSide) * pageWidth, y: y)
         if p > 1 {
             // Overshoot: the tray breathes instead of tearing away from the edge.
             let breathe = 1 + (p - 1) * 0.3
-            tray.transform = tray.transform.scaledBy(x: breathe, y: breathe)
+            primaryTransform = primaryTransform.scaledBy(x: breathe, y: breathe)
+            companionTransform = companionTransform.scaledBy(x: breathe, y: breathe)
         }
+        primary.transform = primaryTransform
+        companion?.transform = companionTransform
         let chromeAlpha = Self.smoothstep(0.6, 0.9, p)
         let ringAlpha = Self.smoothstep(0.8, 1.0, p)
-        header.alpha = chromeAlpha
-        for cell in cells {
-            cell.captionAlpha = chromeAlpha
-            cell.ringAlpha = ringAlpha
-        }
+        primary.setChrome(captionAlpha: chromeAlpha, ringAlpha: ringAlpha)
+        companion?.setChrome(captionAlpha: chromeAlpha, ringAlpha: ringAlpha)
         backdrop.isHidden = p <= 0
         CATransaction.commit()
     }
@@ -387,13 +315,6 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
     private static func smoothstep(_ a: CGFloat, _ b: CGFloat, _ x: CGFloat) -> CGFloat {
         let t = min(max((x - a) / max(b - a, 0.0001), 0), 1)
         return t * t * (3 - 2 * t)
-    }
-
-    private func scrollHighlightedCellIntoView(animated: Bool) {
-        guard tray.isScrollEnabled,
-              let id = controller.highlightedTabID,
-              let cell = cells.first(where: { $0.tabID == id }) else { return }
-        tray.scrollRectToVisible(cell.frame.insetBy(dx: 0, dy: -12), animated: animated)
     }
 
     // MARK: - Display link
@@ -422,12 +343,11 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             setNeedsLayout()
             layoutIfNeeded()
         }
+        stepPageSpring(now: link.timestamp)
         applyProgress()
         if !hero.isHidden { hero.sync() }
-        let visible = tray.bounds
-        for cell in cells where cell.frame.intersects(visible) {
-            cell.mirror.sync()
-        }
+        primary.syncVisibleMirrors()
+        companion?.syncVisibleMirrors()
     }
 
     private final class DisplayLinkProxy: NSObject {
@@ -441,8 +361,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
     // MARK: - Touch / pointer
 
     @objc private func handleTap(_ tap: UITapGestureRecognizer) {
-        guard controller.phase == .presented else { return }
-        if let cell = cell(at: tap.location(in: tray)) {
+        guard controller.phase == .presented, !isPageInteracting else { return }
+        if let cell = primary.cell(at: tap.location(in: primary)) {
             controller.select(cell.tabID)
         } else {
             controller.cancel()
@@ -451,10 +371,10 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
 
     #if !os(visionOS)
     @objc private func handleHover(_ hover: UIHoverGestureRecognizer) {
-        guard controller.phase == .presented else { return }
+        guard controller.phase == .presented, !isPageInteracting else { return }
         switch hover.state {
         case .began, .changed:
-            if let cell = cell(at: hover.location(in: tray)) {
+            if let cell = primary.cell(at: hover.location(in: primary)) {
                 controller.highlightedTabID = cell.tabID
             }
         default:
@@ -462,10 +382,6 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
         }
     }
     #endif
-
-    private func cell(at pointInTray: CGPoint) -> TabExposeCellView? {
-        cells.first { $0.frame.contains(pointInTray) }
-    }
 
     // MARK: - Window-level pull gesture
 
@@ -502,8 +418,9 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             guard vertical else { return false }
             if self.controller.isActive {
                 // Push back up to dismiss; not while already finger-driven,
-                // and not when the tray scrolls instead.
-                return translation.y < 0 && self.controller.phase != .interactive && !self.tray.isScrollEnabled
+                // not mid group swipe, and not when the tray scrolls instead.
+                return translation.y < 0 && self.controller.phase != .interactive
+                    && !self.scopeSwipeActive && !self.primary.isScrollEnabled
             }
             return translation.y > 0 && self.configuration.canBeginReveal()
         }
@@ -520,12 +437,17 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
     }
 }
 
-// MARK: - Horizontal swipe between groups (while presented)
+// MARK: - Horizontal paging between scopes (while presented)
 
 extension TabExposeView {
+    /// A swipe, a settle, or a companion page still on screen.
+    private var isPageInteracting: Bool {
+        scopeSwipeActive || companion != nil || pageTarget != nil
+    }
+
     /// One-finger (or two) touch swipe and two-finger trackpad swipe over the
-    /// presented grid move to the previous / next group. The tray follows the
-    /// finger a little for feedback; the cell slide does the rest.
+    /// presented grid drag the neighbor group's page in beside the current
+    /// one, exactly like the regular tab swipe; release commits or snaps back.
     private func makeScopePan() -> InteractiveEdgePanRecognizer {
         var config = InteractiveEdgePanRecognizer.Configuration(axis: .horizontal, idioms: [.phone, .pad, .mac])
         config.touchCounts = [1, 2]
@@ -546,37 +468,186 @@ extension TabExposeView {
         let callbacks = InteractiveEdgePanRecognizer.Callbacks(
             isInActivationBand: isInBand,
             shouldBegin: shouldBegin,
-            length: { [weak self] in max(self?.bounds.width ?? 1, 1) },
-            onBegin: { _ in },
-            onChange: { [weak self] p in self?.nudgeTray(progress: p) },
+            length: { [weak self] in self?.pageWidth ?? 1 },
+            onBegin: { [weak self] _ in self?.beginScopeSwipe() },
+            onChange: { [weak self] p in self?.updateScopeSwipe(progress: p) },
             onEnd: { [weak self] p, v in self?.endScopeSwipe(progress: p, velocity: v) },
-            onCancel: { [weak self] in self?.settleTray() }
+            onCancel: { [weak self] in self?.cancelScopeSwipe() }
         )
         return InteractiveEdgePanRecognizer(configuration: config, callbacks: callbacks)
     }
 
-    private func nudgeTray(progress: CGFloat) {
-        guard controller.phase == .presented else { return }
-        let clamped = min(max(progress, -1), 1)
-        tray.transform = CGAffineTransform(translationX: clamped * bounds.width * 0.2, y: 0)
+    private func beginScopeSwipe() {
+        guard controller.phase == .presented, controller.canNavigateScope else { return }
+        // Take over a settling page where it is so flicks chain.
+        scopeSwipeBase = pageShift
+        pageTarget = nil
+        pageVelocity = 0
+        scopeCommitDeadline = 0
+        scopeSwipeActive = true
+    }
+
+    /// `progress` is the gesture's signed distance / page width (right-positive).
+    private func updateScopeSwipe(progress: CGFloat) {
+        guard scopeSwipeActive else { return }
+        let W = pageWidth
+        pageShift = Self.rubberBanded(scopeSwipeBase + progress * W, limit: W)
+        updateCompanionForShift()
+        applyProgress()
+    }
+
+    /// Keep the companion on the side the primary is being dragged away from.
+    private func updateCompanionForShift() {
+        guard pageShift != 0 else { return }
+        let delta = pageShift < 0 ? 1 : -1  // swipe left = next group
+        if companion != nil, companionSide == delta { return }
+        guard let tabsModel = controller.tabsModel,
+              let neighbor = controller.neighborScope(offset: delta) else { return }
+        companion?.removeFromSuperview()
+        let tray = makeTray(interactive: false)
+        tray.rebuildCells(
+            tabIDs: neighbor.tabIDs,
+            scopeTitle: neighbor.title,
+            scoped: true,
+            tabsModel: tabsModel,
+            selectedID: tabsModel.preferredTabID(in: neighbor.tabIDs, scope: neighbor.key),
+            highlightedID: nil,
+            appearance: appearance
+        )
+        companion = tray
+        companionSide = delta
+        setNeedsLayout()
+        layoutIfNeeded()
+        // Wake the neighbor's renderers so its mirrors are live while dragging.
+        controller.setScopePreview(neighbor.tabIDs)
     }
 
     private func endScopeSwipe(progress: CGFloat, velocity: CGFloat) {
-        // Swipe left (negative) = next group; content then slides in from the right.
-        if progress < -0.12 || velocity < -500 {
-            controller.navigateScope(by: 1)
-        } else if progress > 0.12 || velocity > 500 {
-            controller.navigateScope(by: -1)
+        guard scopeSwipeActive else { return }
+        scopeSwipeActive = false
+        let W = pageWidth
+        let delta = pageShift < 0 ? 1 : -1
+        // Regular tab swipe thresholds: distance or a flick in the drag direction.
+        let threshold = max(120, min(0.45 * W, 260))
+        let flick = velocity * CGFloat(-delta) >= 900
+        let commits = companion != nil && companionSide == delta && (abs(pageShift) >= threshold || flick)
+        if commits {
+            // Switch now (as the regular swipe does); the scope-changed announce
+            // relabels the pages in place and settles the new primary to 0.
+            controller.navigateScope(by: delta)
+            scopeCommitDeadline = CACurrentMediaTime() + 0.5
+            settlePage(to: CGFloat(-delta) * W, fast: false)
+        } else {
+            settlePage(to: 0, fast: true)
         }
-        settleTray()
     }
 
-    private func settleTray() {
-        guard controller.phase == .presented else { return }
-        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.86, initialSpringVelocity: 0,
-                       options: [.beginFromCurrentState, .allowUserInteraction]) {
-            self.tray.transform = .identity
+    private func cancelScopeSwipe() {
+        guard scopeSwipeActive else { return }
+        scopeSwipeActive = false
+        settlePage(to: 0, fast: true)
+    }
+
+    /// The scope changed by `direction` (swipe commit, ⌘⌥[ ], scope menu):
+    /// the new scope's page slides to the center while the old one leaves.
+    private func pageToNewScope(direction: Int) {
+        let W = pageWidth
+        let previousShift = pageShift
+        let outgoing = primary
+        if let companion, companion.tabIDs == controller.tabIDs {
+            // The dragged-in preview is the new scope: swap roles where they
+            // stand (primary at shift, companion at shift + side·W).
+            primary = companion
+            pageShift += CGFloat(companionSide) * W
+            companionSide = -companionSide
+        } else {
+            companion?.removeFromSuperview()
+            primary = makeTray(interactive: true)
+            companionSide = -direction
+            pageShift = CGFloat(direction) * W
         }
+        companion = outgoing
+        outgoing.isUserInteractionEnabled = false
+        primary.isUserInteractionEnabled = true
+        rebuildPrimary()
+        setNeedsLayout()
+        layoutIfNeeded()
+        // The controller already holds the outgoing page's tabs as the preview
+        // so they render until `dropCompanion` ends it on landing.
+        scopeCommitDeadline = 0
+        if scopeSwipeActive {
+            // Finger still down: keep following it from the relabeled position.
+            scopeSwipeBase += pageShift - previousShift
+        } else {
+            settlePage(to: 0, fast: false)
+        }
+    }
+
+    private func settlePage(to target: CGFloat, fast: Bool) {
+        if controller.reduceMotion() {
+            pageShift = target
+            pageVelocity = 0
+            pageTarget = nil
+            applyProgress()
+            pageDidLand()
+            return
+        }
+        pageTarget = target
+        pageSpringFast = fast
+        lastPageTick = 0
+    }
+
+    private func stepPageSpring(now: CFTimeInterval) {
+        // A committed swipe whose selection never changed: snap back.
+        if scopeCommitDeadline > 0, now >= scopeCommitDeadline, !scopeSwipeActive {
+            scopeCommitDeadline = 0
+            settlePage(to: 0, fast: true)
+        }
+        guard let target = pageTarget else {
+            lastPageTick = now
+            return
+        }
+        let dt = lastPageTick == 0 ? 1.0 / 60.0 : min(max(now - lastPageTick, 0), 1.0 / 20.0)
+        lastPageTick = now
+        ExposeSpring.step(value: &pageShift, velocity: &pageVelocity, target: target,
+                          response: pageSpringFast ? 0.26 : 0.32,
+                          damping: pageSpringFast ? 0.9 : 0.86,
+                          dt: CGFloat(dt))
+        if abs(pageShift - target) < 0.5, abs(pageVelocity) < 1 {
+            pageShift = target
+            pageVelocity = 0
+            pageTarget = nil
+            pageDidLand()
+        }
+    }
+
+    private func pageDidLand() {
+        if pageShift == 0 { dropCompanion() }
+    }
+
+    private func dropCompanion() {
+        companion?.removeFromSuperview()
+        companion = nil
+        companionSide = 0
+        controller.setScopePreview([])
+    }
+
+    /// Back to a single page at rest (activation, deactivation, reduce motion).
+    private func resetPage() {
+        scopeSwipeActive = false
+        pageTarget = nil
+        pageVelocity = 0
+        pageShift = 0
+        scopeCommitDeadline = 0
+        dropCompanion()
+        primary.isUserInteractionEnabled = true
+    }
+
+    /// Beyond one page the drag stiffens instead of tearing away.
+    private static func rubberBanded(_ shift: CGFloat, limit: CGFloat) -> CGFloat {
+        guard abs(shift) > limit else { return shift }
+        let over = (abs(shift) - limit) / limit
+        return (shift < 0 ? -1 : 1) * limit * (1 + 0.08 * tanh(over * 4))
     }
 }
 

--- a/rootshell/UI/Tabs/TabsModel.swift
+++ b/rootshell/UI/Tabs/TabsModel.swift
@@ -1636,29 +1636,48 @@ final class TabsModel {
         preferredTabID(in: section.tabIDs, scope: .project(section.id))
     }
 
-    /// Preferred tab of the scope `offset` steps from the active one,
-    /// wrapping: user groups in sidebar order, or non-empty project sections.
-    /// nil in flat mode or when there is only one scope.
-    func firstTabIDInNeighborScope(offset: Int) -> UUID? {
+    /// A group / project section as the exposé and scope navigation see it.
+    nonisolated struct ScopeInfo {
+        let key: ScopeKey
+        let title: String?
+        /// Navigable members (hidden tmux windows excluded), in scope order:
+        /// exactly `orderProjection.navigationTabIDs` once this scope is active.
+        let tabIDs: [UUID]
+    }
+
+    /// The scope `offset` steps from the active one, wrapping: user groups
+    /// in sidebar order, or project sections; scopes with no navigable tab
+    /// (hidden-only tmux groups) are skipped. nil in flat mode or when there
+    /// is only one scope.
+    func neighborScope(offset: Int) -> ScopeInfo? {
         let projection = orderProjection
-        let scopes: [(tabIDs: [UUID], key: ScopeKey)]
+        let scopes: [ScopeInfo]
         let activeIndex: Int?
         switch projection.mode {
         case .flat:
             return nil
         case .userGrouped:
-            let groups = orderedGroups
-            scopes = groups.map { ($0.tabIDs, .group($0.id)) }
-            activeIndex = groups.firstIndex { $0.id == activeGroupID }
+            let visible = Set(groupingSnapshot().visibleTabs.map(\.id))
+            scopes = orderedGroups.compactMap { group in
+                let ids = group.tabIDs.filter(visible.contains)
+                return ids.isEmpty ? nil : ScopeInfo(key: .group(group.id), title: group.title, tabIDs: ids)
+            }
+            activeIndex = activeGroupID.flatMap { id in scopes.firstIndex { $0.key == .group(id) } }
         case .projectGrouped:
-            let sections = projection.projectSections.filter { !$0.tabIDs.isEmpty }
-            scopes = sections.map { ($0.tabIDs, .project($0.id)) }
-            activeIndex = sections.firstIndex { $0.id == projection.activeProjectID }
+            scopes = projection.projectSections
+                .filter { !$0.tabIDs.isEmpty }
+                .map { ScopeInfo(key: .project($0.id), title: $0.title, tabIDs: $0.tabIDs) }
+            activeIndex = projection.activeProjectID.flatMap { id in scopes.firstIndex { $0.key == .project(id) } }
         }
         guard scopes.count > 1, let activeIndex else { return nil }
         let count = scopes.count
-        let target = scopes[((activeIndex + offset) % count + count) % count]
-        return preferredTabID(in: target.tabIDs, scope: target.key)
+        return scopes[((activeIndex + offset) % count + count) % count]
+    }
+
+    /// Preferred tab of the neighbor scope (see `neighborScope(offset:)`).
+    func firstTabIDInNeighborScope(offset: Int) -> UUID? {
+        guard let scope = neighborScope(offset: offset) else { return nil }
+        return preferredTabID(in: scope.tabIDs, scope: scope.key)
     }
 
     var availableGroups: [TabGroup] {


### PR DESCRIPTION
Swiping left/right while presented now drags the current group's grid and the neighbor group's grid (own header, live mirrors) in side by side, springing to commit or cancel on release; ⌘⌥[ ] gets the same full-page slide. The tray is extracted into TabExposeTrayView so the overlay can hold two pages. Neighbor/outgoing tabs stay un-occluded while on screen, the scope transition is published only with the scope-changed announce, and hidden-only tmux groups are skipped when navigating.