### PR TITLE
Feature/multiplexer expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ brew install --cask rootshell
 - **Grouped Tabs** - Automatic tab sections for local shells, remote hosts (collapsed by subnet), networks, Kubernetes and cloud sessions, and tmux gateways. Group by project or remote host with manual overrides
 - **Move Tabs Between Windows** - Drag a tab or a whole group into another window without disconnecting (iPad and Mac)
 - **Interactive Tab Swipe** - Swipe between tabs with a live carousel; both terminals stay live during the gesture
-- **Tab Exposé** - See live previews of every tab in the current group or project, including Screen Sharing sessions. Pull down from the tab bar or press ⌘⇧A to open it; swipe sideways or use ⌘⌥[ and ⌘⌥] to page between scopes, each of which remembers its last-selected tab
+- **Tab Exposé** - See live previews of every tab in the current group or project, including Screen Sharing sessions. Pull down from the tab bar or press ⌘⇧A to open it; swipe sideways or use ⌘⌥[ and ⌘⌥] to page between scopes, each of which remembers its last-selected tab. On a tab attached to herdr, tmux, or zellij it opens on that session's own tabs with live, colored previews of every pane; pick one to switch the session, or page over to your app tabs
 - **Pixel-Smooth Scrollback** - Sub-cell scroll offsets with ProMotion 120 Hz rendering on iPhone
 - **HDR Brightness Boost** - Drive the terminal brighter on HDR-capable displays via a floating HUD (⌘⌃B), clamped to display headroom
 - **Visor** - Quake-style drop-down terminal summoned by a global hotkey. Slides from any screen edge, joins all Spaces, and floats above other apps (macOS Standalone)

