### PR TITLE
Retire the SSH auth banner card once authentication ends

### DIFF
--- a/rootshell/Features/LocalShell/LocalShellSession+EmbeddedSessions.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+EmbeddedSessions.swift
@@ -355,6 +355,22 @@ extension LocalShellSession {
         displayPrompt()
     }
 
+    /// Runs `teardown` — which nils the embedded session, clearing the card via
+    /// its didSet — while preserving the auth banner that explains the failure.
+    /// Tailscale-style rejection reasons arrive as banners immediately before
+    /// the failure, so the card is the only surface holding the explanation.
+    /// Restored on a countdown so it does not strand the local shell prompt.
+    private func preservingAuthBannerCard(
+        from provider: SSHAuthBannerCardProviding?,
+        teardown: () -> Void
+    ) {
+        let banner = provider?.authBannerCardState ?? authBannerCardModel.current
+        teardown()
+        guard let banner else { return }
+        authBannerCardModel.relay(banner)
+        authBannerCardModel.scheduleAutoDismiss()
+    }
+
     /// Attempt to fall back to a password prompt after auth failure.
     private func attemptPasswordFallback<Config>(
         error: Error,
@@ -569,19 +585,11 @@ extension LocalShellSession {
         // Also guard if we're already in password prompt mode (fallback already happened)
         if case .passwordPrompt = sessionMode { return }
 
-        // Preserve the auth-banner card across teardown: Tailscale-style
-        // rejection reasons arrive as auth banners immediately before the
-        // failure, and stop() plus the session-property didSet would erase
-        // the only copy. Restored below; replaced when the next connection
-        // attempt starts (its stream replays nil) or the shell tears down.
-        let failureBanner = (embeddedSSHSession as? SSHAuthBannerCardProviding)?
-            .authBannerCardState ?? authBannerCardModel.current
-
-        embeddedSSHSession?.stop()
-        embeddedSSHSession = nil
-        activeEmbeddedSSHConfig = nil
-
-        if let failureBanner { authBannerCardModel.relay(failureBanner) }
+        preservingAuthBannerCard(from: embeddedSSHSession as? SSHAuthBannerCardProviding) {
+            embeddedSSHSession?.stop()
+            embeddedSSHSession = nil
+            activeEmbeddedSSHConfig = nil
+        }
 
         // Check if this is an auth failure we can retry with password
         // Only offer password fallback if:
@@ -1814,16 +1822,12 @@ extension LocalShellSession {
         // Also guard if we're already in password prompt mode (fallback already happened)
         if case .moshPasswordPrompt = sessionMode { return }
 
-        // Preserve the auth-banner card across teardown (see handleSSHSessionError).
-        let failureBanner = embeddedMoshSession?.authBannerCardState
-            ?? authBannerCardModel.current
-
-        embeddedMoshSession?.stop()
-        embeddedMoshSession = nil
-        activeEmbeddedMoshConfig = nil
-        NotificationCenter.default.post(name: .ghosttyEmbeddedMoshSessionDidChange, object: self)
-
-        if let failureBanner { authBannerCardModel.relay(failureBanner) }
+        preservingAuthBannerCard(from: embeddedMoshSession) {
+            embeddedMoshSession?.stop()
+            embeddedMoshSession = nil
+            activeEmbeddedMoshConfig = nil
+            NotificationCenter.default.post(name: .ghosttyEmbeddedMoshSessionDidChange, object: self)
+        }
 
         // Check if this is an auth failure we can retry with password
         if attemptPasswordFallback(
@@ -2143,16 +2147,12 @@ extension LocalShellSession {
         // the restored scrollback with no failure UI.
         onEmbeddedTrzszFailedBeforeRunning?()
 
-        // Preserve the auth-banner card across teardown (see handleSSHSessionError).
-        let failureBanner = embeddedTrzszSession?.authBannerCardState
-            ?? authBannerCardModel.current
-
-        embeddedTrzszSession?.stop()
-        embeddedTrzszSession = nil
-        activeEmbeddedTrzszConfig = nil
-        NotificationCenter.default.post(name: .ghosttyEmbeddedTrzszSessionDidChange, object: self)
-
-        if let failureBanner { authBannerCardModel.relay(failureBanner) }
+        preservingAuthBannerCard(from: embeddedTrzszSession) {
+            embeddedTrzszSession?.stop()
+            embeddedTrzszSession = nil
+            activeEmbeddedTrzszConfig = nil
+            NotificationCenter.default.post(name: .ghosttyEmbeddedTrzszSessionDidChange, object: self)
+        }
 
         // Check if this is an auth failure we can retry with password
         if attemptPasswordFallback(

--- a/rootshell/Features/LocalShell/LocalShellSession.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession.swift
@@ -138,13 +138,17 @@ final class LocalShellSession: TerminalSession, EmbeddedConnectionConfigProvidin
     let authBannerCardModel = SSHAuthBannerCardModel()
     private var authBannerCardForwardingTask: Task<Void, Never>?
 
+    /// The embedded session whose card state this one currently mirrors.
+    var currentAuthBannerProvider: SSHAuthBannerCardProviding? {
+        (embeddedSSHSession as? SSHAuthBannerCardProviding)
+            ?? (embeddedMoshSession as SSHAuthBannerCardProviding?)
+            ?? (embeddedTrzszSession as SSHAuthBannerCardProviding?)
+    }
+
     private func updateAuthBannerCardForwarding() {
         authBannerCardForwardingTask?.cancel()
         authBannerCardForwardingTask = nil
-        let provider = (embeddedSSHSession as? SSHAuthBannerCardProviding)
-            ?? (embeddedMoshSession as SSHAuthBannerCardProviding?)
-            ?? (embeddedTrzszSession as SSHAuthBannerCardProviding?)
-        guard let provider else {
+        guard let provider = currentAuthBannerProvider else {
             authBannerCardModel.clear()
             return
         }
@@ -1720,12 +1724,12 @@ final class LocalShellSession: TerminalSession, EmbeddedConnectionConfigProvidin
 // MARK: - Auth banner card
 
 extension LocalShellSession: SSHAuthBannerCardProviding {
-    var authBannerCardState: SSHAuthBannerCardState? {
-        authBannerCardModel.current
-    }
-
-    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
-        authBannerCardModel.states()
+    /// Overrides the default to also retire the embedded session's own copy —
+    /// otherwise a still-authenticating session would replay the dismissed
+    /// banner to the next subscriber.
+    func dismissAuthBannerCard() {
+        authBannerCardModel.clear()
+        currentAuthBannerProvider?.dismissAuthBannerCard()
     }
 }
 

--- a/rootshell/Features/Mosh/Session/MoshSession.swift
+++ b/rootshell/Features/Mosh/Session/MoshSession.swift
@@ -133,9 +133,15 @@ final class MoshSession: TerminalSession {
             // Tailscale SSH sends its rejection reason as an auth banner
             // immediately before disconnecting, so on bootstrap-auth failure
             // the card is the only surface holding the explanation and must
-            // outlive the failure.
-            if case .disconnected = state {
+            // outlive the failure. It outlives it on a countdown, not forever,
+            // which is what a standalone (non-embedded) session relies on.
+            switch state {
+            case .disconnected:
                 authBannerCardModel.clear()
+            case .failed:
+                authBannerCardModel.scheduleAutoDismiss()
+            default:
+                break
             }
             onStateChange?(state)
         }
@@ -2145,12 +2151,4 @@ extension MoshSession {
 
 // MARK: - Auth banner card
 
-extension MoshSession: SSHAuthBannerCardProviding {
-    var authBannerCardState: SSHAuthBannerCardState? {
-        authBannerCardModel.current
-    }
-
-    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
-        authBannerCardModel.states()
-    }
-}
+extension MoshSession: SSHAuthBannerCardProviding {}

--- a/rootshell/Features/SSH/Session/CitadelSSHSession.swift
+++ b/rootshell/Features/SSH/Session/CitadelSSHSession.swift
@@ -211,13 +211,21 @@ final class CitadelSSHSession: SSHTerminalSession {
 
     /// Transitions to a new state and notifies the callback
     private func transition(to state: SSHSessionState) {
-        // Deliberately NO card clear on .failed/.disconnected: Tailscale SSH
-        // sends its rejection reason ("tailnet policy does not permit you to
-        // SSH as user …", "tailscale: access denied") as an auth banner
-        // immediately before disconnecting, so on auth failure the card is the
-        // only surface holding the explanation and must outlive the failure.
-        // Teardown still clears it: stop() clears the buffer (firing .reset),
-        // and a replacement session's observer replays nil on re-subscribe.
+        // Deliberately NO immediate card clear on .failed/.disconnected:
+        // Tailscale SSH sends its rejection reason ("tailnet policy does not
+        // permit you to SSH as user …", "tailscale: access denied") as an auth
+        // banner immediately before disconnecting, so on auth failure the card
+        // is the only surface holding the explanation and must outlive the
+        // failure. It outlives it on a countdown, not forever — a pane left
+        // open on a failed connect would otherwise keep the card indefinitely.
+        // Teardown still clears it sooner: stop() clears the buffer (firing
+        // .reset), and a replacement session's observer replays nil.
+        switch state {
+        case .failed, .disconnected:
+            authBannerCardModel.scheduleAutoDismiss()
+        default:
+            break
+        }
         onStateChange?(state)
     }
 
@@ -2126,12 +2134,4 @@ final class CitadelHostKeyValidatorDelegate: NIOSSHClientServerAuthenticationDel
 
 // MARK: - Auth banner card
 
-extension CitadelSSHSession: SSHAuthBannerCardProviding {
-    var authBannerCardState: SSHAuthBannerCardState? {
-        authBannerCardModel.current
-    }
-
-    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
-        authBannerCardModel.states()
-    }
-}
+extension CitadelSSHSession: SSHAuthBannerCardProviding {}

--- a/rootshell/Features/SSH/Session/SSHAuthBannerCard.swift
+++ b/rootshell/Features/SSH/Session/SSHAuthBannerCard.swift
@@ -38,6 +38,10 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
 
 /// Sessions that can surface live auth banners for the pane card.
 @MainActor protocol SSHAuthBannerCardProviding: AnyObject {
+    /// The session's accumulator. Every conformer stores one under this name,
+    /// which is what lets the defaults below cover all of them.
+    var authBannerCardModel: SSHAuthBannerCardModel { get }
+
     var authBannerCardState: SSHAuthBannerCardState? { get }
 
     /// A fresh stream of card-state updates. Each call registers an
@@ -46,11 +50,31 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
     /// the keyboard-interactive sheet) still see pending banners. The stream
     /// ends when the consuming task is cancelled or the session deallocates.
     func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?>
+
+    /// Retires the card at the user's request. A requirement rather than an
+    /// extension-only member so LocalShellSession's forwarding override still
+    /// dispatches when called through the existential.
+    func dismissAuthBannerCard()
+}
+
+extension SSHAuthBannerCardProviding {
+    var authBannerCardState: SSHAuthBannerCardState? { authBannerCardModel.current }
+
+    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
+        authBannerCardModel.states()
+    }
+
+    func dismissAuthBannerCard() { authBannerCardModel.clear() }
 }
 
 /// Main-actor accumulator each session owns: bridges `AuthBannerBuffer`
 /// events (fired on the NIO event loop) to replaying per-subscriber streams.
 @MainActor final class SSHAuthBannerCardModel {
+    /// How long a banner outlives the end of the auth phase. Long enough to
+    /// read a rejection reason and tap Open/Copy on a URL it carries.
+    /// Nonisolated so it can serve as a default argument below.
+    nonisolated static let autoDismissSeconds: Double = 15
+
     private(set) var current: SSHAuthBannerCardState?
 
     private typealias BannerEvent = (hostLabel: String, event: AuthBannerBuffer.Event)
@@ -66,6 +90,21 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
     private var subscribers: [UUID: AsyncStream<SSHAuthBannerCardState?>.Continuation] = [:]
     private var nextID = 0
 
+    /// Countdown that retires a banner left over from a finished auth phase.
+    private var autoDismissTask: Task<Void, Never>?
+
+    /// Latched once the auth phase ends with the card still up, and only
+    /// unlatched by `clear()`. Banner events reach this actor over an async
+    /// channel while the terminal-state transition that arms the countdown is
+    /// a direct main-actor call, so a banner sent immediately before the
+    /// disconnect — exactly the Tailscale rejection-reason case — routinely
+    /// lands *after* the arm. Without the latch that late broadcast would
+    /// cancel the countdown and never restart it, stranding the card forever.
+    private var autoDismissArmed = false
+
+    /// Interval the latch re-arms with, so a late banner gets a full read.
+    private var autoDismissInterval = SSHAuthBannerCardModel.autoDismissSeconds
+
     init() {
         (eventChannel, eventContinuation) = AsyncStream.makeStream(of: BannerEvent.self)
         pumpTask = Task { [weak self, eventChannel] in
@@ -78,6 +117,7 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
 
     deinit {
         pumpTask?.cancel()
+        autoDismissTask?.cancel()
         eventContinuation.finish()
         for continuation in subscribers.values {
             continuation.finish()
@@ -110,9 +150,34 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
         return stream
     }
 
-    /// Removes the card immediately (auth ended, session torn down/replaced).
+    /// Removes the card immediately (auth ended, session torn down/replaced,
+    /// or the user dismissed it).
     func clear() {
+        // Explicit unlatch for the case where there is no current state, so
+        // broadcast (which also unlatches on nil) never runs.
+        autoDismissArmed = false
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         if current != nil { broadcast(nil) }
+    }
+
+    /// Arms the countdown that retires the current banner once the auth phase
+    /// has ended. Safe to call before the banner itself arrives: the latch
+    /// re-arms on every later broadcast until something clears the card.
+    func scheduleAutoDismiss(after seconds: Double = SSHAuthBannerCardModel.autoDismissSeconds) {
+        autoDismissArmed = true
+        autoDismissInterval = seconds
+        restartAutoDismissTimer()
+    }
+
+    private func restartAutoDismissTimer() {
+        let seconds = autoDismissInterval
+        autoDismissTask?.cancel()
+        autoDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.clear()
+        }
     }
 
     /// Directly relays an already-built state. Used by forwarding wrappers
@@ -142,9 +207,20 @@ struct SSHAuthBannerCardState: Equatable, Sendable {
     }
 
     private func broadcast(_ state: SSHAuthBannerCardState?) {
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
+        // A cleared card ends the armed phase. Without this, a retry that
+        // replays nil (password fallback re-subscribing to a fresh session)
+        // would leave the latch set and put a live auth banner from the *next*
+        // attempt on a countdown.
+        if state == nil { autoDismissArmed = false }
         current = state
         for continuation in subscribers.values {
             continuation.yield(state)
         }
+        // New content restarts the clock rather than cancelling it: while
+        // authenticating nothing is armed, so this is a no-op; after the auth
+        // phase ended it gives a late-arriving banner a full read window.
+        if autoDismissArmed, state != nil { restartAutoDismissTimer() }
     }
 }

--- a/rootshell/Features/SSH/Views/SSHAuthBannerCardHostView.swift
+++ b/rootshell/Features/SSH/Views/SSHAuthBannerCardHostView.swift
@@ -39,6 +39,11 @@ final class SSHAuthBannerCardHostView: UIView {
         ClipboardHistoryManager.shared.record(url.absoluteString, source: .copyLink)
     }
 
+    /// Retires the card in the owning session's model. The host hides itself
+    /// first for immediacy; this makes the dismissal stick across pane
+    /// switches and window transfers, which replay from that model.
+    var onDismissRequested: () -> Void = {}
+
     // MARK: - Initialization
 
     override init(frame: CGRect) {
@@ -98,6 +103,14 @@ final class SSHAuthBannerCardHostView: UIView {
                 if let current = self.currentState {
                     self.showCard(with: current)
                 }
+            },
+            onDismiss: { [weak self] in
+                guard let self else { return }
+                // Hide locally first so the animation is immediate; the model
+                // clear that follows re-broadcasts nil, which update(state:)
+                // no-ops on via its state == currentState early return.
+                self.update(state: nil)
+                self.onDismissRequested()
             },
             onOpenURL: { [weak self] url in self?.onOpenURL(url) },
             onCopyURL: { [weak self] url in self?.onCopyURL(url) }

--- a/rootshell/Features/SSH/Views/SSHAuthBannerCardView.swift
+++ b/rootshell/Features/SSH/Views/SSHAuthBannerCardView.swift
@@ -12,12 +12,13 @@ import SwiftUI
 import UIKit
 
 /// The auth-banner card shown over a terminal pane during SSH authentication.
-/// Collapsible to a pill; never permanently dismissible while auth is pending
-/// (the state going nil removes it).
+/// Collapsible to a pill and closable in either form; a banner arriving after
+/// a dismissal brings the card back, so nothing is lost permanently.
 struct SSHAuthBannerCardView: View {
     let state: SSHAuthBannerCardState
     let isCollapsed: Bool
     let onToggleCollapse: () -> Void
+    let onDismiss: () -> Void
     let onOpenURL: (URL) -> Void
     let onCopyURL: (URL) -> Void
 
@@ -40,36 +41,58 @@ struct SSHAuthBannerCardView: View {
 
     // MARK: - Collapsed pill
 
+    /// Two buttons rather than a row-wide one: a collapsed pill has to be
+    /// closable in a single tap, or dismissing means expanding first.
     private var collapsedPill: some View {
-        Button(action: onToggleCollapse) {
-            HStack(spacing: 6) {
-                Image(systemName: "text.bubble")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                Text("Server message", comment: "Collapsed SSH auth banner pill")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.primary)
-                if state.items.count > 1 {
-                    Text(verbatim: "\(state.items.count)")
-                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+        HStack(spacing: 6) {
+            Button(action: onToggleCollapse) {
+                HStack(spacing: 6) {
+                    Image(systemName: "text.bubble")
+                        .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(.secondary.opacity(0.15))
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                    Text("Server message", comment: "Collapsed SSH auth banner pill")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.primary)
+                    if state.items.count > 1 {
+                        Text(verbatim: "\(state.items.count)")
+                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(.secondary.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
                 }
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text(
+                "Server message during SSH authentication. Tap to expand.",
+                comment: "Accessibility label for collapsed SSH auth banner pill"
+            ))
+
+            dismissButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .bannerBackground()
+    }
+
+    private var dismissButton: some View {
+        Button(action: onDismiss) {
+            Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(4)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .bannerBackground()
         .accessibilityLabel(Text(
-            "Server message during SSH authentication. Tap to expand.",
-            comment: "Accessibility label for collapsed SSH auth banner pill"
+            "Dismiss server message",
+            comment: "Accessibility label for SSH auth banner dismiss button"
         ))
     }
 
@@ -102,6 +125,8 @@ struct SSHAuthBannerCardView: View {
                     "Collapse server message",
                     comment: "Accessibility label for SSH auth banner collapse button"
                 ))
+
+                dismissButton
             }
 
             SSHAuthBannerContentView(

--- a/rootshell/Features/TSSH/Session/TSSHSession.swift
+++ b/rootshell/Features/TSSH/Session/TSSHSession.swift
@@ -152,10 +152,13 @@ final class TrzszSession: TerminalSession {
             // Tailscale SSH sends its rejection reason as an auth banner
             // immediately before disconnecting, so on bootstrap-auth failure
             // the card is the only surface holding the explanation and must
-            // outlive the failure.
+            // outlive the failure. It outlives it on a countdown, not forever,
+            // which is what a standalone (non-embedded) session relies on.
             switch state {
             case .disconnected, .serverShutdown:
                 authBannerCardModel.clear()
+            case .failed:
+                authBannerCardModel.scheduleAutoDismiss()
             default:
                 break
             }
@@ -2161,12 +2164,4 @@ extension TrzszSession {
 
 // MARK: - Auth banner card
 
-extension TrzszSession: SSHAuthBannerCardProviding {
-    var authBannerCardState: SSHAuthBannerCardState? {
-        authBannerCardModel.current
-    }
-
-    func authBannerCardStates() -> AsyncStream<SSHAuthBannerCardState?> {
-        authBannerCardModel.states()
-    }
-}
+extension TrzszSession: SSHAuthBannerCardProviding {}

--- a/rootshell/UI/Terminal/TerminalScrollView.swift
+++ b/rootshell/UI/Terminal/TerminalScrollView.swift
@@ -1157,6 +1157,13 @@ extension Ghostty {
             let hostView = SSHAuthBannerCardHostView()
             hostView.translatesAutoresizingMaskIntoConstraints = false
 
+            // Resolved lazily: the pane's session is replaced on adoption and
+            // on reconnect, so capturing the provider here would go stale.
+            hostView.onDismissRequested = { [weak self] in
+                (self?.terminalView.session as? SSHAuthBannerCardProviding)?
+                    .dismissAuthBannerCard()
+            }
+
             if let parentVC = findViewController() {
                 hostView.setParentViewController(parentVC)
             }


### PR DESCRIPTION
Add a close button and a 15-second countdown so a failed ssh from the local shell no longer strands the card over the prompt. Arm the same countdown on standalone Mosh and tsshd auth failures, and collapse the duplicated provider conformances and failure-teardown blocks.