### PR TITLE
Make the prompt's leading blank line configurable

### DIFF
--- a/rootshell/Core/Prompt/PromptConfig.swift
+++ b/rootshell/Core/Prompt/PromptConfig.swift
@@ -14,6 +14,7 @@ import Foundation
 struct PromptConfig: Sendable {
     var format: String
     var rightFormat: String          // Right-aligned prompt format (empty = disabled)
+    var addNewline: Bool             // Blank row between prior output and the prompt
     var transientPrompt: TransientPromptConfig
     var activePalette: String?
     var palettes: [String: [String: String]]
@@ -36,6 +37,7 @@ struct PromptConfig: Sendable {
     static func parse(from dict: [String: Any]) throws -> PromptConfig {
         let format = dict["format"] as? String ?? "$username$directory$git_branch$time\n$character"
         let rightFormat = dict["right_format"] as? String ?? ""
+        let addNewline = dict["add_newline"] as? Bool ?? true
         let palette = dict["palette"] as? String
 
         // Parse palettes
@@ -57,6 +59,7 @@ struct PromptConfig: Sendable {
         return PromptConfig(
             format: format,
             rightFormat: rightFormat,
+            addNewline: addNewline,
             transientPrompt: TransientPromptConfig.parse(from: dict["transient_prompt"] as? [String: Any] ?? [:]),
             activePalette: palette,
             palettes: palettes,

--- a/rootshell/Core/Prompt/PromptConfigManager.swift
+++ b/rootshell/Core/Prompt/PromptConfigManager.swift
@@ -173,7 +173,7 @@ final class PromptConfigManager {
             config: config,
             context: context
         )
-        result.addsLeadingSeparator = true
+        result.addsLeadingSeparator = config.addNewline
 
         // Validate we have a usable prompt
         let visible = PromptStyle.stripANSI(result.text)

--- a/rootshell/Features/LocalShell/LocalShellSession+Prompt.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+Prompt.swift
@@ -31,6 +31,15 @@ extension LocalShellSession {
         return theme
     }
 
+    // Check setting with default=true
+    var promptAddNewline: Bool {
+        let key = "promptAddNewline"
+        if UserDefaults.standard.object(forKey: key) == nil {
+            return true  // Default to a blank row above the prompt
+        }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
     // Check transient prompt setting (default: false)
     var useTransientPrompt: Bool {
         let key = "useTransientPrompt"
@@ -290,6 +299,11 @@ extension LocalShellSession {
                 result.rightPromptText = rightPrompt.text
                 result.rightPromptWidth = rightPrompt.visibleWidth
             }
+
+            result.addsLeadingSeparator = promptAddNewline
+            // PromptCache stores its own copy before these edits — write back so
+            // redraw sites (Ctrl+L) see the same separator and right prompt.
+            promptCache.cachedPrompt = result
 
             return result
         }

--- a/rootshell/Resources/promptrc_example.toml
+++ b/rootshell/Resources/promptrc_example.toml
@@ -29,6 +29,12 @@
 #   $connection_type → WiFi/Cellular/Wired icon
 
 # --- Layout ---
+
+# Leave a blank row between the previous command's output and the prompt.
+# Default is true. Set false for a condensed prompt.
+#
+# add_newline = true
+
 # Uncomment one format or write your own:
 
 # Default (Catppuccin-style powerline):

--- a/rootshell/UI/Settings/System/PromptSettingsView.swift
+++ b/rootshell/UI/Settings/System/PromptSettingsView.swift
@@ -18,6 +18,7 @@ struct PromptSettingsView: View {
     @AppStorage("clockFormat") private var clockFormat: String = "system"
     @AppStorage("useTransientPrompt") private var useTransientPrompt: Bool = false
     @AppStorage("useRightPrompt") private var useRightPrompt: Bool = false
+    @AppStorage("promptAddNewline") private var promptAddNewline: Bool = true
 
     #if !targetEnvironment(macCatalyst)
     @State private var customConfigStatus: PromptConfigStatus = .none
@@ -177,19 +178,30 @@ struct PromptSettingsView: View {
                         .disabled(hasCustomConfig && customConfigIsActive)
                         .opacity(hasCustomConfig && customConfigIsActive ? 0.5 : 1.0)
                         #endif
+
+                    Toggle("Blank Line Before Prompt", isOn: $promptAddNewline)
+                        .themedRow()
+                        #if !targetEnvironment(macCatalyst)
+                        .disabled(hasCustomConfig && customConfigIsActive)
+                        .opacity(hasCustomConfig && customConfigIsActive ? 0.5 : 1.0)
+                        #endif
                 } header: {
                     Text("Advanced")
                 } footer: {
-                    if useTransientPrompt && useRightPrompt {
-                        Text("Transient prompt replaces the full prompt with ❯ after running a command. Right prompt moves the clock to the right side of the info bar.")
-                            .font(.caption)
-                    } else if useTransientPrompt {
-                        Text("Replaces the full prompt with a minimal ❯ after running a command, reducing scrollback clutter.")
-                            .font(.caption)
-                    } else if useRightPrompt {
-                        Text("Moves the clock from the info bar to the right side, making the left prompt shorter.")
-                            .font(.caption)
+                    VStack(alignment: .leading, spacing: 4) {
+                        if useTransientPrompt && useRightPrompt {
+                            Text("Transient prompt replaces the full prompt with ❯ after running a command. Right prompt moves the clock to the right side of the info bar.")
+                        } else if useTransientPrompt {
+                            Text("Replaces the full prompt with a minimal ❯ after running a command, reducing scrollback clutter.")
+                        } else if useRightPrompt {
+                            Text("Moves the clock from the info bar to the right side, making the left prompt shorter.")
+                        }
+
+                        if !promptAddNewline {
+                            Text("Draws the prompt directly under the previous command's output instead of leaving a blank row.")
+                        }
                     }
+                    .font(.caption)
                 }
             }
 


### PR DESCRIPTION
Adds a top-level add_newline key to .promptrc.toml (default true, matching Starship) and a "Blank Line Before Prompt" toggle in Settings for the built-in themes. The plain "$ " prompt is unchanged.

Refines #303.