--- a/rootshell/Core/Helper/HelperConnection.swift
+++ b/rootshell/Core/Helper/HelperConnection.swift
@@ -242,15 +242,19 @@ public class HelperConnection {
     ///   - workingDirectory: Working directory (nil = use default)
     ///   - timeout: Maximum execution time (default 30s)
     /// - Returns: Final result with exit code and timing
+    ///   - maxOutputBytes: Stop after this many bytes; the result is a prefix
+    ///     marked `truncated`, and the helper stops streaming. Unbounded when nil.
     public func executeCommand(
         command: String,
         workingDirectory: String? = nil,
-        timeout: TimeInterval = 30
+        timeout: TimeInterval = 30,
+        maxOutputBytes: Int? = nil
     ) async throws -> ExecuteCommandResult {
         try await socketConnection.executeCommand(
             command: command,
             cwd: workingDirectory,
             timeout: timeout,
+            maxOutputBytes: maxOutputBytes,
             onOutput: { _, _ in }  // No-op output handler
         )
     }

--- a/rootshell/Core/Helper/SocketHelperConnection.swift
+++ b/rootshell/Core/Helper/SocketHelperConnection.swift
@@ -83,6 +83,7 @@ class SocketHelperConnection {
         command: String,
         cwd: String?,
         timeout: TimeInterval?,
+        maxOutputBytes: Int? = nil,
         onOutput: @escaping (Data, Bool) -> Void
     ) async throws -> ExecuteCommandResult {
         guard let socketPath = AppGroupHelper.commandSocketPath else {
@@ -102,6 +103,7 @@ class SocketHelperConnection {
                     let result = try Self.executeCommandSync(
                         socketPath: socketPath,
                         request: request,
+                        maxOutputBytes: maxOutputBytes,
                         onOutput: onOutput
                     )
                     continuation.resume(returning: result)
@@ -116,6 +118,7 @@ class SocketHelperConnection {
     private static func executeCommandSync(
         socketPath: String,
         request: ExecuteCommandRequest,
+        maxOutputBytes: Int? = nil,
         onOutput: @escaping (Data, Bool) -> Void
     ) throws -> ExecuteCommandResult {
         // Create socket
@@ -190,6 +193,19 @@ class SocketHelperConnection {
             let chunk = try JSONDecoder().decode(ExecuteOutputChunk.self, from: payload)
             accumulatedOutput.append(chunk.data)
             onOutput(chunk.data, chunk.isStderr)
+
+            // A caller that set a cap gets a prefix and nothing more: returning
+            // here closes the socket (`defer`), so the helper stops streaming
+            // instead of filling memory on both sides of the IPC.
+            if let maxOutputBytes, accumulatedOutput.count >= maxOutputBytes {
+                return ExecuteCommandResult(
+                    output: String(decoding: accumulatedOutput.prefix(maxOutputBytes), as: UTF8.self),
+                    exitCode: 0,
+                    timedOut: false,
+                    duration: 0,
+                    truncated: true
+                )
+            }
         }
     }
 

--- a/rootshell/Core/Helper/SocketProtocol.swift
+++ b/rootshell/Core/Helper/SocketProtocol.swift
@@ -105,6 +105,9 @@ public struct ExecuteCommandResult: Sendable {
     public let exitCode: Int32
     public let timedOut: Bool
     public let duration: TimeInterval
+    /// The caller's `maxOutputBytes` was reached and the rest was dropped:
+    /// `output` is a prefix, and `exitCode`/`duration` are unknown.
+    public var truncated: Bool = false
 }
 
 // MARK: - Wire Protocol

--- a/rootshell/Core/Terminal/TerminalPTY.swift
+++ b/rootshell/Core/Terminal/TerminalPTY.swift
@@ -248,6 +248,10 @@ public final class TerminalPTY {
         print("📎 Setting external PTY master FD: \(fd), setting ownsFds = false")
         self.masterFd = fd
         self.ownsFds = false
+        // The helper opened the pair, but the master fd names its slave here too.
+        if let name = ptsname(fd) {
+            slavePath = String(cString: name)
+        }
         print("📎 ownsFds is now: \(self.ownsFds)")
     }
 

--- a/rootshell/Features/Multiplexer/Expose/HerdrExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/HerdrExposeAdapter.swift
@@ -1,0 +1,127 @@
+//
+//  HerdrExposeAdapter.swift
+//  rootshell
+//
+//  herdr: `herdr api snapshot` for the tree + layouts, `pane read --raw` for
+//  colored content. PaneInfo.revision only moves on title/metadata changes,
+//  not output, so frames are hashed client-side like tmux's.
+//
+
+import Foundation
+
+nonisolated struct HerdrExposeAdapter: MultiplexerExposeAdapter {
+    let type = MultiplexerType.herdr
+
+    /// `hx` runs herdr against the bound session; nil means the default one.
+    private func prelude(session: String?) -> String {
+        let env = session.map { "HERDR_SESSION=\(MuxScript.dq($0)) " } ?? ""
+        return "hx() { \(env)herdr \"$@\" 2>/dev/null; }; command -v herdr >/dev/null 2>&1 || echo \(MuxScript.dq(MuxScript.unsupportedMarker))"
+    }
+
+    func resolveSessionScript(nonce: String) -> String {
+        // The default session is always addressable; nothing to resolve.
+        MuxScript.wrap("echo \(MuxScript.dq(MuxScript.topology(nonce))); echo default", nonce: nonce)
+    }
+
+    func tickScript(session: String?, request: MuxTickRequest, nonce: String) -> String {
+        var body = prelude(session: session)
+        body += "; echo \(MuxScript.dq(MuxScript.topology(nonce))); hx api snapshot; echo"
+        for paneID in request.fetch {
+            body += "; \(MuxScript.paneMarker(nonce: nonce, id: paneID))"
+            body += "; hx pane read \(MuxScript.dq(paneID)) --source visible --raw; echo"
+        }
+        return MuxScript.wrap(body, nonce: nonce)
+    }
+
+    func parseTick(output: String, nonce: String) -> MuxTickResult? {
+        let sections = MuxScript.sections(of: output, nonce: nonce)
+        guard sections.found, !sections.unsupported else { return nil }
+        guard let root = MuxScript.json(sections.topology) as? [String: Any] else { return nil }
+        // CLI prints the whole response: {"id":..,"result":{"type":"session_snapshot","snapshot":{..}}}
+        let snap = root.mxDict("result")?.mxDict("snapshot") ?? root.mxDict("snapshot") ?? root
+        guard snap["tabs"] != nil else { return nil }
+
+        let focusedWorkspace = snap.mxString("focused_workspace_id")
+        let focusedTab = snap.mxString("focused_tab_id")
+        let layoutsByTab = Dictionary(
+            snap.mxArray("layouts").compactMap { layout -> (String, [String: Any])? in
+                guard let id = layout.mxString("tab_id") else { return nil }
+                return (id, layout)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let panesByID = Dictionary(
+            snap.mxArray("panes").compactMap { pane -> (String, [String: Any])? in
+                guard let id = pane.mxString("pane_id") else { return nil }
+                return (id, pane)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        // Focused workspace only; `number` is herdr's display order.
+        let infos = snap.mxArray("tabs")
+            .filter { focusedWorkspace == nil || $0.mxString("workspace_id") == focusedWorkspace }
+            .enumerated()
+            .sorted { ($0.element.mxInt("number") ?? Int.max, $0.offset) < ($1.element.mxInt("number") ?? Int.max, $1.offset) }
+            .map(\.element)
+        var tabs: [MuxTab] = []
+        for info in infos {
+            guard let tabID = info.mxString("tab_id") else { continue }
+            let layout = layoutsByTab[tabID]
+            let area = layout?.mxDict("area")
+            let cols = area?.mxInt("width") ?? 0
+            let rows = area?.mxInt("height") ?? 0
+            let originX = area?.mxInt("x") ?? 0
+            let originY = area?.mxInt("y") ?? 0
+            var panes: [MuxPane] = []
+            for entry in layout?.mxArray("panes") ?? [] {
+                guard let paneID = entry.mxString("pane_id"), let rect = entry.mxDict("rect") else { continue }
+                let pane = panesByID[paneID]
+                panes.append(MuxPane(
+                    id: paneID,
+                    rect: MuxCellRect(
+                        x: (rect.mxInt("x") ?? 0) - originX,
+                        y: (rect.mxInt("y") ?? 0) - originY,
+                        width: rect.mxInt("width") ?? 0,
+                        height: rect.mxInt("height") ?? 0
+                    ),
+                    isActive: entry.mxBool("focused"),
+                    isPreviewable: true,
+                    title: pane?.mxString("title") ?? pane?.mxString("terminal_title_stripped")
+                ))
+            }
+            let status = info.mxString("agent_status")?.lowercased()
+            let badge = status.flatMap { ["idle", "unknown", "none", ""].contains($0) ? nil : $0 }
+            tabs.append(MuxTab(
+                id: tabID,
+                index: tabs.count,
+                title: info.mxString("label") ?? tabID,
+                isActive: info.mxBool("focused") || tabID == focusedTab,
+                cols: cols,
+                rows: rows,
+                panes: panes,
+                badge: badge
+            ))
+        }
+        var frames: [String: MuxPaneFrame] = [:]
+        for section in sections.panes {
+            frames[section.id] = MuxPaneFrame(
+                ansi: section.body,
+                cursor: nil,
+                revision: MuxExposeIdentity.contentRevision(section.body)
+            )
+        }
+        let activeTab = focusedTab ?? tabs.first(where: \.isActive)?.id
+        return MuxTickResult(
+            snapshot: MuxExposeSnapshot(tabs: tabs, activeTabID: activeTab),
+            frames: frames,
+            unchanged: [],
+            truncated: sections.truncated
+        )
+    }
+
+    func focusScript(session: String?, tabID: String) -> String {
+        let nonce = "focus"
+        return MuxScript.wrap("\(prelude(session: session)); hx tab focus \(MuxScript.dq(tabID))", nonce: nonce)
+    }
+}

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeAdapter.swift
@@ -1,0 +1,172 @@
+//
+//  MultiplexerExposeAdapter.swift
+//  rootshell
+//
+//  One adapter per raw multiplexer turns "what do I need this tick" into a
+//  single shell script and its output back into a MuxTickResult. Scripts run
+//  through RemoteExecProbe on the pane's own connection, so they must be
+//  self-contained, nonce-framed, and exit 0 (Citadel discards the output of
+//  a failing command).
+//
+
+import Foundation
+
+nonisolated struct MuxTickRequest: Sendable {
+    /// Panes whose content the script should capture, in priority order.
+    var fetch: [String] = []
+    /// Last revision the client holds per pane; adapters with a server-side
+    /// counter skip captures that would return the same content.
+    var knownRevisions: [String: String] = [:]
+}
+
+nonisolated protocol MultiplexerExposeAdapter: Sendable {
+    var type: MultiplexerType { get }
+
+    /// Prints the only running session's name, or nothing. Used when the
+    /// binding has no session name.
+    func resolveSessionScript(nonce: String) -> String
+
+    func tickScript(session: String?, request: MuxTickRequest, nonce: String) -> String
+
+    /// nil when the multiplexer is unusable here (too old, no session).
+    func parseTick(output: String, nonce: String) -> MuxTickResult?
+
+    func focusScript(session: String?, tabID: String) -> String
+}
+
+/// Marker framing and shell quoting shared by the adapters.
+nonisolated enum MuxScript {
+    static let unsupportedMarker = "::MX_UNSUPPORTED::"
+    static let sameMarker = "::MX_SAME::"
+
+    static func begin(_ nonce: String) -> String { "::MX_B_\(nonce)::" }
+    static func end(_ nonce: String) -> String { "::MX_E_\(nonce)::" }
+    static func topology(_ nonce: String) -> String { "::MX_T_\(nonce)::" }
+    static func panePrefix(_ nonce: String) -> String { "::MX_P_\(nonce):" }
+
+    /// `sh -lc` wrapper with the app's PATH prefix; `body` uses double quotes only.
+    static func wrap(_ body: String, nonce: String) -> String {
+        let script = "echo \"\(begin(nonce))\"; \(body); echo \"\(end(nonce))\"; exit 0"
+        let escaped = script.replacingOccurrences(of: "'", with: "'\\''")
+        return "sh -lc '\(SSHConfig.remoteExecPathPrefix)\(escaped)'"
+    }
+
+    /// A double-quoted shell word.
+    static func dq(_ value: String) -> String {
+        var out = "\""
+        for ch in value {
+            switch ch {
+            case "\"", "\\", "$", "`": out.append("\\"); out.append(ch)
+            default: out.append(ch)
+            }
+        }
+        out.append("\"")
+        return out
+    }
+
+    /// `printf` line announcing a pane section: `::MX_P_n:<id>:<extra>::`.
+    static func paneMarker(nonce: String, id: String, extra: String = "") -> String {
+        "echo \(dq("\(panePrefix(nonce))\(id):\(extra)::"))"
+    }
+
+    struct Sections {
+        var topology = ""
+        /// In script order: pane id, marker extra, body (trailing newline removed).
+        var panes: [(id: String, extra: String, body: String)] = []
+        var truncated = false
+        var unsupported = false
+        var found = false
+    }
+
+    static func sections(of output: String, nonce: String) -> Sections {
+        var result = Sections()
+        guard let start = output.range(of: begin(nonce)) else { return result }
+        result.found = true
+        var body = output[start.upperBound...]
+        if let stop = body.range(of: end(nonce)) {
+            body = body[..<stop.lowerBound]
+        } else {
+            result.truncated = true
+        }
+        let topologyMarker = topology(nonce)
+        // Only the prelude may declare unsupported. Captured pane content is
+        // arbitrary text — a pane showing this source, a log, or a diff would
+        // otherwise fail every tick by quoting our own markers.
+        let preludeEnd = body.range(of: topologyMarker)?.lowerBound ?? body.endIndex
+        if body[..<preludeEnd].contains(unsupportedMarker) {
+            result.unsupported = true
+            return result
+        }
+        let prefix = panePrefix(nonce)
+        var current: (id: String, extra: String)? = nil
+        var buffer = ""
+        var sawTopology = false
+
+        func flush() {
+            // Each section's `echo` terminator adds one newline we don't want.
+            var text = buffer
+            if text.hasSuffix("\n") { text.removeLast() }
+            if let current {
+                result.panes.append((current.id, current.extra, text))
+            } else if sawTopology {
+                result.topology = text
+            }
+            buffer = ""
+        }
+
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            if line.hasPrefix(topologyMarker) {
+                flush()
+                current = nil
+                sawTopology = true
+                continue
+            }
+            if line.hasPrefix(prefix), line.hasSuffix("::") {
+                flush()
+                let inner = line.dropFirst(prefix.count).dropLast(2)
+                // Pane ids may contain colons (herdr `w1:p1`); `extra` never does.
+                if let colon = inner.lastIndex(of: ":") {
+                    current = (String(inner[..<colon]), String(inner[inner.index(after: colon)...]))
+                } else {
+                    current = (String(inner), "")
+                }
+                continue
+            }
+            buffer.append(contentsOf: line)
+            buffer.append("\n")
+        }
+        // The body ends with the newline before the end marker (or nothing on truncation).
+        if buffer.hasSuffix("\n") { buffer.removeLast() }
+        flush()
+        // A truncated last pane is unusable; keep the topology and the rest.
+        if result.truncated, !result.panes.isEmpty { result.panes.removeLast() }
+        return result
+    }
+
+    static func json(_ text: String) -> Any? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+}
+
+/// Lenient JSONSerialization readers for the adapters.
+nonisolated extension Dictionary where Key == String, Value == Any {
+    func mxInt(_ key: String) -> Int? {
+        if let n = self[key] as? NSNumber { return n.intValue }
+        if let s = self[key] as? String { return Int(s) }
+        return nil
+    }
+    func mxBool(_ key: String) -> Bool {
+        (self[key] as? NSNumber)?.boolValue ?? (self[key] as? Bool) ?? false
+    }
+    func mxString(_ key: String) -> String? {
+        self[key] as? String
+    }
+    func mxDict(_ key: String) -> [String: Any]? {
+        self[key] as? [String: Any]
+    }
+    func mxArray(_ key: String) -> [[String: Any]] {
+        (self[key] as? [Any])?.compactMap { $0 as? [String: Any] } ?? []
+    }
+}

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -188,6 +188,8 @@ final class MultiplexerExposeFeed {
         hints = [:]
         lastHints = [:]
         lastFetchAt = [:]
+        // Pane ids are the previous session's; the tray reports afresh.
+        visiblePanes = []
         tickCount = 0
         failures = 0
         fetchCap = Int.max
@@ -432,6 +434,12 @@ final class MultiplexerExposeFeed {
                 return nil
             }
             let binding: Ghostty.TerminalView.RawMultiplexerBinding
+            // A multiplexer's own server process carries the same binary
+            // name as its client and is a descendant of the client that
+            // spawned it, so it would otherwise pass every test below and
+            // double the candidates for a single session.
+            if words.contains("--server") || words.dropFirst().first == "server" { continue }
+
             switch command {
             case "tmux":
                 // Control mode is the app's own projection, not a raw attach.
@@ -468,13 +476,18 @@ final class MultiplexerExposeFeed {
             found.append((binding, pid, processTTY))
         }
         guard !found.isEmpty else { return nil }
-        if found.count == 1 || tty != nil { return found[0].binding }
-        // Several attached elsewhere on the host: keep the one sharing this
-        // connection's sshd. Never guess — a wrong session is worse than none.
+        // On the pane's own tty there is nothing to disambiguate, and a lone
+        // client on the host is the one this pane is attached to.
+        if tty != nil || found.count == 1 { return found[0].binding }
+        // Otherwise keep only what shares this connection's sshd, and give up
+        // unless exactly one does: showing another session's tabs, or focusing
+        // one, is worse than falling back to the app tabs.
         let related = found.filter { !(chains[$0.pid] ?? []).intersection(ownChain).isEmpty }
-        if related.count == 1 { return related[0].binding }
-        Self.logger.debug("detect: \(found.count) candidates, \(related.count) on this connection")
-        return related.first?.binding
+        guard related.count == 1 else {
+            Self.logger.debug("detect: \(found.count) candidates, \(related.count) on this connection; not guessing")
+            return nil
+        }
+        return related[0].binding
     }
 
     /// Lines grouped by the `::MX_PID:<pid>::` markers the script emits.

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -1,0 +1,712 @@
+//
+//  MultiplexerExposeFeed.swift
+//  rootshell
+//
+//  Keeps a raw multiplexer session's tabs and pane frames fresh while the
+//  exposé is up, over one-shot exec commands on the pane's own connection
+//  (RemoteExecProbe). Ticks are strictly serialized and adaptively paced:
+//  fast while frames change, backing off when the session is quiet, with
+//  visible panes fetched first and the rest on a slower cadence.
+//
+
+import Foundation
+import GhosttyKit
+import QuartzCore
+import os
+
+@MainActor
+final class MultiplexerExposeFeed {
+    enum State: Equatable {
+        case idle
+        /// No binding yet: working out which multiplexer a local pane is
+        /// attached to (hand-started `tmux` / `herdr` / `zellij`).
+        case detecting
+        case loading
+        case live
+        /// The multiplexer is unusable here (too old, no session): show app tabs.
+        case unsupported
+        /// Ticks keep failing; the last frames stay up with a hint.
+        case failed
+    }
+
+    private static let logger = Logger(subsystem: "com.rootshell", category: "MuxExpose")
+
+    private(set) var state: State = .idle
+    private(set) var snapshot: MuxExposeSnapshot?
+    private(set) var type: MultiplexerType?
+    private(set) var sessionName: String?
+    /// Fired on state or topology changes (frames are polled by the views).
+    var onChange: (() -> Void)?
+
+    private(set) weak var terminal: Ghostty.TerminalView?
+    var ghosttyApp: Ghostty.App? { terminal?.ghosttyApp }
+
+    private var adapter: (any MultiplexerExposeAdapter)?
+    private var frames: [String: MuxPaneFrame] = [:]
+    private var loop: Task<Void, Never>?
+    private var sleeper: Task<Void, Never>?
+    private var stopTask: Task<Void, Never>?
+    private var visiblePanes: Set<String> = []
+    private var lastFetchAt: [String: CFTimeInterval] = [:]
+    private var hints: [String: String] = [:]
+    /// Bumped by every teardown; identifies the run that owns the feed.
+    private var generation: UInt64 = 0
+    private var tickCount = 0
+    private var interval: TimeInterval = baseInterval
+    private var failures = 0
+    private var fetchCap = Int.max
+    private var cleanTicks = 0
+    /// Last presentation, reusable for an instant repaint on quick re-entry.
+    private var cache: (owner: ObjectIdentifier, session: String, snapshot: MuxExposeSnapshot,
+                        frames: [String: MuxPaneFrame], at: CFTimeInterval)?
+
+    private static let baseInterval: TimeInterval = 0.4
+    private static let maxInterval: TimeInterval = 2.5
+    private static let hiddenPaneEveryNthTick = 3
+    private static let staleAfter: CFTimeInterval = 2
+    private static let cacheLifetime: CFTimeInterval = 60
+    private static let maxPreviewPanesPerTab = 6
+    private static let responseCap = 512 * 1024
+    private static let tickTimeout: TimeInterval = 5
+    /// Retries while another probe holds the transport's single slot.
+    private static let focusAttempts = 12
+    /// Consecutive failures before the tray says the session is unavailable.
+    private static let failuresBeforeUnavailable = 3
+
+    // MARK: - Identity
+
+    var sessionKey: String { "\(type?.rawValue ?? "-"):\(sessionName ?? "")" }
+
+    var tabs: [MuxTab] { snapshot?.tabs ?? [] }
+
+    var tabUUIDs: [UUID] { tabs.map { $0.uuid(sessionKey: sessionKey) } }
+
+    var activeTabUUID: UUID? {
+        snapshot?.activeTabID.flatMap { id in snapshot?.tab(withID: id) }?.uuid(sessionKey: sessionKey)
+    }
+
+    func tab(uuid: UUID) -> MuxTab? {
+        tabs.first { $0.uuid(sessionKey: sessionKey) == uuid }
+    }
+
+    func frame(for paneID: String) -> MuxPaneFrame? { frames[paneID] }
+
+    var isServing: Bool { state == .loading || state == .live || state == .failed }
+
+    /// Short name for the tray header.
+    var title: String {
+        let mux: String
+        switch type {
+        case .tmux: mux = "tmux"
+        case .zellij: mux = "zellij"
+        case .herdr: mux = "herdr"
+        case nil: mux = ""
+        }
+        if let sessionName, !sessionName.isEmpty { return "\(mux) · \(sessionName)" }
+        return mux
+    }
+
+    // MARK: - Eligibility
+
+    /// The multiplexer this terminal is attached to, once it owns the screen.
+    /// `hasOwnedAltScreen` is maintained by agent attention's scans, which
+    /// may not have run yet; the surface's own alt-screen state stands in.
+    static func binding(for terminal: Ghostty.TerminalView?) -> Ghostty.TerminalView.RawMultiplexerBinding? {
+        guard let terminal, let binding = terminal.rawMultiplexer, RemoteExecProbe.canProbe(terminal),
+              binding.hasOwnedAltScreen || isAlternateScreenActive(terminal) else { return nil }
+        return binding
+    }
+
+    /// A pane with no binding whose screen is taken by something: ask the
+    /// host what is running there. The alternate screen is the gate — every
+    /// multiplexer holds it for its whole attach — so an ordinary shell is
+    /// never probed just because the exposé opened.
+    static func canDetect(_ terminal: Ghostty.TerminalView) -> Bool {
+        RemoteExecProbe.canProbe(terminal) && isAlternateScreenActive(terminal)
+    }
+
+    private static func isAlternateScreenActive(_ terminal: Ghostty.TerminalView) -> Bool {
+        guard let surface = terminal.surface else { return false }
+        var altActive = false
+        guard ghostty_surface_try_is_alternate_active(surface, &altActive) else { return false }
+        return altActive
+    }
+
+    /// `ttys004` for a local macOS pane; nil for anything remote.
+    private static func localTTY(_ terminal: Ghostty.TerminalView) -> String? {
+        #if targetEnvironment(macCatalyst)
+        guard terminal.connectionConfig.underlyingSSHConfig == nil,
+              let path = terminal.session?.pty.slavePath, path.hasPrefix("/dev/") else { return nil }
+        return String(path.dropFirst("/dev/".count))
+        #else
+        return nil
+        #endif
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begin (or resume) serving `terminal`'s session. Returns false when the
+    /// terminal has no usable multiplexer binding and nothing to detect.
+    @discardableResult
+    func start(terminal: Ghostty.TerminalView) -> Bool {
+        let binding = Self.binding(for: terminal)
+        guard binding != nil || Self.canDetect(terminal) else {
+            Self.logger.debug("not a multiplexer pane: bound=\(terminal.rawMultiplexer != nil) probe=\(RemoteExecProbe.canProbe(terminal)) alt=\(Self.isAlternateScreenActive(terminal))")
+            return false
+        }
+        Self.logger.debug("start: \(binding?.type.rawValue ?? "detect", privacy: .public)")
+        stopTask?.cancel()
+        stopTask = nil
+        if loop != nil, self.terminal === terminal,
+           binding == nil || (type == binding?.type && sessionName == binding?.sessionName) {
+            // Re-opened inside the stop grace: the running feed still serves
+            // this session, so its tabs and frames are already current.
+            Self.logger.debug("reusing live feed: \(self.tabs.count) tabs, \(self.frames.count) frames")
+            return true
+        }
+        teardownLoop()
+
+        self.terminal = terminal
+        resetSession()
+        if let binding {
+            configure(binding)
+        } else {
+            type = nil
+            sessionName = nil
+            adapter = nil
+            state = .detecting
+        }
+        onChange?()
+        let generation = self.generation
+        loop = Task { [weak self] in await self?.run(generation: generation) }
+        return true
+    }
+
+    private func resetSession() {
+        frames = [:]
+        snapshot = nil
+        hints = [:]
+        lastHints = [:]
+        lastFetchAt = [:]
+        tickCount = 0
+        failures = 0
+        fetchCap = Int.max
+        cleanTicks = 0
+        interval = Self.baseInterval
+    }
+
+    private func configure(_ binding: Ghostty.TerminalView.RawMultiplexerBinding) {
+        type = binding.type
+        sessionName = binding.sessionName
+        switch binding.type {
+        case .herdr: adapter = HerdrExposeAdapter()
+        case .tmux: adapter = TmuxExposeAdapter()
+        case .zellij: adapter = ZellijExposeAdapter()
+        }
+        // Quick re-entry: repaint the last picture while the first tick runs.
+        if let terminal, let cache, cache.owner == ObjectIdentifier(terminal),
+           cache.session == "\(binding.type.rawValue):\(binding.sessionName ?? "")",
+           CACurrentMediaTime() - cache.at < Self.cacheLifetime {
+            snapshot = cache.snapshot
+            frames = cache.frames
+            state = .live
+        } else {
+            state = .loading
+        }
+    }
+
+    /// Stop after `grace` seconds unless restarted; the picture is cached.
+    func stop(grace: TimeInterval) {
+        guard loop != nil else { return }
+        stopTask?.cancel()
+        stopTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(grace))
+            guard !Task.isCancelled else { return }
+            self?.stopNow()
+        }
+    }
+
+    func stopNow() {
+        stopTask?.cancel()
+        stopTask = nil
+        if let terminal, let snapshot, let type {
+            cache = (ObjectIdentifier(terminal), "\(type.rawValue):\(sessionName ?? "")", snapshot, frames, CACurrentMediaTime())
+        }
+        teardownLoop()
+        state = .idle
+        snapshot = nil
+        frames = [:]
+        onChange?()
+    }
+
+    private func teardownLoop() {
+        // Invalidates any work already in flight for the previous run.
+        generation &+= 1
+        loop?.cancel()
+        loop = nil
+        sleeper?.cancel()
+        sleeper = nil
+    }
+
+    /// Panes on screen right now; they are fetched first and every tick.
+    func setVisiblePanes(_ ids: Set<String>) {
+        guard ids != visiblePanes else { return }
+        let newcomers = ids.subtracting(visiblePanes)
+        visiblePanes = ids
+        // A cell that scrolled in with no picture yet should not wait a whole interval.
+        if newcomers.contains(where: { frames[$0] == nil }) { wake() }
+    }
+
+    /// Switch the multiplexer to `tabID`. Independent of the tick loop so it
+    /// still runs while the exposé is already dismissing.
+    func focus(tabID: String) {
+        guard let terminal, let adapter else { return }
+        let script = adapter.focusScript(session: sessionName, tabID: tabID)
+        Task { [weak self] in
+            for attempt in 0..<Self.focusAttempts {
+                do {
+                    _ = try await RemoteExecProbe.run(script, on: terminal, timeout: 4, maxResponseBytes: 4096)
+                    self?.wake()
+                    return
+                } catch RemoteExecProbe.ProbeError.busy {
+                    // tssh: one probe at a time; the tick in flight is short.
+                    try? await Task.sleep(for: .milliseconds(250))
+                    if attempt == Self.focusAttempts - 1 { Self.logger.warning("focus abandoned: transport busy") }
+                } catch {
+                    Self.logger.warning("focus failed: \(error.localizedDescription)")
+                    return
+                }
+            }
+        }
+    }
+
+    private func wake() {
+        sleeper?.cancel()
+    }
+
+    // MARK: - Loop
+
+    /// Work started by a superseded run must never touch the feed again: its
+    /// answers describe a session this feed no longer serves, and its
+    /// teardown would stop the run that replaced it. Every await in the loop
+    /// is followed by this check before anything shared is read or written.
+    private func isCurrent(_ generation: UInt64) -> Bool {
+        generation == self.generation && !Task.isCancelled
+    }
+
+    private func giveUp(_ reason: String) {
+        Self.logger.debug("\(reason, privacy: .public)")
+        state = .unsupported
+        loop = nil
+        onChange?()
+    }
+
+    private func run(generation: UInt64) async {
+        if adapter == nil {
+            let detected = await detect()
+            guard isCurrent(generation) else {
+                Self.logger.debug("detect superseded by a newer run")
+                return
+            }
+            guard let detected else {
+                giveUp("detect: nothing attached on this tty")
+                return
+            }
+            Self.logger.debug("detected \(detected.type.rawValue, privacy: .public), session named=\(detected.sessionName != nil)")
+            configure(detected)
+            onChange?()
+        }
+        if sessionName == nil {
+            let resolved = await resolveSession()
+            guard isCurrent(generation) else { return }
+            guard let resolved else {
+                giveUp("resolveSession: no single session")
+                return
+            }
+            sessionName = resolved
+            onChange?()
+        }
+        while true {
+            let outcome = await tick(generation: generation)
+            guard isCurrent(generation) else { return }
+            switch outcome {
+            case .cancelled:
+                return
+            case .unsupported:
+                giveUp("tick: session no longer usable")
+                return
+            case .immediate:
+                continue
+            case .wait(let seconds):
+                let sleeper = Task<Void, Never> { try? await Task.sleep(for: .seconds(seconds)) }
+                self.sleeper = sleeper
+                await sleeper.value
+                guard isCurrent(generation) else { return }
+            }
+        }
+    }
+
+    /// Which multiplexer is attached in this pane, and to which session.
+    ///
+    /// A pane the app did not start has no binding to read, so the host is
+    /// asked. Locally the pane's own tty names the process directly. Over a
+    /// connection there is no tty to name, so candidates are found by
+    /// command and narrowed by ancestry: this exec channel and the pane's
+    /// shell descend from the same sshd/tsshd, exactly as the project probe
+    /// identifies a pane's process. (id=mux-expose-detect)
+    private func detect() async -> Ghostty.TerminalView.RawMultiplexerBinding? {
+        guard let terminal else { return nil }
+        let tty = Self.localTTY(terminal)
+        let nonce = Self.nonce()
+        // Candidate multiplexer clients: on this tty locally, ours anywhere
+        // otherwise. `grep` only narrows; the command name is checked here.
+        let candidates = tty.map { "ps -t \(MuxScript.dq($0)) -o pid=,ppid=,tty=,args= 2>/dev/null" }
+            ?? "ps -xo pid=,ppid=,tty=,args= 2>/dev/null | grep -E \"tmux|herdr|zellij\" | grep -v grep"
+        let candidatePIDs = "$(\(candidates) | awk \"{print \\$1}\")"
+        // Ancestor walks, so a candidate can be tied to THIS connection.
+        let walk = "_q=$1; while [ -n \"$_q\" ] && [ \"$_q\" -gt 1 ] 2>/dev/null;"
+            + " do echo \"$_q\"; _q=$(ps -o ppid= -p \"$_q\" 2>/dev/null | tr -d \" \"); done"
+
+        var body = "_walk() { \(walk); }"
+        body += "; echo \(MuxScript.dq(MuxScript.topology(nonce)))"
+        body += "; \(candidates)"
+        body += "; echo \"::MX_SELF::\"; _walk $$"
+        body += "; echo \"::MX_CHAINS::\"; for _p in \(candidatePIDs); do echo \"::MX_PID:$_p::\"; _walk \"$_p\"; done"
+        body += "; echo \"::MX_CLIENTS::\""
+        body += "; tmux list-clients -F \"#{client_tty}\(TmuxExposeAdapter.separator)#{session_name}\" 2>/dev/null"
+        // A name is often absent from argv: `zellij` alone joins a
+        // server-named session and herdr's default is implicit. The client
+        // holds its session's socket open, which names it. Two ways to read
+        // that: `lsof` (macOS), and /proc — where a connected client socket
+        // has no path of its own, so its inode is matched in /proc/net/unix.
+        // Linux servers routinely lack lsof, and a client socket there
+        // usually has no name in it even when installed.
+        body += "; echo \"::MX_SOCKETS::\"; for _p in \(candidatePIDs); do"
+        body += " echo \"::MX_PID:$_p::\"; lsof -a -p \"$_p\" -U -F n 2>/dev/null;"
+        body += " if [ -d \"/proc/$_p/fd\" ]; then"
+        body += " for _i in $(ls -l \"/proc/$_p/fd\" 2>/dev/null"
+        body += " | sed -n \"s/.*socket:\\[\\([0-9][0-9]*\\)\\].*/\\1/p\"); do"
+        body += " awk -v i=\"$_i\" \"\\$7==i && \\$8 ~ /^\\// {print \\$8}\" /proc/net/unix 2>/dev/null;"
+        body += " done; fi; done"
+        // Exported by the user's own shell where it was used (`HERDR_SESSION=x herdr`).
+        body += "; echo \"::MX_ENV::\"; for _p in \(candidatePIDs); do echo \"::MX_PID:$_p::\";"
+        body += " [ -r \"/proc/$_p/environ\" ] && tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
+        body += " | grep -E \"^(HERDR_SESSION|HERDR_SOCKET_PATH|ZELLIJ_SESSION_NAME)=\"; done"
+        // zellij's server runs as `zellij --server <sock dir>/<session>`.
+        body += "; echo \"::MX_SERVERS::\"; ps -xo pid=,ppid=,args= 2>/dev/null | grep -- \"--server\" | grep -v grep"
+
+        guard let output = try? await RemoteExecProbe.run(
+            MuxScript.wrap(body, nonce: nonce), on: terminal,
+            timeout: Self.tickTimeout, maxResponseBytes: 64 * 1024
+        ) else {
+            Self.logger.debug("detect: probe failed")
+            return nil
+        }
+        let parts = ["::MX_SELF::", "::MX_CHAINS::", "::MX_CLIENTS::", "::MX_SOCKETS::", "::MX_ENV::", "::MX_SERVERS::"]
+            .reduce([MuxScript.sections(of: output, nonce: nonce).topology]) { sections, marker in
+                sections.flatMap { $0.components(separatedBy: marker) }
+            }
+        guard parts.count >= 7 else {
+            Self.logger.debug("detect: unexpected reply, \(output.count) bytes")
+            return nil
+        }
+        let ownChain = Set(parts[1].split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) })
+        let chains = Self.pidSections(parts[2]).mapValues { Set($0) }
+        let clients = parts[3]
+        let sockets = Self.pidSections(parts[4])
+        let environments = Self.pidSections(parts[5]).mapValues { Self.environment($0) }
+        let servers = parts[6]
+
+        var found: [(binding: Ghostty.TerminalView.RawMultiplexerBinding, pid: String, tty: String)] = []
+        for line in parts[0].split(separator: "\n") {
+            var words = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+            guard words.count >= 4 else { continue }
+            let pid = words.removeFirst()
+            words.removeFirst()                       // ppid
+            let processTTY = words.removeFirst()
+            guard let command = words.first?.split(separator: "/").last.map(String.init) else { continue }
+            func value(after flags: [String]) -> String? {
+                for (index, word) in words.enumerated() where flags.contains(word) && index + 1 < words.count {
+                    return words[index + 1]
+                }
+                return nil
+            }
+            let binding: Ghostty.TerminalView.RawMultiplexerBinding
+            switch command {
+            case "tmux":
+                // Control mode is the app's own projection, not a raw attach.
+                if words.contains("-CC") { continue }
+                let wanted = "/dev/\(tty ?? processTTY)"
+                let session = clients.split(separator: "\n").lazy
+                    .map { $0.components(separatedBy: TmuxExposeAdapter.separator) }
+                    .first { $0.count == 2 && ($0[0] == wanted || $0[0].hasSuffix("/\(processTTY)")) }?[1]
+                binding = .init(type: .tmux, sessionName: session, hasOwnedAltScreen: true)
+            case "herdr":
+                let environment = environments[pid] ?? [:]
+                var session = value(after: ["--session", "-s"])
+                if session == nil, let index = words.firstIndex(of: "attach"), index > 0, index + 1 < words.count,
+                   words[index - 1] == "session" {
+                    session = words[index + 1]
+                }
+                session = session ?? environment["HERDR_SESSION"]
+                    ?? Self.herdrSession(in: sockets[pid] ?? [])
+                    ?? environment["HERDR_SOCKET_PATH"].flatMap { Self.herdrSession(in: [$0]) }
+                binding = .init(type: .herdr, sessionName: session ?? "default", hasOwnedAltScreen: true)
+            case "zellij":
+                var session = value(after: ["--session", "-s"])
+                if session == nil, let index = words.firstIndex(where: { $0 == "attach" || $0 == "a" }),
+                   index + 1 < words.count, !words[index + 1].hasPrefix("-") {
+                    session = words[index + 1]
+                }
+                session = session ?? (environments[pid] ?? [:])["ZELLIJ_SESSION_NAME"]
+                    ?? Self.zellijSession(in: sockets[pid] ?? [])
+                    ?? Self.zellijSession(servers: servers, clientPID: pid)
+                binding = .init(type: .zellij, sessionName: session, hasOwnedAltScreen: true)
+            default:
+                continue
+            }
+            found.append((binding, pid, processTTY))
+        }
+        guard !found.isEmpty else { return nil }
+        if found.count == 1 || tty != nil { return found[0].binding }
+        // Several attached elsewhere on the host: keep the one sharing this
+        // connection's sshd. Never guess — a wrong session is worse than none.
+        let related = found.filter { !(chains[$0.pid] ?? []).intersection(ownChain).isEmpty }
+        if related.count == 1 { return related[0].binding }
+        Self.logger.debug("detect: \(found.count) candidates, \(related.count) on this connection")
+        return related.first?.binding
+    }
+
+    /// Lines grouped by the `::MX_PID:<pid>::` markers the script emits.
+    /// `lsof -F` prefixes paths with `n`, which is stripped here.
+    private static func pidSections(_ text: String) -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        var pid: String?
+        for line in text.split(separator: "\n") {
+            if line.hasPrefix("::MX_PID:"), line.hasSuffix("::") {
+                pid = String(line.dropFirst("::MX_PID:".count).dropLast(2))
+            } else if let pid {
+                let value = line.hasPrefix("n") ? String(line.dropFirst()) : String(line)
+                let trimmed = value.trimmingCharacters(in: .whitespaces)
+                if !trimmed.isEmpty { result[pid, default: []].append(trimmed) }
+            }
+        }
+        return result
+    }
+
+    /// `NAME=value` lines into a dictionary; a value may contain `=`.
+    private static func environment(_ lines: [String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for line in lines {
+            guard let split = line.firstIndex(of: "="), split > line.startIndex else { continue }
+            let value = String(line[line.index(after: split)...])
+            guard !value.isEmpty else { continue }
+            result[String(line[..<split])] = value
+        }
+        return result
+    }
+
+    /// zellij's client socket is `<sock dir>/<session name>`.
+    private static func zellijSession(in paths: [String]) -> String? {
+        for path in paths where path.contains("zellij") {
+            let name = (path as NSString).lastPathComponent
+            guard !name.isEmpty, name != "web_server_bus", !name.hasPrefix("zellij") else { continue }
+            return name
+        }
+        return nil
+    }
+
+    /// zellij's server is `zellij --server <sock dir>/<session name>`, and
+    /// the client that created a session is its parent. With one server there
+    /// is no ambiguity; with several, only the client's own child answers
+    /// (attaching by name already carries the name in argv).
+    private static func zellijSession(servers: String, clientPID: String) -> String? {
+        var names: [(ppid: String, name: String)] = []
+        for line in servers.split(separator: "\n") {
+            let words = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+            guard words.count >= 4, words.contains("--server"),
+                  let index = words.firstIndex(of: "--server"), index + 1 < words.count,
+                  words[2].split(separator: "/").last.map(String.init)?.hasPrefix("zellij") == true else { continue }
+            let path = words[index + 1]
+            let name = (path as NSString).lastPathComponent
+            guard !name.isEmpty else { continue }
+            names.append((words[1], name))
+        }
+        if let own = names.first(where: { $0.ppid == clientPID }) { return own.name }
+        return names.count == 1 ? names[0].name : nil
+    }
+
+    /// herdr's client socket is `<config>/herdr-client.sock` for the default
+    /// session and `<config>/sessions/<name>/herdr-client.sock` for a named one.
+    private static func herdrSession(in paths: [String]) -> String? {
+        for path in paths where (path as NSString).lastPathComponent.hasPrefix("herdr") {
+            let directory = (path as NSString).deletingLastPathComponent
+            let parent = ((directory as NSString).deletingLastPathComponent as NSString).lastPathComponent
+            if parent == "sessions" {
+                return (directory as NSString).lastPathComponent
+            }
+            return "default"
+        }
+        return nil
+    }
+
+    /// The session name when the host runs exactly one; nil leaves the feed
+    /// unusable rather than guessing (the caller applies the result).
+    private func resolveSession() async -> String? {
+        guard let terminal, let adapter else { return nil }
+        let nonce = Self.nonce()
+        guard let output = try? await RemoteExecProbe.run(
+            adapter.resolveSessionScript(nonce: nonce), on: terminal, timeout: Self.tickTimeout, maxResponseBytes: 16 * 1024
+        ) else { return nil }
+        let names = MuxScript.sections(of: output, nonce: nonce).topology
+            .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        guard names.count == 1 else { return nil }
+        return names[0]
+    }
+
+    private enum Outcome {
+        /// This run was superseded while awaiting: touch nothing, just stop.
+        case cancelled
+        case unsupported
+        case immediate
+        case wait(TimeInterval)
+    }
+
+    private func tick(generation: UInt64) async -> Outcome {
+        guard let terminal, let adapter else { return .unsupported }
+        let now = CACurrentMediaTime()
+        let request = MuxTickRequest(fetch: fetchList(now: now), knownRevisions: frames.mapValues(\.revision))
+        let nonce = Self.nonce()
+        let script = adapter.tickScript(session: sessionName, request: request, nonce: nonce)
+        let output: String
+        do {
+            output = try await RemoteExecProbe.run(script, on: terminal, timeout: Self.tickTimeout, maxResponseBytes: Self.responseCap)
+        } catch RemoteExecProbe.ProbeError.busy {
+            return isCurrent(generation) ? .wait(0.3) : .cancelled
+        } catch {
+            guard isCurrent(generation) else { return .cancelled }
+            return failed("tick: \(error.localizedDescription)")
+        }
+        // The reply describes the session this run was started for; a newer
+        // run may already own the feed's frames and snapshot.
+        guard isCurrent(generation) else { return .cancelled }
+        guard let result = adapter.parseTick(output: output, nonce: nonce) else {
+            // Only the prelude's own verdict is final. Anything else (a
+            // half-written reply, a momentarily unavailable server) is a
+            // transient failure worth retrying, and never throws away a
+            // session that has already been serving.
+            if MuxScript.sections(of: output, nonce: nonce).unsupported {
+                Self.logger.debug("multiplexer reports unsupported")
+                return .unsupported
+            }
+            Self.logger.debug("tick: unparseable reply, \(output.count) bytes")
+            if snapshot == nil, failures >= 2 { return .unsupported }
+            return failed("tick: unparseable")
+        }
+        tickCount += 1
+        if tickCount == 1 {
+            Self.logger.debug("first tick: \(result.snapshot.tabs.count) tabs, \(result.snapshot.allPanes.count) panes")
+        }
+        failures = 0
+        hints.merge(result.changeHints) { _, new in new }
+        let fetched = Set(request.fetch)
+
+        var changed = false
+        for (id, frame) in result.frames {
+            // A capture of nothing at all is a failed read, not a blank
+            // screen (a cleared pane still returns its rows). Keeping the
+            // last picture beats painting an empty one that then sticks,
+            // since an unchanged revision would never be redrawn.
+            guard !frame.ansi.isEmpty else {
+                Self.logger.debug("empty capture for pane \(id); keeping last frame")
+                continue
+            }
+            if frames[id]?.revision != frame.revision { changed = true }
+            frames[id] = frame
+        }
+        for id in fetched { lastFetchAt[id] = now }
+        // Panes that vanished take their frames with them.
+        let live = Set(result.snapshot.allPanes.map(\.id))
+        frames = frames.filter { live.contains($0.key) }
+
+        let topologyChanged = result.snapshot != snapshot
+        snapshot = result.snapshot
+        let wasLoading = state != .live
+        state = .live
+        if topologyChanged || wasLoading { onChange?() }
+
+        if result.truncated {
+            fetchCap = max(1, min(fetchCap, max(request.fetch.count, 2)) / 2)
+            cleanTicks = 0
+            Self.logger.debug("reply truncated at \(Self.responseCap) bytes; fetching \(self.fetchCap) panes per tick")
+        } else {
+            cleanTicks += 1
+            if cleanTicks >= 5, fetchCap != Int.max {
+                fetchCap = fetchCap >= (Int.max / 2) ? Int.max : fetchCap * 2
+                cleanTicks = 0
+            }
+        }
+
+        // First topology lands with no frames: fetch the visible set right away.
+        if tickCount == 1 { return .immediate }
+        if changed {
+            interval = Self.baseInterval
+        } else {
+            interval = min(interval * 1.5, Self.maxInterval)
+        }
+        return .wait(interval)
+    }
+
+    private func failed(_ message: String) -> Outcome {
+        failures += 1
+        Self.logger.debug("\(message, privacy: .public) (failure \(self.failures))")
+        if failures >= Self.failuresBeforeUnavailable, state != .failed {
+            state = .failed
+            // The tray now says the session is unavailable: worth one line.
+            Self.logger.warning("multiplexer session stopped answering after \(self.failures) attempts")
+            onChange?()
+        }
+        return .wait(min(pow(2, Double(failures - 1)), 10))
+    }
+
+    /// Panes to capture this tick, active tab first, then visible, then the rest.
+    private func fetchList(now: CFTimeInterval) -> [String] {
+        guard let snapshot else { return [] }
+        var ordered: [(String, Int)] = []
+        for tab in snapshot.tabs {
+            // Over the cap only the active pane gets a picture.
+            var budget = Self.maxPreviewPanesPerTab
+            for pane in tab.panes where pane.isPreviewable {
+                if budget <= 0, !pane.isActive { continue }
+                budget -= 1
+                let visible = visiblePanes.contains(pane.id)
+                let rank = tab.id == snapshot.activeTabID ? 0 : (visible ? 1 : 2)
+                ordered.append((pane.id, rank))
+            }
+        }
+        var fetch: [String] = []
+        for (id, rank) in ordered.sorted(by: { $0.1 < $1.1 }) {
+            guard let last = lastFetchAt[id], frames[id] != nil else {
+                fetch.append(id)
+                continue
+            }
+            let hintChanged = hints[id] != nil && hints[id] != lastHints[id]
+            let stale = now - last >= Self.staleAfter
+            if rank < 2 {
+                if hintChanged || stale || hints[id] == nil { fetch.append(id) }
+            } else if hintChanged || (stale && tickCount % Self.hiddenPaneEveryNthTick == 0) {
+                fetch.append(id)
+            }
+        }
+        for id in fetch { lastHints[id] = hints[id] }
+        if fetch.count > fetchCap { fetch.removeLast(fetch.count - fetchCap) }
+        return fetch
+    }
+
+    /// Hint value each pane was last fetched under.
+    private var lastHints: [String: String] = [:]
+
+    private static func nonce() -> String {
+        String(UInt64.random(in: 0...UInt64.max), radix: 36)
+    }
+}

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeModel.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeModel.swift
@@ -1,0 +1,110 @@
+//
+//  MultiplexerExposeModel.swift
+//  rootshell
+//
+//  What the exposé shows for a raw multiplexer session (herdr, plain tmux,
+//  zellij): its tabs/windows, each with the cell geometry of its panes, and
+//  the latest colored frame of every pane. Multiplexer-neutral so the tray
+//  and preview views never learn which one they are looking at.
+//
+
+import CryptoKit
+import Foundation
+
+/// Pane geometry in terminal cells, relative to the tab's area.
+nonisolated struct MuxCellRect: Equatable, Hashable, Sendable {
+    var x: Int
+    var y: Int
+    var width: Int
+    var height: Int
+}
+
+nonisolated struct MuxPane: Equatable, Sendable {
+    /// The multiplexer's own stable id (`w1:p1`, `%3`, `terminal_7`).
+    let id: String
+    let rect: MuxCellRect
+    let isActive: Bool
+    /// False for panes whose content cannot be read (zellij plugins).
+    let isPreviewable: Bool
+    let title: String?
+}
+
+nonisolated struct MuxTab: Equatable, Sendable {
+    /// The multiplexer's own stable id (`w1:t1`, `@7`, zellij `tab_id`).
+    let id: String
+    /// 0-based display position.
+    let index: Int
+    let title: String
+    let isActive: Bool
+    /// Tab area in cells; pane rects live inside it.
+    let cols: Int
+    let rows: Int
+    let panes: [MuxPane]
+    /// Short trailing note for the caption (tmux flags, herdr agent status).
+    let badge: String?
+
+    /// Exposé cells are keyed by UUID; this one is stable per session + tab.
+    func uuid(sessionKey: String) -> UUID {
+        MuxExposeIdentity.uuid(for: "\(sessionKey)|\(id)")
+    }
+}
+
+nonisolated struct MuxCursor: Equatable, Sendable {
+    let x: Int
+    let y: Int
+    let visible: Bool
+}
+
+nonisolated struct MuxPaneFrame: Equatable, Sendable {
+    /// Colored screen text, `\n` between rows.
+    let ansi: String
+    let cursor: MuxCursor?
+    /// Changes whenever `ansi` does; equal revisions are skipped by the renderer.
+    let revision: String
+}
+
+nonisolated struct MuxExposeSnapshot: Equatable, Sendable {
+    let tabs: [MuxTab]
+    let activeTabID: String?
+
+    var allPanes: [MuxPane] { tabs.flatMap(\.panes) }
+
+    func tab(withID id: String) -> MuxTab? {
+        tabs.first { $0.id == id }
+    }
+}
+
+/// One tick's parse: fresh topology plus whichever frames the script fetched.
+nonisolated struct MuxTickResult: Sendable {
+    var snapshot: MuxExposeSnapshot
+    var frames: [String: MuxPaneFrame]
+    /// Panes the script reported unchanged (herdr revision match).
+    var unchanged: Set<String>
+    /// The end marker was missing: the response was cut by the byte cap.
+    var truncated: Bool
+    /// Cheap per-pane "probably changed" signals (tmux activity/cursor tuple);
+    /// a differing hint forces a fetch, an equal one only delays it.
+    var changeHints: [String: String] = [:]
+}
+
+nonisolated enum MuxExposeIdentity {
+    /// Deterministic UUID (v5-shaped) from a string key.
+    static func uuid(for key: String) -> UUID {
+        var bytes = Array(SHA256.hash(data: Data(key.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+                           bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]))
+    }
+
+    /// FNV-1a over the frame text: cheap content revision for multiplexers
+    /// without a server-side counter.
+    static func contentRevision(_ text: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        return String(hash, radix: 16)
+    }
+}

--- a/rootshell/Features/Multiplexer/Expose/TmuxExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/TmuxExposeAdapter.swift
@@ -1,0 +1,160 @@
+//
+//  TmuxExposeAdapter.swift
+//  rootshell
+//
+//  Plain tmux (not control mode): one `list-panes -s` row per pane gives the
+//  whole session's windows and geometry; `capture-pane -p -e -N` gives a
+//  pane's colored rows. tmux has no per-pane output counter the app can rely
+//  on, so the row's activity/history/cursor tuple is only a hint and the
+//  frame revision is a hash of the capture.
+//
+
+import Foundation
+
+nonisolated struct TmuxExposeAdapter: MultiplexerExposeAdapter {
+    let type = MultiplexerType.tmux
+
+    /// Printable separator: control characters don't survive every transport.
+    static let separator = "<|>"
+    /// window_name and pane_title last: free text that may itself contain the separator.
+    private static let fields = [
+        "window_id", "window_index", "window_active", "window_width", "window_height",
+        "window_activity", "window_raw_flags", "pane_id", "pane_active", "pane_left", "pane_top",
+        "pane_width", "pane_height", "history_size", "cursor_x", "cursor_y", "cursor_flag",
+        "window_name", "pane_title",
+    ]
+    private static let format = fields.map { "#{\($0)}" }.joined(separator: separator)
+
+    private func target(_ session: String?) -> String {
+        session.map { " -t \(MuxScript.dq("=\($0)"))" } ?? ""
+    }
+
+    func resolveSessionScript(nonce: String) -> String {
+        MuxScript.wrap(
+            "echo \(MuxScript.dq(MuxScript.topology(nonce))); tmux list-sessions -F \"#{session_name}\" 2>/dev/null",
+            nonce: nonce
+        )
+    }
+
+    func tickScript(session: String?, request: MuxTickRequest, nonce: String) -> String {
+        var body = "command -v tmux >/dev/null 2>&1 || echo \(MuxScript.dq(MuxScript.unsupportedMarker))"
+        body += "; echo \(MuxScript.dq(MuxScript.topology(nonce)))"
+        body += "; tmux list-panes -s\(target(session)) -F \(MuxScript.dq(Self.format)) 2>/dev/null"
+        for paneID in request.fetch {
+            let id = MuxScript.dq(paneID)
+            body += "; \(MuxScript.paneMarker(nonce: nonce, id: paneID))"
+            // -N (keep trailing spaces, 3.1+) so colored bars keep their width; older tmux falls back.
+            body += "; tmux capture-pane -p -e -N -t \(id) 2>/dev/null || tmux capture-pane -p -e -t \(id) 2>/dev/null"
+        }
+        return MuxScript.wrap(body, nonce: nonce)
+    }
+
+    private struct Row {
+        let windowID: String
+        let windowIndex: Int
+        let windowActive: Bool
+        let windowWidth: Int
+        let windowHeight: Int
+        let activity: String
+        let flags: String
+        let paneID: String
+        let paneActive: Bool
+        let rect: MuxCellRect
+        let historySize: String
+        let cursor: MuxCursor
+        let windowName: String
+        let paneTitle: String
+    }
+
+    private func row(_ line: Substring) -> Row? {
+        let parts = line.components(separatedBy: Self.separator)
+        guard parts.count >= Self.fields.count else { return nil }
+        func int(_ i: Int) -> Int { Int(parts[i]) ?? 0 }
+        return Row(
+            windowID: parts[0],
+            windowIndex: int(1),
+            windowActive: parts[2] == "1",
+            windowWidth: int(3),
+            windowHeight: int(4),
+            activity: parts[5],
+            flags: parts[6],
+            paneID: parts[7],
+            paneActive: parts[8] == "1",
+            rect: MuxCellRect(x: int(9), y: int(10), width: int(11), height: int(12)),
+            historySize: parts[13],
+            cursor: MuxCursor(x: int(14), y: int(15), visible: parts[16] != "0"),
+            windowName: parts[17],
+            paneTitle: parts[18...].joined(separator: Self.separator)
+        )
+    }
+
+    func parseTick(output: String, nonce: String) -> MuxTickResult? {
+        let sections = MuxScript.sections(of: output, nonce: nonce)
+        guard sections.found, !sections.unsupported else { return nil }
+        let rows = sections.topology.split(separator: "\n").compactMap(row)
+        guard !rows.isEmpty else { return nil }
+
+        var order: [String] = []
+        var byWindow: [String: [Row]] = [:]
+        for r in rows {
+            if byWindow[r.windowID] == nil { order.append(r.windowID) }
+            byWindow[r.windowID, default: []].append(r)
+        }
+        order.sort { (byWindow[$0]?.first?.windowIndex ?? 0) < (byWindow[$1]?.first?.windowIndex ?? 0) }
+
+        var tabs: [MuxTab] = []
+        var cursors: [String: MuxCursor] = [:]
+        var hints: [String: String] = [:]
+        for (index, windowID) in order.enumerated() {
+            guard let group = byWindow[windowID], let first = group.first else { continue }
+            let zoomed = first.flags.contains("Z")
+            var panes: [MuxPane] = []
+            for r in group {
+                cursors[r.paneID] = r.cursor
+                hints[r.paneID] = "\(r.activity)|\(r.historySize)|\(r.cursor.x)|\(r.cursor.y)|\(r.rect.width)x\(r.rect.height)"
+                // A zoomed window shows only its active pane, full size.
+                if zoomed, !r.paneActive { continue }
+                let rect = zoomed
+                    ? MuxCellRect(x: 0, y: 0, width: first.windowWidth, height: first.windowHeight)
+                    : r.rect
+                panes.append(MuxPane(id: r.paneID, rect: rect, isActive: r.paneActive,
+                                     isPreviewable: true, title: r.paneTitle))
+            }
+            let badgeFlags = first.flags.filter { "#!~Z".contains($0) }
+            tabs.append(MuxTab(
+                id: windowID,
+                index: index,
+                title: first.windowName.isEmpty ? "\(first.windowIndex)" : "\(first.windowIndex): \(first.windowName)",
+                isActive: first.windowActive,
+                cols: first.windowWidth,
+                rows: first.windowHeight,
+                panes: panes,
+                badge: badgeFlags.isEmpty ? nil : String(badgeFlags)
+            ))
+        }
+
+        var frames: [String: MuxPaneFrame] = [:]
+        for section in sections.panes {
+            // SGR state is threaded across the whole capture; close it.
+            let ansi = section.body + "\u{1b}[0m"
+            frames[section.id] = MuxPaneFrame(
+                ansi: ansi,
+                cursor: cursors[section.id],
+                revision: MuxExposeIdentity.contentRevision(section.body)
+            )
+        }
+        var result = MuxTickResult(
+            snapshot: MuxExposeSnapshot(tabs: tabs, activeTabID: tabs.first(where: \.isActive)?.id),
+            frames: frames,
+            unchanged: [],
+            truncated: sections.truncated
+        )
+        result.changeHints = hints
+        return result
+    }
+
+    func focusScript(session: String?, tabID: String) -> String {
+        let spec = session.map { "=\($0):\(tabID)" } ?? tabID
+        return MuxScript.wrap("tmux select-window -t \(MuxScript.dq(spec))", nonce: "focus")
+    }
+}

--- a/rootshell/Features/Multiplexer/Expose/ZellijExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/ZellijExposeAdapter.swift
@@ -1,0 +1,125 @@
+//
+//  ZellijExposeAdapter.swift
+//  rootshell
+//
+//  zellij ≥ 0.45: `list-tabs --json` + `list-panes --json` for the tree and
+//  geometry, `dump-screen --pane-id N --ansi` for content (reads any pane
+//  without moving focus). Older releases lack all three and report
+//  unsupported, which drops the exposé back to app tabs.
+//
+
+import Foundation
+
+nonisolated struct ZellijExposeAdapter: MultiplexerExposeAdapter {
+    let type = MultiplexerType.zellij
+
+    private func zj(_ session: String?) -> String {
+        session.map { "zellij -s \(MuxScript.dq($0)) action" } ?? "zellij action"
+    }
+
+    /// Same gate as ZellijSessionDiscovery: major > 0 or minor ≥ 45.
+    private let versionGate =
+        "command -v zellij >/dev/null 2>&1 || echo \(MuxScript.dq(MuxScript.unsupportedMarker))"
+        + "; _zv=$(zellij --version 2>/dev/null | grep -oE \"[0-9]+\\.[0-9]+\" | head -1); _zmaj=${_zv%%.*}; _zmin=${_zv#*.}"
+        + "; if [ \"${_zmaj:-0}\" -eq 0 ] 2>/dev/null && [ \"${_zmin:-0}\" -lt 45 ] 2>/dev/null; then echo \(MuxScript.dq(MuxScript.unsupportedMarker)); fi"
+
+    func resolveSessionScript(nonce: String) -> String {
+        // `--short` also lists exited sessions, which are not attachable and
+        // would make a single live session look ambiguous.
+        MuxScript.wrap(
+            "echo \(MuxScript.dq(MuxScript.topology(nonce)))"
+            + "; zellij list-sessions --no-formatting 2>/dev/null | grep -v EXITED | cut -d \" \" -f1",
+            nonce: nonce
+        )
+    }
+
+    func tickScript(session: String?, request: MuxTickRequest, nonce: String) -> String {
+        var body = versionGate
+        body += "; echo \(MuxScript.dq(MuxScript.topology(nonce)))"
+        body += "; \(zj(session)) list-tabs --json 2>/dev/null; echo; echo \"::MX_PANES::\""
+        body += "; \(zj(session)) list-panes --json 2>/dev/null; echo"
+        for paneID in request.fetch {
+            body += "; \(MuxScript.paneMarker(nonce: nonce, id: paneID))"
+            body += "; \(zj(session)) dump-screen --pane-id \(MuxScript.dq(paneID)) --ansi 2>/dev/null; echo"
+        }
+        return MuxScript.wrap(body, nonce: nonce)
+    }
+
+    func parseTick(output: String, nonce: String) -> MuxTickResult? {
+        let sections = MuxScript.sections(of: output, nonce: nonce)
+        guard sections.found, !sections.unsupported else { return nil }
+        let halves = sections.topology.components(separatedBy: "::MX_PANES::")
+        guard halves.count == 2,
+              let tabInfos = MuxScript.json(halves[0]) as? [[String: Any]],
+              let paneInfos = MuxScript.json(halves[1]) as? [[String: Any]] else { return nil }
+
+        var panesByTab: [Int: [[String: Any]]] = [:]
+        for pane in paneInfos {
+            guard let tabID = pane.mxInt("tab_id") else { continue }
+            panesByTab[tabID, default: []].append(pane)
+        }
+
+        var cursors: [String: MuxCursor] = [:]
+        var tabs: [MuxTab] = []
+        for info in tabInfos.sorted(by: { ($0.mxInt("position") ?? 0) < ($1.mxInt("position") ?? 0) }) {
+            guard let tabID = info.mxInt("tab_id") else { continue }
+            let cols = info.mxInt("display_area_columns") ?? info.mxInt("viewport_columns") ?? 0
+            let rows = info.mxInt("display_area_rows") ?? info.mxInt("viewport_rows") ?? 0
+            var panes: [MuxPane] = []
+            let members = (panesByTab[tabID] ?? [])
+                .filter { !$0.mxBool("is_suppressed") && $0.mxBool("is_selectable") }
+                // Tiled first so floating panes draw on top.
+                .sorted { !$0.mxBool("is_floating") && $1.mxBool("is_floating") }
+            for pane in members {
+                guard let number = pane.mxInt("id") else { continue }
+                let isPlugin = pane.mxBool("is_plugin")
+                let id = isPlugin ? "plugin_\(number)" : "terminal_\(number)"
+                let rect = MuxCellRect(
+                    x: pane.mxInt("pane_content_x") ?? pane.mxInt("pane_x") ?? 0,
+                    y: pane.mxInt("pane_content_y") ?? pane.mxInt("pane_y") ?? 0,
+                    width: pane.mxInt("pane_content_columns") ?? pane.mxInt("pane_columns") ?? 0,
+                    height: pane.mxInt("pane_content_rows") ?? pane.mxInt("pane_rows") ?? 0
+                )
+                if let coords = pane["cursor_coordinates_in_pane"] as? [Any], coords.count == 2,
+                   let x = (coords[0] as? NSNumber)?.intValue, let y = (coords[1] as? NSNumber)?.intValue {
+                    cursors[id] = MuxCursor(x: x, y: y, visible: true)
+                } else {
+                    cursors[id] = MuxCursor(x: 0, y: 0, visible: false)
+                }
+                panes.append(MuxPane(
+                    id: id, rect: rect, isActive: pane.mxBool("is_focused"),
+                    isPreviewable: !isPlugin, title: pane.mxString("title")
+                ))
+            }
+            tabs.append(MuxTab(
+                id: String(tabID),
+                index: tabs.count,
+                title: info.mxString("name") ?? "Tab \(tabs.count + 1)",
+                isActive: info.mxBool("active"),
+                cols: cols,
+                rows: rows,
+                panes: panes,
+                badge: info.mxBool("has_bell_notification") ? "!" : nil
+            ))
+        }
+
+        var frames: [String: MuxPaneFrame] = [:]
+        for section in sections.panes {
+            frames[section.id] = MuxPaneFrame(
+                ansi: section.body,
+                cursor: cursors[section.id],
+                revision: MuxExposeIdentity.contentRevision(section.body)
+            )
+        }
+        return MuxTickResult(
+            snapshot: MuxExposeSnapshot(tabs: tabs, activeTabID: tabs.first(where: \.isActive)?.id),
+            frames: frames,
+            unchanged: [],
+            truncated: sections.truncated
+        )
+    }
+
+    func focusScript(session: String?, tabID: String) -> String {
+        MuxScript.wrap("\(zj(session)) go-to-tab-by-id \(MuxScript.dq(tabID))", nonce: "focus")
+    }
+}

--- a/rootshell/Features/SSH/Discovery/SessionDiscoveryRunner.swift
+++ b/rootshell/Features/SSH/Discovery/SessionDiscoveryRunner.swift
@@ -195,7 +195,10 @@ extension SessionDiscoveryRunner {
         let result = try await HelperConnection.shared.executeCommand(
             command: command,
             workingDirectory: workingDirectory,
-            timeout: 7
+            timeout: 7,
+            // The same bound the SSH path applies; a local host's captures are
+            // no smaller, and the parser tolerates a truncated reply.
+            maxOutputBytes: Self.maxDiscoveryResponseBytes
         )
 
         if result.timedOut {

--- a/rootshell/Features/SSH/Session/RemoteExecProbe.swift
+++ b/rootshell/Features/SSH/Session/RemoteExecProbe.swift
@@ -145,7 +145,11 @@ enum RemoteExecProbe {
             }
             let result = try await HelperConnection.shared.executeCommand(
                 command: command,
-                timeout: timeout
+                timeout: timeout,
+                // Same bound as the remote transports: a local command can
+                // stream just as much, and the caller's framing detects the
+                // truncation exactly as it does for a capped SSH channel.
+                maxOutputBytes: maxResponseBytes
             )
             guard !result.timedOut else { throw ProbeError.timedOut }
             return result.output

--- a/rootshell/Features/Tmux/Settings/MultiplexerSettingsView.swift
+++ b/rootshell/Features/Tmux/Settings/MultiplexerSettingsView.swift
@@ -6,6 +6,7 @@ struct MultiplexerSettingsView: View {
     @AppStorage("herdrSessionDiscoveryEnabled") private var herdrDiscoveryEnabled = true
     @AppStorage("localSessionDiscoveryEnabled") private var localDiscoveryEnabled = true
     @AppStorage(SessionDiscoverySortOrder.storageKey) private var sortOrder = SessionDiscoverySortOrder.attachedFirst.rawValue
+    @AppStorage(TabExposeSettings.multiplexerEnabledKey) private var exposeMultiplexerEnabled = true
     @AppStorage("tmuxSessionName") private var sessionName = ""
     @AppStorage("tmuxCustomCommand") private var customCommand = ""
     @AppStorage("herdrSessionName") private var herdrSessionName = ""
@@ -98,6 +99,20 @@ struct MultiplexerSettingsView: View {
                 Text("Session Discovery")
             } footer: {
                 Text(discoveryFooterText)
+            }
+
+            Section {
+                Toggle(isOn: $exposeMultiplexerEnabled) {
+                    HStack(spacing: 12) {
+                        SettingsIcon(systemName: "rectangle.grid.2x2")
+                        Text("Show Multiplexer Tabs")
+                    }
+                }
+                .themedRow()
+            } header: {
+                Text("Tab Exposé")
+            } footer: {
+                Text("On a tab attached to tmux, zellij, or herdr, Tab Exposé opens on that session's own tabs with live previews, and swiping sideways returns to your app tabs. Reads the session's layout and pane contents over the connection the tab already holds while the exposé is open.")
             }
 
             Section {

--- a/rootshell/Features/Tmux/Views/TmuxPreviewView.swift
+++ b/rootshell/Features/Tmux/Views/TmuxPreviewView.swift
@@ -96,32 +96,128 @@ extension Ghostty {
             ghosttyApp?.registerSurface(newSurface)
         }
 
+        /// Cell size in points once the surface has been sized; nil before.
+        var cellSize: CGSize? {
+            guard let surface, hasSized else { return nil }
+            let size = ghostty_surface_size(surface)
+            guard size.cell_width_px > 0, size.cell_height_px > 0 else { return nil }
+            let scale = max(contentScaleFactor, 1)
+            return CGSize(width: CGFloat(size.cell_width_px) / scale, height: CGFloat(size.cell_height_px) / scale)
+        }
+
+        /// The grid this surface actually renders into. Content wider than
+        /// `columns` wraps, so callers sizing a surface to hold a captured
+        /// screen must check this rather than trusting their own arithmetic
+        /// (padding and rounding both eat columns).
+        var gridSize: (columns: Int, rows: Int)? {
+            guard let surface, hasSized else { return nil }
+            let size = ghostty_surface_size(surface)
+            guard size.columns > 0, size.rows > 0 else { return nil }
+            return (Int(size.columns), Int(size.rows))
+        }
+
         /// Write ANSI text content to the surface for rendering.
         func writeContent(_ ansiText: String) {
-            guard slaveFd >= 0, surface != nil else { return }
             // Clear screen + home cursor so stale content from a previous session is erased
             let clearPrefix = "\u{1b}[2J\u{1b}[H"
             // Terminal expects \r\n for proper line positioning; tmux capture-pane outputs \n only
-            let normalized = (clearPrefix + ansiText).replacingOccurrences(of: "\n", with: "\r\n")
-            guard let data = normalized.data(using: .utf8) else { return }
+            writeToSurface((clearPrefix + ansiText).replacingOccurrences(of: "\n", with: "\r\n"))
+        }
 
-            // Write the ANSI content to the slave fd
-            data.withUnsafeBytes { buffer in
+        /// Replace the whole screen atomically (synchronized output), leaving
+        /// the cursor at `cursor` or hidden. For live previews that repaint
+        /// on every change: no intermediate blank frame is ever shown.
+        func writeFrame(_ ansiText: String, cursor: (x: Int, y: Int, visible: Bool)?) {
+            var text = "\u{1b}[?2026h\u{1b}[?25l\u{1b}[0m\u{1b}[H\u{1b}[2J"
+            text += ansiText.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\n", with: "\r\n")
+            text += "\u{1b}[0m"
+            if let cursor, cursor.visible {
+                text += "\u{1b}[\(cursor.y + 1);\(cursor.x + 1)H\u{1b}[?25h"
+            }
+            text += "\u{1b}[?2026l"
+            writeToSurface(text)
+        }
+
+        /// A frame is far larger than the pipe to the emulator: a coloured
+        /// full screen runs to tens of KB against a pipe buffer of 16-64 KB,
+        /// so `write` returns short and the rest MUST follow later. Dropping
+        /// the remainder used to cut a frame mid-sequence — inside the
+        /// synchronized-update wrapper that means the screen never repaints
+        /// again, which is a preview that flashes once and then stays blank.
+        private var pending = Data()
+        /// A frame was cut short: the next one must abort its leftovers.
+        private var pendingIsPartial = false
+        private var drawScheduled = false
+        private var flushScheduled = false
+
+        private func writeToSurface(_ normalized: String) {
+            guard slaveFd >= 0, surface != nil else { return }
+            var text = ""
+            if pendingIsPartial {
+                // CAN abandons any half-written control sequence, then leave
+                // synchronized output so this frame can paint.
+                text = "\u{18}\u{1b}[?2026l"
+            }
+            text += normalized
+            guard let data = text.data(using: .utf8), !data.isEmpty else { return }
+            // A newer frame supersedes whatever is still queued: the preview
+            // wants the latest screen, not every screen.
+            pending = data
+            pendingIsPartial = false
+            flushPendingWrites()
+        }
+
+        /// Push as much of the queued frame as the pipe accepts. Callers on a
+        /// display link call this every tick, so a frame too large for one
+        /// write completes over the next few. Returns true when nothing is left.
+        @discardableResult
+        func flushPendingWrites() -> Bool {
+            guard slaveFd >= 0, surface != nil else {
+                pending.removeAll()
+                pendingIsPartial = false
+                return true
+            }
+            guard !pending.isEmpty else { return true }
+            var written = 0
+            pending.withUnsafeBytes { buffer in
                 guard let ptr = buffer.baseAddress else { return }
-                var written = 0
-                let total = buffer.count
-                while written < total {
-                    let n = write(slaveFd, ptr.advanced(by: written), total - written)
+                while written < buffer.count {
+                    let n = write(slaveFd, ptr.advanced(by: written), buffer.count - written)
                     if n <= 0 { break }
                     written += n
                 }
             }
+            if written > 0 {
+                pending.removeFirst(written)
+                pendingIsPartial = !pending.isEmpty
+                // Tick the app to process the written data through the terminal
+                // emulator, then draw the surface to render it to the Metal layer.
+                ghosttyApp?.appTick()
+                scheduleDraw()
+            }
+            // Not every caller is on a display link, and the pipe drains on
+            // the emulator's own thread: come back for the rest either way.
+            if !pending.isEmpty { scheduleFlush() }
+            return pending.isEmpty
+        }
 
-            // Tick the app to process the written data through the terminal emulator,
-            // then draw the surface to render it to the Metal layer.
-            ghosttyApp?.appTick()
+        private func scheduleFlush() {
+            guard !flushScheduled else { return }
+            flushScheduled = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.016) { [weak self] in
+                guard let self else { return }
+                self.flushScheduled = false
+                self.flushPendingWrites()
+            }
+        }
+
+        private func scheduleDraw() {
+            guard !drawScheduled else { return }
+            drawScheduled = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                guard let self, let surface = self.surface,
+                guard let self else { return }
+                self.drawScheduled = false
+                guard let surface = self.surface,
                       self.ghosttyApp?.isInBackground != true,
                       !Ghostty.isSecureDrawProhibitedAtomic else { return }
                 self.ghosttyApp?.appTick()
@@ -130,6 +226,8 @@ extension Ghostty {
         }
 
         func cleanup() {
+            pending.removeAll()
+            pendingIsPartial = false
             guard let surface = self.surface else { return }
             ghosttyApp?.unregisterSurface(surface)
             self.surface = nil

--- a/rootshell/Features/Tmux/Views/TmuxPreviewView.swift
+++ b/rootshell/Features/Tmux/Views/TmuxPreviewView.swift
@@ -55,6 +55,10 @@ extension Ghostty {
                     if sublayer.frame != bounds {
                         sublayer.frame = bounds
                     }
+                    // Previews composite at ~0.25x; bilinear crawls on glyph stems.
+                    if sublayer.minificationFilter != .trilinear {
+                        sublayer.minificationFilter = .trilinear
+                    }
                 }
             }
 

--- a/rootshell/UI/Shell/MainView+TabExpose.swift
+++ b/rootshell/UI/Shell/MainView+TabExpose.swift
@@ -78,12 +78,32 @@ extension MainView {
                 .padding(.horizontal, 4)
             )
         }
+        appearance.muxCaptionProvider = { tab, index in
+            AnyView(
+                MuxTabCaption(
+                    tab: tab,
+                    keyboardShortcut: compact ? nil : keyboardShortcut(for: index),
+                    titleFont: .system(size: compact ? 12 : 13, weight: .semibold),
+                    shortcutFont: .system(size: compact ? 11 : 12, weight: .medium),
+                    textColor: textColor.opacity(0.85)
+                )
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal, 4)
+            )
+        }
         return appearance
     }
 
     /// One-time wiring; the closures read live state through the property wrappers.
     func installTabExposeHooks() {
         tabExpose.tabsModel = tabsModel
+        tabExpose.muxFeed = muxExposeFeed
+        let controller = tabExpose
+        muxExposeFeed.onChange = { controller.muxFeedDidChange() }
+        tabExpose.multiplexerTerminal = {
+            let tab = tabsModel.selectedTab
+            return tab?.focusedPane?.asTerminal ?? tab?.splitTree.terminalLeaves.first
+        }
         tabExpose.reduceMotion = {
             UserDefaults.standard.bool(forKey: "tabBarAnimationsDisabled") || UIAccessibility.isReduceMotionEnabled
         }
@@ -99,7 +119,7 @@ extension MainView {
             reconcileSurfaceOcclusion(reason: "tabExpose")
             reassertSelectedTabVisibility(reason: "tabExpose")
         }
-        tabExpose.onNavigateScope = { delta in navigateScope(by: delta) }
+        tabExpose.onNavigateScope = { delta in navigateAppScope(by: delta) }
         tabExpose.onScopePreviewChanged = { ids in
             // A group swipe drags the neighbor's live mirrors in: wake them;
             // the reconcile re-occludes a preview that was replaced or ended.
@@ -131,10 +151,20 @@ extension MainView {
 
     /// Switch the active group / project by `delta` (wraps). Lands on the
     /// scope's remembered (else first navigable) tab; no-op in flat mode or
-    /// with one scope. While the exposé is up it stays up and pages over.
+    /// with one scope. While the exposé is up it stays up and pages over,
+    /// the multiplexer page included.
     func navigateScope(by delta: Int) {
+        if tabExpose.isActive {
+            tabExpose.navigateScope(by: delta)
+            return
+        }
+        navigateAppScope(by: delta)
+    }
+
+    /// The app-scope half of `navigateScope`: select a tab in the neighbor
+    /// group / project.
+    private func navigateAppScope(by delta: Int) {
         guard let id = tabsModel.firstTabIDInNeighborScope(offset: delta) else { return }
-        if tabExpose.isActive { tabExpose.pendingScopeTransition = delta }
         if tabBarHidden && id != tabsModel.selectedTabID {
             tabIndicator.suppressNextHiddenIndicator = tabExpose.isActive
         }
@@ -188,6 +218,36 @@ extension MainView {
             if let focused = tabsModel.selectedTab?.focusedPane {
                 focused.setOverlayOwnsKeyboard(isAnySheetPresented)
                 _ = focused.focusDidChange(true)
+            }
+        }
+    }
+}
+
+/// Caption under a multiplexer tab cell: shortcut, title, and the tab's
+/// badge (tmux flags, herdr agent status).
+private struct MuxTabCaption: View {
+    let tab: MuxTab
+    let keyboardShortcut: String?
+    let titleFont: Font
+    let shortcutFont: Font
+    let textColor: Color
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if let keyboardShortcut {
+                Text(keyboardShortcut)
+                    .font(shortcutFont)
+                    .foregroundStyle(textColor.opacity(0.6))
+            }
+            Text(tab.title)
+                .font(titleFont)
+                .foregroundStyle(textColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if let badge = tab.badge, !badge.isEmpty {
+                Text(badge)
+                    .font(shortcutFont)
+                    .foregroundStyle(textColor.opacity(0.6))
             }
         }
     }

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -197,6 +197,8 @@ struct MainView: View {
 
     // Tab exposé (live previews of the current scope; see TabExposeController).
     @State var tabExpose = TabExposeController()
+    /// Serves the exposé's multiplexer page (herdr / tmux / zellij tabs).
+    @State var muxExposeFeed = MultiplexerExposeFeed()
     
     
     // Unified main-alert queue: host-key validation, SSH/GPG agent

--- a/rootshell/UI/Tabs/MuxTabPreviewView.swift
+++ b/rootshell/UI/Tabs/MuxTabPreviewView.swift
@@ -1,0 +1,215 @@
+//
+//  MuxTabPreviewView.swift
+//  rootshell
+//
+//  The exposé cell picture of one multiplexer tab (herdr tab, tmux window,
+//  zellij tab): its pane layout reproduced from cell rects, each pane an
+//  offscreen Ghostty preview surface fed the latest frame from the feed.
+//  Surfaces are sized to the pane's real column/row count and scaled into
+//  the cell, so wrapping matches the source; a frame is written only when
+//  its revision changes, atomically, so nothing ever flickers.
+//
+
+import UIKit
+
+@MainActor
+final class MuxTabPreviewView: UIView {
+    weak var feed: MultiplexerExposeFeed?
+    var tab: MuxTab? {
+        didSet {
+            guard tab != oldValue else { return }
+            if tab == nil { removeAll() } else { setNeedsLayout() }
+        }
+    }
+
+    private final class PanePreview {
+        let container = UIView()
+        var surface: Ghostty.TmuxPreviewView?
+        var placeholder: CALayer?
+        var writtenRevision: String?
+        /// Grid the written frame was laid out for. A resize reflows and can
+        /// clear what was already painted, and an unchanged revision would
+        /// never redraw it, so the frame is rewritten whenever this changes.
+        var writtenGrid: String?
+        var surfaceSize: CGSize = .zero
+        /// Cells added on top of the pane's own grid so the surface really
+        /// holds it; grown when the surface reports a grid that is too small.
+        var slackColumns: CGFloat = 2
+        var slackRows: CGFloat = 2
+    }
+
+    private var previews: [String: PanePreview] = [:]
+    /// Used while the surface has not reported its real cell size yet.
+    private static let fallbackCellSize = CGSize(width: 8, height: 16)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        layer.masksToBounds = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        sync()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        // Off screen the surfaces go; they come back on the next sync.
+        if window == nil { removeAll() }
+    }
+
+    /// Pane ids this view is showing (for the feed's visible set).
+    var paneIDs: Set<String> {
+        Set(tab?.panes.filter(\.isPreviewable).map(\.id) ?? [])
+    }
+
+    /// Refresh geometry and frames; cheap when nothing changed (per display tick).
+    func sync() {
+        guard let tab, tab.cols > 0, tab.rows > 0, bounds.width > 0, bounds.height > 0, window != nil else { return }
+        let cw = bounds.width / CGFloat(tab.cols)
+        let ch = bounds.height / CGFloat(tab.rows)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        var seen: Set<String> = []
+        for pane in tab.panes {
+            seen.insert(pane.id)
+            let preview = previews[pane.id] ?? makePreview(for: pane.id)
+            let rect = pane.rect
+            let frame = CGRect(
+                x: CGFloat(rect.x) * cw, y: CGFloat(rect.y) * ch,
+                width: CGFloat(rect.width) * cw, height: CGFloat(rect.height) * ch
+            )
+            preview.container.frame = frame
+            bringSubviewToFront(preview.container)
+            guard pane.isPreviewable, rect.width > 0, rect.height > 0 else {
+                preview.surface?.cleanup()
+                preview.surface?.removeFromSuperview()
+                preview.surface = nil
+                ensurePlaceholder(preview)
+                continue
+            }
+            let surface = preview.surface ?? makeSurface(preview)
+            guard let surface else {
+                ensurePlaceholder(preview)
+                continue
+            }
+            // The pane's own grid plus slack, so no captured row wraps here.
+            let cell = surface.cellSize ?? Self.fallbackCellSize
+            // A grid smaller than the source wraps every row; grow and retry.
+            if let grid = surface.gridSize, preview.surfaceSize != .zero {
+                if grid.columns < rect.width {
+                    preview.slackColumns += CGFloat(rect.width - grid.columns) + 1
+                }
+                if grid.rows < rect.height {
+                    preview.slackRows += CGFloat(rect.height - grid.rows) + 1
+                }
+            }
+            // Ghostty insets the grid by the window padding, so the surface
+            // needs room for it on top of the cells it must hold.
+            let padX = CGFloat(PaddingManager.shared.effectivePaddingX)
+            let padY = CGFloat(PaddingManager.shared.effectivePaddingY)
+            let virtual = CGSize(
+                width: (CGFloat(rect.width) + preview.slackColumns) * cell.width + padX * 2,
+                height: (CGFloat(rect.height) + preview.slackRows) * cell.height + padY * 2
+            )
+            if abs(preview.surfaceSize.width - virtual.width) > 0.5
+                || abs(preview.surfaceSize.height - virtual.height) > 0.5 {
+                preview.surfaceSize = virtual
+                surface.bounds = CGRect(origin: .zero, size: virtual)
+                surface.setNeedsLayout()
+                surface.layoutIfNeeded()
+                // The old frame was laid out for the old grid: draw it again.
+                preview.writtenRevision = nil
+                preview.writtenGrid = nil
+            }
+            // Map the pane's own cells onto the cell, ignoring slack AND the
+            // padding: the grid starts at (padX, padY), so scaling from the
+            // surface's origin would push its last row past the bottom edge.
+            // Padding balance is off app-wide, so the leading inset is exact
+            // and any sub-cell remainder sits on the trailing edges.
+            let sx = frame.width / max(CGFloat(rect.width) * cell.width, 1)
+            let sy = frame.height / max(CGFloat(rect.height) * cell.height, 1)
+            surface.transform = CGAffineTransform(translationX: -padX * sx, y: -padY * sy)
+                .scaledBy(x: sx, y: sy)
+
+            // Write only into a grid that can hold the capture unwrapped.
+            let grid = surface.gridSize
+            let fits = grid.map { $0.columns >= rect.width && $0.rows >= rect.height } ?? false
+            let gridKey = grid.map { "\($0.columns)x\($0.rows)" }
+            if fits, let latest = feed?.frame(for: pane.id),
+               latest.revision != preview.writtenRevision || gridKey != preview.writtenGrid {
+                surface.writeFrame(latest.ansi, cursor: latest.cursor.map { ($0.x, $0.y, $0.visible) })
+                preview.writtenRevision = latest.revision
+                preview.writtenGrid = gridKey
+                preview.placeholder?.removeFromSuperlayer()
+                preview.placeholder = nil
+            } else if preview.writtenRevision == nil {
+                ensurePlaceholder(preview)
+            }
+            // A frame larger than the pipe finishes over the next few ticks.
+            surface.flushPendingWrites()
+        }
+
+        for (id, preview) in previews where !seen.contains(id) {
+            preview.surface?.cleanup()
+            preview.container.removeFromSuperview()
+            previews[id] = nil
+        }
+    }
+
+    private func makePreview(for id: String) -> PanePreview {
+        let preview = PanePreview()
+        preview.container.clipsToBounds = true
+        preview.container.isUserInteractionEnabled = false
+        preview.container.layer.borderWidth = 1 / max(traitCollection.displayScale, 1)
+        preview.container.layer.borderColor = UIColor.white.withAlphaComponent(0.08).cgColor
+        addSubview(preview.container)
+        previews[id] = preview
+        return preview
+    }
+
+    private func makeSurface(_ preview: PanePreview) -> Ghostty.TmuxPreviewView? {
+        guard let app = feed?.ghosttyApp else { return nil }
+        let surface = Ghostty.TmuxPreviewView(ghosttyApp: app)
+        surface.layer.anchorPoint = .zero
+        surface.layer.position = .zero
+        preview.container.addSubview(surface)
+        preview.surface = surface
+        preview.writtenRevision = nil
+        preview.surfaceSize = .zero
+        return surface
+    }
+
+    private func ensurePlaceholder(_ preview: PanePreview) {
+        let bounds = preview.container.bounds
+        if let placeholder = preview.placeholder {
+            placeholder.position = CGPoint(x: bounds.midX, y: bounds.midY)
+            return
+        }
+        let config = UIImage.SymbolConfiguration(pointSize: 28, weight: .light)
+        guard let image = UIImage(systemName: "terminal", withConfiguration: config)?
+            .withTintColor(.white.withAlphaComponent(0.3), renderingMode: .alwaysOriginal) else { return }
+        let symbol = CALayer()
+        symbol.contents = image.cgImage
+        symbol.contentsGravity = .resizeAspect
+        symbol.bounds = CGRect(origin: .zero, size: image.size)
+        symbol.position = CGPoint(x: bounds.midX, y: bounds.midY)
+        preview.container.layer.addSublayer(symbol)
+        preview.placeholder = symbol
+    }
+
+    private func removeAll() {
+        for preview in previews.values {
+            preview.surface?.cleanup()
+            preview.container.removeFromSuperview()
+        }
+        previews.removeAll()
+    }
+}

--- a/rootshell/UI/Tabs/TabExposeController.swift
+++ b/rootshell/UI/Tabs/TabExposeController.swift
@@ -37,6 +37,21 @@ final class TabExposeController {
         case dismiss
     }
 
+    /// One page of the exposé: the attached multiplexer session's tabs, or
+    /// an app-tab scope (a group / project, or every tab in flat mode).
+    struct Scope: Equatable {
+        enum Kind: Equatable {
+            case multiplexer
+            case app(TabsModel.ScopeKey?)
+        }
+        let kind: Kind
+        let title: String?
+        let tabIDs: [UUID]
+        /// Cell marked current and landed on when entering the page.
+        let currentID: UUID?
+        var isMultiplexer: Bool { kind == .multiplexer }
+    }
+
     // MARK: - State
 
     private(set) var phase: Phase = .hidden
@@ -45,6 +60,13 @@ final class TabExposeController {
     private(set) var scopeTitle: String?
     /// Shown in the scope header; nil in flat mode.
     private(set) var isScoped = false
+    /// The current page is the multiplexer session's tabs.
+    private(set) var showsMultiplexer = false
+    /// The multiplexer page exists for this presentation (the hero tab is
+    /// attached to herdr / tmux / zellij and the feed could start).
+    @ObservationIgnored private(set) var multiplexerAttached = false
+    /// The app tab whose terminal feeds the multiplexer page.
+    @ObservationIgnored private var multiplexerHostTabID: UUID?
     /// The tab whose full-size live picture slides in/out with the tray.
     private(set) var heroTabID: UUID?
     var highlightedTabID: UUID? {
@@ -58,9 +80,14 @@ final class TabExposeController {
     /// (the host keeps their renderers live; empty when no preview).
     @ObservationIgnored private(set) var previewTabIDs: [UUID] = []
     var isActive: Bool { phase != .hidden }
-    /// Grouped/project mode with more than one scope to move between.
+    /// More than one page to move between (groups / projects, or the
+    /// multiplexer page next to the app tabs).
     var canNavigateScope: Bool {
-        isScoped && tabsModel?.firstTabIDInNeighborScope(offset: 1) != nil
+        scopeList().scopes.count > 1
+    }
+    /// Cell marked as current on the active page.
+    var currentCellID: UUID? {
+        showsMultiplexer ? muxFeed?.activeTabUUID : tabsModel?.selectedTabID
     }
 
     /// 0 hidden … 1 presented (may overshoot slightly). Read per frame by the
@@ -73,6 +100,12 @@ final class TabExposeController {
 
     @ObservationIgnored weak var tabsModel: TabsModel?
     @ObservationIgnored weak var observer: TabExposeControllerObserver?
+    /// Serves the multiplexer page; started on activation when the hero
+    /// tab's terminal is bound to a raw multiplexer.
+    @ObservationIgnored weak var muxFeed: MultiplexerExposeFeed?
+    /// The terminal holding the selected tab's connection (focused pane,
+    /// else any terminal in the tab).
+    @ObservationIgnored var multiplexerTerminal: (() -> Ghostty.TerminalView?)?
     /// Un-occlude scope tabs (and anything else the host needs before showing).
     @ObservationIgnored var onWillPresent: (([UUID]) -> Void)?
     /// Restore occlusion after the overlay is gone.
@@ -112,6 +145,9 @@ final class TabExposeController {
     @ObservationIgnored private var scopeObservationArmed = false
     @ObservationIgnored private var isRefreshingScope = false
     @ObservationIgnored private var highlightChangedDuringRefresh = false
+    /// Inside `attachMultiplexer`: the feed's synchronous start notification
+    /// must not re-enter `refreshScope` from underneath one.
+    @ObservationIgnored private var isAttachingMultiplexer = false
 
     // MARK: - Interactive reveal / dismiss
 
@@ -195,9 +231,22 @@ final class TabExposeController {
     }
 
     /// Switch to `id`: it becomes the hero that slides back in while the
-    /// tray leaves; the real selection changes immediately.
+    /// tray leaves; the real selection changes immediately. On the
+    /// multiplexer page the hero is unchanged: the session switches tabs
+    /// underneath it and its own PTY repaints.
     func select(_ id: UUID) {
         guard isActive, tabIDs.contains(id) else { return }
+        if showsMultiplexer {
+            highlightedTabID = id
+            pendingSelectedTabID = nil
+            observer?.tabExposeDidChangeCells(self)
+            if let tab = muxFeed?.tab(uuid: id) {
+                onCommitHaptic?()
+                muxFeed?.focus(tabID: tab.id)
+            }
+            settle(to: 0, fast: false)
+            return
+        }
         heroTabID = id
         highlightedTabID = id
         pendingSelectedTabID = id
@@ -208,11 +257,42 @@ final class TabExposeController {
         settle(to: 0, fast: false)
     }
 
-    /// Previous / next group or project while presented (swipe, keys).
+    /// Previous / next page while presented (swipe, ⌘⌥[ ]): the multiplexer
+    /// page re-scopes in place; an app scope selects a tab in it and the
+    /// observation re-scopes.
     func navigateScope(by delta: Int) {
         guard isActive, delta != 0 else { return }
+        let list = scopeList()
+        guard list.scopes.count > 1 else { return }
+        let count = list.scopes.count
+        let targetIndex = ((list.activeIndex + delta) % count + count) % count
+        let target = list.scopes[targetIndex]
         pendingScopeTransition = delta
-        onNavigateScope?(delta)
+        // Re-scope on the next turn, like the observation-driven app-scope
+        // switch: the view's swipe commit must finish arming its settle
+        // before the pages swap roles.
+        let deferredRefresh = { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.isActive else { return }
+                self.refreshScope()
+            }
+        }
+        switch target.kind {
+        case .multiplexer:
+            showsMultiplexer = true
+            deferredRefresh()
+        case .app:
+            showsMultiplexer = false
+            let appOffset = targetIndex - list.appActiveIndex
+            if appOffset == 0 {
+                deferredRefresh()
+            } else {
+                onNavigateScope?(appOffset)
+                // The host's selection re-scopes asynchronously; keep the
+                // page direction the user asked for, not the app-scope offset.
+                pendingScopeTransition = delta
+            }
+        }
     }
 
     /// The view consumes the page direction of the scope switch this
@@ -222,9 +302,63 @@ final class TabExposeController {
         return scopeTransition
     }
 
-    /// The neighbor scope a swipe would land on (nil: flat mode / one scope).
-    func neighborScope(offset: Int) -> TabsModel.ScopeInfo? {
-        tabsModel?.neighborScope(offset: offset)
+    /// The page a swipe would land on (nil: a single page).
+    func neighborScope(offset: Int) -> Scope? {
+        let list = scopeList()
+        guard list.scopes.count > 1 else { return nil }
+        let count = list.scopes.count
+        return list.scopes[((list.activeIndex + offset) % count + count) % count]
+    }
+
+    /// Every page in order: the multiplexer session first when attached,
+    /// then the app scopes (a single "Tabs" page in flat mode).
+    private func scopeList() -> (scopes: [Scope], activeIndex: Int, appActiveIndex: Int) {
+        guard let tabsModel else { return ([], 0, 0) }
+        var scopes: [Scope] = []
+        if multiplexerAttached, let feed = muxFeed {
+            scopes.append(Scope(kind: .multiplexer, title: feed.title, tabIDs: feed.tabUUIDs, currentID: feed.activeTabUUID))
+        }
+        let appActive: Int
+        if let list = tabsModel.scopeList() {
+            appActive = scopes.count + list.activeIndex
+            scopes += list.scopes.map { info in
+                Scope(kind: .app(info.key), title: info.title, tabIDs: info.tabIDs,
+                      currentID: tabsModel.preferredTabID(in: info.tabIDs, scope: info.key))
+            }
+        } else {
+            appActive = scopes.count
+            scopes.append(Scope(
+                kind: .app(nil),
+                title: String(localized: "Tabs", comment: "Exposé page title for all app tabs next to a multiplexer page"),
+                tabIDs: tabsModel.orderProjection.navigationTabIDs,
+                currentID: tabsModel.selectedTabID
+            ))
+        }
+        let active = (showsMultiplexer && multiplexerAttached) ? 0 : appActive
+        return (scopes, active, appActive)
+    }
+
+    /// The feed's state or topology changed.
+    func muxFeedDidChange() {
+        // Starting the feed notifies synchronously; the attach path is
+        // already inside a refresh that will pick the new state up.
+        guard !isAttachingMultiplexer else { return }
+        guard let muxFeed, let host = multiplexerHostTabID else { return }
+        if !multiplexerAttached {
+            // Detection finished: adopt the page if we're still on the host tab.
+            guard isActive, muxFeed.isServing, tabsModel?.selectedTabID == host else { return }
+            multiplexerAttached = true
+            showsMultiplexer = true
+            refreshScope()
+            return
+        }
+        if muxFeed.state == .unsupported {
+            multiplexerAttached = false
+            showsMultiplexer = false
+        }
+        // Tab ids survive a topology change: force the rebuild that carries
+        // the new layouts, titles, current tab, and header state.
+        refreshScope(force: true)
     }
 
     /// The view is previewing `ids` (a neighbor scope dragged in); empty ends it.
@@ -239,6 +373,11 @@ final class TabExposeController {
         guard isActive else { return }
         progress = 0
         velocity = 0
+        // Detach first so the feed's stop notification doesn't re-scope.
+        multiplexerAttached = false
+        showsMultiplexer = false
+        multiplexerHostTabID = nil
+        muxFeed?.stopNow()
         finishHide()
     }
 
@@ -349,10 +488,17 @@ final class TabExposeController {
     /// Snapshot the scope and tell the host we're about to show. False if there is nothing to show.
     private func activate() -> Bool {
         guard let tabsModel else { return false }
+        attachMultiplexer()
         refreshScope(announce: false)
-        guard !tabIDs.isEmpty else { return false }
+        guard !tabIDs.isEmpty || showsMultiplexer else {
+            muxFeed?.stop(grace: 0)
+            multiplexerAttached = false
+            multiplexerHostTabID = nil
+            return false
+        }
         heroTabID = tabsModel.selectedTabID
-        highlightedTabID = tabsModel.selectedTabID.flatMap { tabIDs.contains($0) ? $0 : nil } ?? tabIDs.first
+        let landing = showsMultiplexer ? muxFeed?.activeTabUUID : tabsModel.selectedTabID
+        highlightedTabID = landing.flatMap { tabIDs.contains($0) ? $0 : nil } ?? tabIDs.first
         pendingSelectedTabID = nil
         hideDeadline = 0
         lastTick = 0
@@ -393,8 +539,49 @@ final class TabExposeController {
         pendingScopeTransition = nil
         scopeTransition = nil
         previewTabIDs = []
+        if multiplexerHostTabID != nil {
+            // Keep the session's picture warm briefly for a quick re-entry.
+            muxFeed?.stop(grace: 3)
+        }
+        multiplexerAttached = false
+        showsMultiplexer = false
+        multiplexerHostTabID = nil
         observer?.tabExposeDidChangeActivity(self)
         onDidDismiss?()
+    }
+
+    /// The multiplexer page always belongs to the SELECTED tab: after any
+    /// selection change (scope paging, ⌘N, the sidebar) the feed re-binds to
+    /// that tab's terminal, and the page disappears if it has no multiplexer.
+    /// Which page is showing is the user's choice and is preserved.
+    private func rebindMultiplexerIfNeeded() {
+        guard isActive, tabsModel?.selectedTabID != multiplexerHostTabID else { return }
+        let wasShowing = showsMultiplexer
+        attachMultiplexer()
+        showsMultiplexer = wasShowing && multiplexerAttached
+    }
+
+    /// Open on the multiplexer page when the selected tab's terminal is
+    /// attached to one and the feed can serve it.
+    private func attachMultiplexer() {
+        multiplexerAttached = false
+        showsMultiplexer = false
+        // Remember the tab that was evaluated even when it has no
+        // multiplexer, so the rebind check does not re-probe every refresh.
+        multiplexerHostTabID = tabsModel?.selectedTabID
+        isAttachingMultiplexer = true
+        defer { isAttachingMultiplexer = false }
+        guard TabExposeSettings.multiplexerEnabled() else { return }
+        guard let feed = muxFeed, let terminal = multiplexerTerminal?() else { return }
+        guard feed.start(terminal: terminal) else {
+            // Whatever the feed was serving belongs to another tab now.
+            feed.stop(grace: 1)
+            return
+        }
+        // Still detecting: the page is adopted when the feed reports in.
+        guard feed.isServing else { return }
+        multiplexerAttached = true
+        showsMultiplexer = true
     }
 
     private func rubberBanded(_ p: CGFloat) -> CGFloat {
@@ -405,16 +592,24 @@ final class TabExposeController {
 
     /// Re-read the scope from the model. Tabs that left are dropped (their
     /// cells vanish); a new selection made elsewhere becomes a select.
-    func refreshScope(announce: Bool = true) {
+    /// `force` rebuilds the cells even when the scope's membership is
+    /// unchanged: the multiplexer feed revises pane layouts, titles, badges,
+    /// the session's own current tab, and its header state under stable tab
+    /// ids, and cells hold those values until they are rebuilt.
+    func refreshScope(announce: Bool = true, force: Bool = false) {
         guard let tabsModel else { return }
-        let projection = tabsModel.orderProjection
-        let ids = projection.navigationTabIDs
-        let title = projection.activeScopeTitle
+        rebindMultiplexerIfNeeded()
+        let list = scopeList()
+        let scope = list.scopes.indices.contains(list.activeIndex) ? list.scopes[list.activeIndex] : nil
+        let ids = scope?.tabIDs ?? []
+        let title = scope?.title
         let scoped: Bool = {
-            if case .flat = projection.mode { return false }
+            if list.scopes.count > 1 { return true }
+            if case .flat = tabsModel.orderProjection.mode { return false }
             return true
         }()
-        let scopeChanged = ids != tabIDs
+        let multiplexerPage = scope?.isMultiplexer ?? false
+        let scopeChanged = ids != tabIDs || multiplexerPage != showsMultiplexer
         let changed = scopeChanged || title != scopeTitle || scoped != isScoped
         // Only a real scope change pages; a stale direction must not leak
         // into a later announce.
@@ -424,15 +619,35 @@ final class TabExposeController {
         tabIDs = ids
         scopeTitle = title
         isScoped = scoped
+        showsMultiplexer = multiplexerPage
         guard isActive else { return }
 
-        if ids.isEmpty {
+        if ids.isEmpty, !multiplexerPage {
             forceHide(reason: "scopeEmpty")
             return
         }
         isRefreshingScope = true
         highlightChangedDuringRefresh = false
         defer { isRefreshingScope = false }
+        if multiplexerPage {
+            // The hero is the attached app tab; the highlight follows the
+            // session's own current tab until the user moves it.
+            heroTabID = tabsModel.selectedTabID
+            if let h = highlightedTabID, !ids.contains(h) {
+                highlightedTabID = scope?.currentID ?? ids.first
+            } else if highlightedTabID == nil {
+                highlightedTabID = scope?.currentID ?? ids.first
+            }
+            scopeTransition = scopeChanged ? transition : nil
+            if scopeTransition != nil { previewTabIDs = previousIDs }
+            if announce, changed || highlightChangedDuringRefresh || force {
+                if changed { onScopeDidChange?(ids) }
+                observer?.tabExposeDidChangeCells(self)
+            } else {
+                scopeTransition = nil
+            }
+            return
+        }
         if let selected = tabsModel.selectedTabID, selected != heroTabID, ids.contains(selected) {
             if scopeChanged || phase == .settling(target: 0) {
                 // The selection moved to another scope (group swipe, ⌘⌥[ ],
@@ -451,7 +666,7 @@ final class TabExposeController {
             heroTabID = tabsModel.selectedTabID
         }
         if let h = highlightedTabID, !ids.contains(h) {
-            highlightedTabID = ids.first
+            highlightedTabID = scope?.currentID ?? ids.first
         }
         scopeTransition = scopeChanged ? transition : nil
         if scopeTransition != nil {
@@ -459,7 +674,7 @@ final class TabExposeController {
             // the host's reconcile until the view drops it (`setScopePreview([])`).
             previewTabIDs = previousIDs
         }
-        if announce, changed || highlightChangedDuringRefresh {
+        if announce, changed || highlightChangedDuringRefresh || force {
             if changed { onScopeDidChange?(ids) }
             observer?.tabExposeDidChangeCells(self)
         } else {

--- a/rootshell/UI/Tabs/TabExposeSettings.swift
+++ b/rootshell/UI/Tabs/TabExposeSettings.swift
@@ -13,9 +13,15 @@ nonisolated enum TabExposeSettings {
     static let gestureEnabledKey = "tabExposeGestureEnabled"
     /// Title + badges under each preview.
     static let showsCaptionsKey = "tabExposeShowsCaptions"
+    /// On a tab attached to herdr / tmux / zellij, open on that session's tabs.
+    static let multiplexerEnabledKey = "tabExposeMultiplexerEnabled"
 
     static func gestureEnabled(_ defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: gestureEnabledKey) as? Bool ?? true
+    }
+
+    static func multiplexerEnabled(_ defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: multiplexerEnabledKey) as? Bool ?? true
     }
 
     static func showsCaptions(_ defaults: UserDefaults = .standard) -> Bool {

--- a/rootshell/UI/Tabs/TabExposeTrayView.swift
+++ b/rootshell/UI/Tabs/TabExposeTrayView.swift
@@ -185,17 +185,18 @@ final class TabExposeTrayView: UIScrollView {
 
     // MARK: - Per frame
 
-    /// Refresh the previews of on-screen cells only. The active page also
-    /// tells the feed which multiplexer panes are on screen so they are
-    /// fetched first.
-    func syncVisibleMirrors(reportVisibility: Bool = false) {
+    /// Refresh the previews of on-screen cells only, and report which
+    /// multiplexer panes those cells show. Empty for a page of app tabs, so
+    /// the caller can tell the feed that none of its panes are on screen.
+    @discardableResult
+    func syncVisibleMirrors() -> Set<String> {
         let visible = bounds
         var panes: Set<String> = []
         for cell in cells where cell.frame.intersects(visible) {
             cell.syncPreview()
-            if reportVisibility { panes.formUnion(cell.muxPreview.paneIDs) }
+            panes.formUnion(cell.muxPreview.paneIDs)
         }
-        if reportVisibility, let muxFeed { muxFeed.setVisiblePanes(panes) }
+        return panes
     }
 
     // MARK: - Hit testing / scrolling

--- a/rootshell/UI/Tabs/TabExposeTrayView.swift
+++ b/rootshell/UI/Tabs/TabExposeTrayView.swift
@@ -20,6 +20,8 @@ final class TabExposeTrayView: UIScrollView {
     private let headerIcon = UIImageView()
     private let headerLabel = UILabel()
     private var appearance = TabExposeView.Appearance()
+    /// Set while this page shows a multiplexer session's tabs.
+    private weak var muxFeed: MultiplexerExposeFeed?
 
     init() {
         super.init(frame: .zero)
@@ -60,16 +62,20 @@ final class TabExposeTrayView: UIScrollView {
         scopeTitle: String?,
         scoped: Bool,
         tabsModel: TabsModel,
+        muxFeed: MultiplexerExposeFeed? = nil,
         selectedID: UUID?,
         highlightedID: UUID?,
         appearance: TabExposeView.Appearance
     ) -> [TabExposeCellView] {
         self.appearance = appearance
+        self.muxFeed = muxFeed
         var byID = Dictionary(uniqueKeysWithValues: cells.map { ($0.tabID, $0) })
         var ordered: [TabExposeCellView] = []
         var entering: [TabExposeCellView] = []
         for (index, id) in ids.enumerated() {
-            guard let tab = tabsModel.tab(withID: id) else { continue }
+            let tab = tabsModel.tab(withID: id)
+            let muxTab = tab == nil ? muxFeed?.tab(uuid: id) : nil
+            guard tab != nil || muxTab != nil else { continue }
             let cell: TabExposeCellView
             if let existing = byID.removeValue(forKey: id) {
                 cell = existing
@@ -78,14 +84,25 @@ final class TabExposeTrayView: UIScrollView {
                 addSubview(cell)
                 entering.append(cell)
             }
-            cell.mirror.tab = tab
+            if let tab {
+                cell.showMirror(of: tab)
+            } else if let muxTab {
+                cell.showMultiplexerTab(muxTab, feed: muxFeed)
+            }
             cell.isCurrent = id == selectedID
             cell.isHighlighted = id == highlightedID
             // Captions only re-host when the cell's position changes (hover
-            // highlight churn must not rebuild SwiftUI per cell).
-            if cell.captionIndex != index {
+            // highlight churn must not rebuild SwiftUI per cell). A
+            // multiplexer caption also follows the tab's title.
+            let captionKey = muxTab.map { "\($0.title)|\($0.badge ?? "")" }
+            if cell.captionIndex != index || cell.captionKey != captionKey {
                 cell.captionIndex = index
-                cell.setCaption(appearance.showsCaptions ? appearance.captionProvider?(tab, index) : nil)
+                cell.captionKey = captionKey
+                if let tab {
+                    cell.setCaption(appearance.showsCaptions ? appearance.captionProvider?(tab, index) : nil)
+                } else if let muxTab {
+                    cell.setCaption(appearance.showsCaptions ? appearance.muxCaptionProvider?(muxTab, index) : nil)
+                }
             }
             ordered.append(cell)
         }
@@ -95,10 +112,19 @@ final class TabExposeTrayView: UIScrollView {
 
         header.isHidden = !scoped
         if scoped {
-            headerLabel.text = [scopeTitle, "\(ids.count)"]
-                .compactMap { $0 }
-                .joined(separator: " · ")
-            let symbol = tabsModel.isProjectGroupingActive ? "folder" : "square.grid.2x2"
+            var parts = [scopeTitle, "\(ids.count)"].compactMap { $0 }
+            if let muxFeed {
+                switch muxFeed.state {
+                case .loading:
+                    parts = [scopeTitle, String(localized: "Loading…", comment: "Exposé header while the multiplexer session is being read")].compactMap { $0 }
+                case .failed:
+                    parts.append(String(localized: "Unavailable", comment: "Exposé header when the multiplexer session stopped answering"))
+                default:
+                    break
+                }
+            }
+            headerLabel.text = parts.joined(separator: " · ")
+            let symbol = muxFeed != nil ? "rectangle.split.2x1" : (tabsModel.isProjectGroupingActive ? "folder" : "square.grid.2x2")
             headerIcon.image = UIImage(systemName: symbol)
         }
         applyAppearance(appearance)
@@ -159,12 +185,17 @@ final class TabExposeTrayView: UIScrollView {
 
     // MARK: - Per frame
 
-    /// Refresh the mirrors of on-screen cells only.
-    func syncVisibleMirrors() {
+    /// Refresh the previews of on-screen cells only. The active page also
+    /// tells the feed which multiplexer panes are on screen so they are
+    /// fetched first.
+    func syncVisibleMirrors(reportVisibility: Bool = false) {
         let visible = bounds
+        var panes: Set<String> = []
         for cell in cells where cell.frame.intersects(visible) {
-            cell.mirror.sync()
+            cell.syncPreview()
+            if reportVisibility { panes.formUnion(cell.muxPreview.paneIDs) }
         }
+        if reportVisibility, let muxFeed { muxFeed.setVisiblePanes(panes) }
     }
 
     // MARK: - Hit testing / scrolling

--- a/rootshell/UI/Tabs/TabExposeView.swift
+++ b/rootshell/UI/Tabs/TabExposeView.swift
@@ -42,6 +42,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
         var showsCaptions: Bool = true
         /// Caption for a cell (title + badges); index is the navigation position.
         var captionProvider: ((TabModel, Int) -> AnyView)?
+        /// Caption for a multiplexer tab cell.
+        var muxCaptionProvider: ((MuxTab, Int) -> AnyView)?
     }
 
     let controller: TabExposeController
@@ -77,6 +79,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
     private var scopeCommitDeadline: CFTimeInterval = 0
 
     private var heroRect: CGRect = .zero
+    /// Highlight the tray was last scrolled to; see `tabExposeDidChangeCells`.
+    private var lastScrolledHighlightID: UUID?
     private var displayLink: CADisplayLink?
     private var lastAppliedProgress: CGFloat = -1
     private var lastAppliedShift: CGFloat = 0
@@ -141,6 +145,7 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             rebuildPrimary()
             setNeedsLayout()
             layoutIfNeeded()
+            lastScrolledHighlightID = controller.highlightedTabID
             primary.scrollCellIntoView(id: controller.highlightedTabID, animated: false)
             startDisplayLink()
             if controller.wantsFirstResponderFallback {
@@ -197,7 +202,12 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             rebuildPrimary()
         }
         setNeedsLayout()
-        primary.scrollCellIntoView(id: controller.highlightedTabID, animated: true)
+        // Only a moved highlight scrolls: a multiplexer feed revising its
+        // topology announces cells too, and must not fight a scrolling finger.
+        if controller.highlightedTabID != lastScrolledHighlightID {
+            lastScrolledHighlightID = controller.highlightedTabID
+            primary.scrollCellIntoView(id: controller.highlightedTabID, animated: true)
+        }
     }
 
     // MARK: - Cells
@@ -209,7 +219,8 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
             scopeTitle: controller.scopeTitle,
             scoped: controller.isScoped,
             tabsModel: tabsModel,
-            selectedID: tabsModel.selectedTabID,
+            muxFeed: controller.showsMultiplexer ? controller.muxFeed : nil,
+            selectedID: controller.currentCellID,
             highlightedID: controller.highlightedTabID,
             appearance: appearance
         )
@@ -389,7 +400,7 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
         // A just-selected tab's host may attach a frame or two later.
         syncTerminalConcealment()
         if !hero.isHidden { hero.sync() }
-        primary.syncVisibleMirrors()
+        primary.syncVisibleMirrors(reportVisibility: true)
         companion?.syncVisibleMirrors()
     }
 
@@ -553,7 +564,8 @@ extension TabExposeView {
             scopeTitle: neighbor.title,
             scoped: true,
             tabsModel: tabsModel,
-            selectedID: tabsModel.preferredTabID(in: neighbor.tabIDs, scope: neighbor.key),
+            muxFeed: neighbor.isMultiplexer ? controller.muxFeed : nil,
+            selectedID: neighbor.currentID,
             highlightedID: nil,
             appearance: appearance
         )
@@ -699,9 +711,14 @@ extension TabExposeView {
 @MainActor
 final class TabExposeCellView: UIView {
     let tabID: UUID
+    /// Live picture of an app tab.
     let mirror = TabPreviewMirrorView()
+    /// Rendered picture of a multiplexer tab; only one of the two is showing.
+    let muxPreview = MuxTabPreviewView()
     /// Navigation index the current caption was built for; -1 = none yet.
     var captionIndex = -1
+    /// Multiplexer caption content the caption was built for.
+    var captionKey: String?
 
     private let preview = UIView()
     private let currentRing = UIView()
@@ -712,6 +729,7 @@ final class TabExposeCellView: UIView {
         didSet {
             preview.backgroundColor = previewBackgroundColor
             mirror.backgroundColor = previewBackgroundColor
+            muxPreview.backgroundColor = previewBackgroundColor
         }
     }
     var accentColor: UIColor = .systemBlue {
@@ -749,6 +767,8 @@ final class TabExposeCellView: UIView {
         preview.layer.borderColor = UIColor.white.withAlphaComponent(0.08).cgColor
         preview.isUserInteractionEnabled = false
         preview.addSubview(mirror)
+        preview.addSubview(muxPreview)
+        muxPreview.isHidden = true
         addSubview(currentRing)
         addSubview(highlightRing)
         addSubview(preview)
@@ -764,6 +784,26 @@ final class TabExposeCellView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func showMirror(of tab: TabModel) {
+        muxPreview.tab = nil
+        muxPreview.isHidden = true
+        mirror.isHidden = false
+        mirror.tab = tab
+    }
+
+    func showMultiplexerTab(_ tab: MuxTab, feed: MultiplexerExposeFeed?) {
+        mirror.tab = nil
+        mirror.isHidden = true
+        muxPreview.isHidden = false
+        muxPreview.feed = feed
+        muxPreview.tab = tab
+    }
+
+    /// Per display tick: refresh whichever picture is showing.
+    func syncPreview() {
+        if mirror.isHidden { muxPreview.sync() } else { mirror.sync() }
+    }
 
     func setCaption(_ view: AnyView?) {
         guard let view else {
@@ -787,6 +827,7 @@ final class TabExposeCellView: UIView {
         preview.frame = CGRect(origin: .zero, size: previewSize)
         preview.layer.cornerRadius = cornerRadius
         mirror.frame = preview.bounds
+        muxPreview.frame = preview.bounds
         let ringFrame = preview.frame.insetBy(dx: -3, dy: -3)
         for ring in [currentRing, highlightRing] {
             ring.frame = ringFrame

--- a/rootshell/UI/Tabs/TabExposeView.swift
+++ b/rootshell/UI/Tabs/TabExposeView.swift
@@ -400,8 +400,12 @@ final class TabExposeView: UIView, TabExposeControllerObserver {
         // A just-selected tab's host may attach a frame or two later.
         syncTerminalConcealment()
         if !hero.isHidden { hero.sync() }
-        primary.syncVisibleMirrors(reportVisibility: true)
-        companion?.syncVisibleMirrors()
+        // Both pages report: a swipe drags the multiplexer page in as the
+        // companion, and paging away from it leaves no mux cells at all —
+        // which the feed must hear, or it keeps refreshing panes nobody sees.
+        var visibleMuxPanes = primary.syncVisibleMirrors()
+        if let companion { visibleMuxPanes.formUnion(companion.syncVisibleMirrors()) }
+        controller.muxFeed?.setVisiblePanes(visibleMuxPanes)
     }
 
     private final class DisplayLinkProxy: NSObject {

--- a/rootshell/UI/Tabs/TabsModel.swift
+++ b/rootshell/UI/Tabs/TabsModel.swift
@@ -1650,6 +1650,14 @@ final class TabsModel {
     /// (hidden-only tmux groups) are skipped. nil in flat mode or when there
     /// is only one scope.
     func neighborScope(offset: Int) -> ScopeInfo? {
+        guard let list = scopeList(), list.scopes.count > 1 else { return nil }
+        let count = list.scopes.count
+        return list.scopes[((list.activeIndex + offset) % count + count) % count]
+    }
+
+    /// Every navigable scope in order with the active one's index; nil in
+    /// flat mode or when the active scope cannot be found.
+    func scopeList() -> (scopes: [ScopeInfo], activeIndex: Int)? {
         let projection = orderProjection
         let scopes: [ScopeInfo]
         let activeIndex: Int?
@@ -1669,9 +1677,8 @@ final class TabsModel {
                 .map { ScopeInfo(key: .project($0.id), title: $0.title, tabIDs: $0.tabIDs) }
             activeIndex = projection.activeProjectID.flatMap { id in scopes.firstIndex { $0.key == .project(id) } }
         }
-        guard scopes.count > 1, let activeIndex else { return nil }
-        let count = scopes.count
-        return scopes[((activeIndex + offset) % count + count) % count]
+        guard !scopes.isEmpty, let activeIndex else { return nil }
+        return (scopes, activeIndex)
     }
 
     /// Preferred tab of the neighbor scope (see `neighborScope(offset:)`).


### PR DESCRIPTION
Open the exposé on the session's own tabs when a tab is attached to
herdr, tmux, or zellij, each preview reproducing the tab's split layout
with live coloured pane content. The app tabs sit one page sideways,
reached by the same swipe that moves between groups. Picking a preview
switches the session.