### PR TITLE
Revert stale GCKeyboard masking

### DIFF
--- a/rootshell/UI/Keyboard/KeyboardTracker.swift
+++ b/rootshell/UI/Keyboard/KeyboardTracker.swift
@@ -30,13 +30,6 @@ class KeyboardTracker {
     @MainActor
     private(set) var isHardwareKeyboard: Bool = false
 
-    /// Set when UIKit presents a full software keyboard while GCKeyboard still
-    /// claims a hardware keyboard (stale gamecontrollerd state, e.g. after
-    /// iPhone Mirroring). Cleared by a real GCKeyboard connect/disconnect or
-    /// the first real key event. Masks `isHardwareKeyboard` while set.
-    @MainActor
-    private var hardwareKeyboardClaimContradicted = false
-
     /// True if the on-screen (software) keyboard is currently visible
     @MainActor
     private(set) var isSoftwareKeyboardVisible: Bool = false
@@ -349,8 +342,6 @@ class KeyboardTracker {
     @MainActor
     @objc private func hardwareKeyboardDidConnect(_ notification: Notification) {
         Ghostty.logger.debug("KeyboardTracker: GCKeyboard connected")
-        // A real connect event supersedes the stale-claim heuristic.
-        hardwareKeyboardClaimContradicted = false
         updateHardwareKeyboardState(true)
         setupKeyboardInputHandler()
     }
@@ -358,20 +349,7 @@ class KeyboardTracker {
     @MainActor
     @objc private func hardwareKeyboardDidDisconnect(_ notification: Notification) {
         Ghostty.logger.debug("KeyboardTracker: GCKeyboard disconnected")
-        hardwareKeyboardClaimContradicted = false
         updateHardwareKeyboardState(false)
-    }
-
-    /// A real key event proves the GCKeyboard is not a phantom: lift the
-    /// contradiction mask. Phantom (stale) keyboards never deliver key events.
-    @MainActor
-    private func hardwareKeyEventObserved() {
-        guard hardwareKeyboardClaimContradicted else { return }
-        hardwareKeyboardClaimContradicted = false
-        Ghostty.logger.debug("KeyboardTracker: Hardware key event observed, clearing stale-claim mask")
-        #if !os(visionOS)
-        updateHardwareKeyboardState(GCKeyboard.coalesced != nil)
-        #endif
     }
 
     #if targetEnvironment(macCatalyst)
@@ -660,9 +638,6 @@ class KeyboardTracker {
         }
 
         keyboardInput.keyChangedHandler = { [weak self] _, key, keyCode, pressed in
-            Task { @MainActor in
-                self?.hardwareKeyEventObserved()
-            }
             // Detect modifier key changes to refresh link detection
             // (e.g., Cmd+hover should highlight links without requiring mouse movement)
             let isModifierKey = keyCode == .leftGUI || keyCode == .rightGUI ||
@@ -1194,36 +1169,17 @@ class KeyboardTracker {
         // On iOS/iPadOS, GCKeyboard handles detection - we just track the frame here
         // Double-check GCKeyboard state in case notifications were missed
         let gcKeyboardConnected = GCKeyboard.coalesced != nil
-        // Previous GCKeyboard claim: hardware true implies connected, and the
-        // mask is only ever set while connected.
-        let gcKeyboardWasConnected = isHardwareKeyboard || hardwareKeyboardClaimContradicted
-        if !gcKeyboardConnected {
-            hardwareKeyboardClaimContradicted = false
-        }
-        // UIKit never presents a full software keyboard with a real hardware
-        // keyboard attached; if it does while GCKeyboard claims one, the claim
-        // is stale (system-level, survives app relaunch). Mask it until a real
-        // key event or connect/disconnect proves otherwise.
-        if gcKeyboardConnected,
-           visibleHeight > Self.softwareKeyboardHeightThreshold,
-           !hardwareKeyboardClaimContradicted {
-            hardwareKeyboardClaimContradicted = true
-            Ghostty.logger.debug("KeyboardTracker: Software keyboard shown while GCKeyboard claims hardware - masking stale claim")
-        }
-        let effectiveHardware = gcKeyboardConnected && !hardwareKeyboardClaimContradicted
-        if effectiveHardware != isHardwareKeyboard {
-            Ghostty.logger.debug("KeyboardTracker: GCKeyboard state sync - was \(self.isHardwareKeyboard), now \(effectiveHardware) (gc=\(gcKeyboardConnected), contradicted=\(self.hardwareKeyboardClaimContradicted))")
-            updateHardwareKeyboardState(effectiveHardware)
-        }
-        // Reinstall key handler if keyboard reconnected - the old handler was on
-        // a different instance. Done even while masked: the handler is what
-        // observes the real key event that lifts the mask.
-        if gcKeyboardConnected && !gcKeyboardWasConnected {
-            setupKeyboardInputHandler()
+        if gcKeyboardConnected != isHardwareKeyboard {
+            Ghostty.logger.debug("KeyboardTracker: GCKeyboard state sync - was \(self.isHardwareKeyboard), now \(gcKeyboardConnected)")
+            updateHardwareKeyboardState(gcKeyboardConnected)
+            // Reinstall key handler if keyboard reconnected - the old handler was on a different instance
+            if gcKeyboardConnected {
+                setupKeyboardInputHandler()
+            }
         }
         #endif
 
-        Ghostty.logger.debug("KeyboardTracker: Frame updated, height=\(keyboardFrameEnd.height), isHardware=\(self.isHardwareKeyboard), contradicted=\(self.hardwareKeyboardClaimContradicted)")
+        Ghostty.logger.debug("KeyboardTracker: Frame updated, height=\(keyboardFrameEnd.height), isHardware=\(self.isHardwareKeyboard)")
     }
 
     @MainActor


### PR DESCRIPTION
Keep hardware attachment and software keyboard visibility independent. A software keyboard can legitimately appear while a Bluetooth keyboard remains connected, as with the Clicks Power Keyboard, so treating that state as a stale GCKeyboard claim caused the software keyboard to close after MagSafe removal.