### PR TITLE
Add Liquid Glass blur style on macOS 26

### DIFF
--- a/rootshell/Core/Backup/BackupImporter.swift
+++ b/rootshell/Core/Backup/BackupImporter.swift
@@ -693,6 +693,10 @@ enum BackupImporter {
         if UserDefaults.standard.object(forKey: "blurEnabled") != nil {
             transparency.blurEnabled = UserDefaults.standard.bool(forKey: "blurEnabled")
         }
+        if let styleRaw = UserDefaults.standard.string(forKey: "blurStyle"),
+           let style = TransparencyManager.BlurStyle(rawValue: styleRaw) {
+            transparency.blurStyle = style
+        }
         if UserDefaults.standard.object(forKey: "pinnedSidebarTransparencyEnabled") != nil {
             transparency.pinnedSidebarTransparencyEnabled = UserDefaults.standard.bool(
                 forKey: "pinnedSidebarTransparencyEnabled"

--- a/rootshell/Core/Ghostty/GhosttyApp.swift
+++ b/rootshell/Core/Ghostty/GhosttyApp.swift
@@ -1310,9 +1310,27 @@ extension Ghostty {
         /// set on a valid window, so WindowAccessor can call this the moment
         /// it claims a freshly created NSWindow.
         func applyWindowBlur(to nsWindow: NSObject) {
-            let opacity = TransparencyManager.shared.backgroundOpacity
+            // The NSApplication.windows sweep includes our own glass backdrops.
+            guard !isGlassBackdropWindow(nsWindow) else { return }
+            let manager = TransparencyManager.shared
+            let opacity = manager.backgroundOpacity
+            let style = manager.effectiveBlurStyle
+
+            if style != .standard, opacity < 1.0 {
+                removeVisualEffectBlurFromWindow(nsWindow)
+                if addGlassEffectViewToWindow(nsWindow, style: style) {
+                    // Standalone: libghostty clears the CGS radius for glass styles.
+                    if !TransparencyManager.useSandboxBlur, let app = self.app {
+                        ghostty_set_window_background_blur(app, Unmanaged.passUnretained(nsWindow).toOpaque())
+                    }
+                    return
+                }
+                // NSGlassEffectView unavailable: fall through to standard.
+            }
+
+            removeGlassEffectViewFromWindow(nsWindow)
             if TransparencyManager.useSandboxBlur {
-                if opacity < 1.0 && TransparencyManager.shared.blurEnabled {
+                if opacity < 1.0 && manager.blurEnabled {
                     addVisualEffectBlurToWindow(nsWindow)
                 } else {
                     removeVisualEffectBlurFromWindow(nsWindow)
@@ -1323,20 +1341,192 @@ extension Ghostty {
             }
         }
 
+        // MARK: - Liquid Glass (macOS 26+, public API)
+
+        /// Glass lives in a borderless child NSWindow ordered directly behind
+        /// the terminal window, replacing the CGS blur. Catalyst's hosted UIKit
+        /// tree gets treated as foreground by an in-window glass pass (it
+        /// refracts the terminal), whereas a lower window can only sample the
+        /// desktop. The terminal keeps drawing its theme background at the
+        /// configured opacity, so the window's alpha (and shadow) is unchanged.
+        private final class GlassBackdrop {
+            let window: NSObject
+            let glassView: NSObject
+            var observers: [NSObjectProtocol] = []
+            init(window: NSObject, glassView: NSObject) {
+                self.window = window
+                self.glassView = glassView
+            }
+        }
+
+        private var glassBackdrops: [ObjectIdentifier: GlassBackdrop] = [:]
+
+        private func isGlassBackdropWindow(_ window: NSObject) -> Bool {
+            glassBackdrops.values.contains { $0.window === window }
+        }
+
+        /// Attach (or update) the glass backdrop behind `window`.
+        /// Returns false when NSGlassEffectView is unavailable (pre-macOS 26).
+        @discardableResult
+        private func addGlassEffectViewToWindow(_ window: NSObject, style: TransparencyManager.BlurStyle) -> Bool {
+            guard let glassClass = NSClassFromString("NSGlassEffectView") as? NSObject.Type,
+                  let windowClass = NSClassFromString("NSWindow") as? NSObject.Type else {
+                return false
+            }
+            // A child ordered in before the parent is on screen would show alone;
+            // WindowAccessor re-asserts blur once the window becomes visible.
+            guard (window.value(forKey: "isVisible") as? Bool) == true else { return true }
+
+            let key = ObjectIdentifier(window)
+            let backdrop: GlassBackdrop
+            if let existing = glassBackdrops[key] {
+                backdrop = existing
+            } else {
+                guard let frame = window.value(forKey: "frame") as? CGRect,
+                      let child = Self.makeBorderlessWindow(windowClass, frame: frame),
+                      let glassView = Self.makeView(glassClass, frame: CGRect(origin: .zero, size: frame.size)) else {
+                    logger.warning("Failed to create glass backdrop window")
+                    return false
+                }
+                glassView.setValue(18, forKey: "autoresizingMask") // width | height sizable
+                child.setValue(glassView, forKey: "contentView")
+                // Dark-appearance "regular" glass is a dark smoky material that
+                // hides the desktop; light appearance renders bright frosted
+                // glass that passes the desktop through like the CGS blur.
+                if let appearanceClass = NSClassFromString("NSAppearance") as? NSObject.Type,
+                   let aqua = appearanceClass.perform(
+                       NSSelectorFromString("appearanceNamed:"), with: "NSAppearanceNameAqua"
+                   )?.takeUnretainedValue() {
+                    child.setValue(aqua, forKey: "appearance")
+                }
+
+                let addSelector = NSSelectorFromString("addChildWindow:ordered:")
+                typealias AddChildFunction = @convention(c) (NSObject, Selector, NSObject, Int) -> Void
+                let addChild = unsafeBitCast(window.method(for: addSelector), to: AddChildFunction.self)
+                addChild(window, addSelector, child, -1) // NSWindowBelow
+
+                backdrop = GlassBackdrop(window: child, glassView: glassView)
+                let center = NotificationCenter.default
+                for name in ["NSWindowDidResizeNotification", "NSWindowDidMoveNotification",
+                             "NSWindowDidEnterFullScreenNotification", "NSWindowDidExitFullScreenNotification"] {
+                    backdrop.observers.append(center.addObserver(
+                        forName: Notification.Name(name), object: window, queue: .main
+                    ) { [weak self, weak window] _ in
+                        guard let window else { return }
+                        Task { @MainActor in self?.syncGlassBackdrop(to: window) }
+                    })
+                }
+                backdrop.observers.append(center.addObserver(
+                    forName: Notification.Name("NSWindowWillCloseNotification"), object: window, queue: .main
+                ) { [weak self, weak window] _ in
+                    guard let window else { return }
+                    Task { @MainActor in self?.removeGlassEffectViewFromWindow(window) }
+                })
+                glassBackdrops[key] = backdrop
+            }
+
+            // NSGlassEffectView.Style: regular = 0, clear = 1
+            backdrop.glassView.setValue(style == .glassClear ? 1 : 0, forKey: "style")
+            syncGlassBackdrop(to: window)
+            return true
+        }
+
+        /// Match the backdrop's frame and corner radius to its parent.
+        private func syncGlassBackdrop(to window: NSObject) {
+            guard let backdrop = glassBackdrops[ObjectIdentifier(window)],
+                  let frame = window.value(forKey: "frame") as? CGRect else { return }
+
+            let setFrameSelector = NSSelectorFromString("setFrame:display:")
+            typealias SetFrameFunction = @convention(c) (NSObject, Selector, CGRect, Bool) -> Void
+            let setFrame = unsafeBitCast(backdrop.window.method(for: setFrameSelector), to: SetFrameFunction.self)
+            setFrame(backdrop.window, setFrameSelector, frame, true)
+
+            // Rounded corners are the parent's; full screen has none. Same
+            // private `_cornerRadius` read ghostty uses for its glass shape.
+            let styleMask = (window.value(forKey: "styleMask") as? UInt) ?? 0
+            let isFullScreen = styleMask & (1 << 14) != 0
+            var radius: CGFloat = 0
+            if !isFullScreen, window.responds(to: NSSelectorFromString("_cornerRadius")),
+               let r = window.value(forKey: "_cornerRadius") as? CGFloat {
+                radius = r
+            }
+            backdrop.glassView.setValue(radius, forKey: "cornerRadius")
+        }
+
+        private func removeGlassEffectViewFromWindow(_ window: NSObject) {
+            let key = ObjectIdentifier(window)
+            guard let backdrop = glassBackdrops.removeValue(forKey: key) else { return }
+            backdrop.observers.forEach { NotificationCenter.default.removeObserver($0) }
+            if window.responds(to: NSSelectorFromString("removeChildWindow:")) {
+                window.perform(NSSelectorFromString("removeChildWindow:"), with: backdrop.window)
+            }
+            backdrop.window.perform(NSSelectorFromString("orderOut:"), with: nil)
+        }
+
+        /// Borderless, transparent, click-through NSWindow via the ObjC runtime.
+        private static func makeBorderlessWindow(_ windowClass: NSObject.Type, frame: CGRect) -> NSObject? {
+            guard let allocated = windowClass.perform(NSSelectorFromString("alloc"))?.takeUnretainedValue() as? NSObject else {
+                return nil
+            }
+            let initSelector = NSSelectorFromString("initWithContentRect:styleMask:backing:defer:")
+            typealias WindowInitFunction = @convention(c) (NSObject, Selector, CGRect, UInt, UInt, Bool) -> NSObject
+            let initFunc = unsafeBitCast(allocated.method(for: initSelector), to: WindowInitFunction.self)
+            // styleMask 0 = borderless, backing 2 = buffered
+            let window = initFunc(allocated, initSelector, frame, 0, 2, false)
+            window.setValue(false, forKey: "opaque")
+            window.setValue(false, forKey: "hasShadow")
+            window.setValue(true, forKey: "ignoresMouseEvents")
+            window.setValue(false, forKey: "releasedWhenClosed")
+            if let nsColorClass = NSClassFromString("NSColor") as? NSObject.Type,
+               let clear = nsColorClass.value(forKey: "clearColor") {
+                window.setValue(clear, forKey: "backgroundColor")
+            }
+            return window
+        }
+
+        private static func makeView(_ viewClass: NSObject.Type, frame: CGRect) -> NSObject? {
+            guard let allocated = viewClass.perform(NSSelectorFromString("alloc"))?.takeUnretainedValue() as? NSObject else {
+                return nil
+            }
+            let initSelector = NSSelectorFromString("initWithFrame:")
+            typealias InitFunction = @convention(c) (NSObject, Selector, CGRect) -> NSObject
+            return unsafeBitCast(allocated.method(for: initSelector), to: InitFunction.self)(allocated, initSelector, frame)
+        }
+
+        /// Current theme background parsed from its hex string.
+        private static func themeBackgroundRGB() -> (r: CGFloat, g: CGFloat, b: CGFloat)? {
+            guard let hex = ThemeManager.shared.currentThemeInfo?.colors.background else { return nil }
+            let cleaned = hex.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "#", with: "")
+            var rgb: UInt64 = 0
+            guard Scanner(string: cleaned).scanHexInt64(&rgb) else { return nil }
+            return (
+                CGFloat((rgb & 0xFF0000) >> 16) / 255.0,
+                CGFloat((rgb & 0x00FF00) >> 8) / 255.0,
+                CGFloat(rgb & 0x0000FF) / 255.0
+            )
+        }
+
+        /// Current theme background as an NSColor built via the ObjC runtime.
+        static func themeBackgroundNSColor(alpha: CGFloat) -> NSObject? {
+            guard let (r, g, b) = Self.themeBackgroundRGB(),
+                  let nsColorClass = NSClassFromString("NSColor") as? NSObject.Type else { return nil }
+            let colorSelector = NSSelectorFromString("colorWithRed:green:blue:alpha:")
+            guard nsColorClass.responds(to: colorSelector) else { return nil }
+            typealias ColorFunction = @convention(c) (AnyClass, Selector, CGFloat, CGFloat, CGFloat, CGFloat) -> NSObject
+            let colorFunc = unsafeBitCast(nsColorClass.method(for: colorSelector), to: ColorFunction.self)
+            return colorFunc(nsColorClass, colorSelector, r, g, b, alpha)
+        }
+
         // MARK: - Private API Implementation (non-sandbox)
 
         /// Apply blur using private CGS API (non-sandbox builds only)
         private func applyWindowBlurPrivateAPI() {
             guard self.app != nil else { return }
 
-            let opacity = TransparencyManager.shared.backgroundOpacity
             let blurRadius = TransparencyManager.shared.backgroundBlurRadius
 
-            // Only apply blur if opacity < 1.0 (matching macOS behavior)
-            guard opacity < 1.0 else {
-                logger.info("Skipping blur application: opacity is 1.0 (fully opaque)")
-                return
-            }
+            // No opacity gate: applyWindowBlur(to:) must still run when opaque
+            // so glass views get removed.
 
             // Get NSApplication.sharedApplication
             guard let nsAppClass = NSClassFromString("NSApplication") as? NSObject.Type,

--- a/rootshell/Core/Ghostty/GhosttyConfig.swift
+++ b/rootshell/Core/Ghostty/GhosttyConfig.swift
@@ -242,9 +242,12 @@ extension Ghostty {
         private static func effectiveTransparencySettings() -> (opacity: Double, blur: Int) {
 #if targetEnvironment(macCatalyst)
             let transparencyManager = TransparencyManager.shared
+            // Glass styles blur via an NSGlassEffectView window behind the
+            // terminal, so the CGS radius must be 0. The renderer still draws
+            // the theme background at `opacity`; the glass shows through it.
             return (
                 opacity: transparencyManager.backgroundOpacity,
-                blur: Int(transparencyManager.backgroundBlurRadius)
+                blur: transparencyManager.usesGlass ? 0 : Int(transparencyManager.backgroundBlurRadius)
             )
 #else
             return (opacity: 1.0, blur: 0)

--- a/rootshell/Core/Migration/GhosttyConfigImporter.swift
+++ b/rootshell/Core/Migration/GhosttyConfigImporter.swift
@@ -524,7 +524,15 @@ final class GhosttyConfigImporter {
 
         case "background-blur":
             #if targetEnvironment(macCatalyst)
-            if let d = parseBlurValue(value) {
+            if let style = parseGlassStyle(value) {
+                plan.recognized.append(
+                    RecognizedChange(
+                        category: .transparency, key: key,
+                        summary: String(localized: "Background blur → \(style.title)", comment: "Migration preview"),
+                        payload: .backgroundBlurStyle(style.rawValue)
+                    )
+                )
+            } else if let d = parseBlurValue(value) {
                 let label: String = (d > 0)
                     ? String(localized: "Background blur → \(Int(d))", comment: "Migration preview")
                     : String(localized: "Background blur → off", comment: "Migration preview")
@@ -808,6 +816,7 @@ final class GhosttyConfigImporter {
 
         case .backgroundBlur(let radius):
             #if targetEnvironment(macCatalyst)
+            TransparencyManager.shared.blurStyle = .standard
             if let r = radius {
                 TransparencyManager.shared.blurEnabled = true
                 TransparencyManager.shared.backgroundBlurRadius = r
@@ -816,6 +825,15 @@ final class GhosttyConfigImporter {
             }
             #else
             _ = radius
+            #endif
+
+        case .backgroundBlurStyle(let raw):
+            #if targetEnvironment(macCatalyst)
+            if let style = TransparencyManager.BlurStyle(rawValue: raw) {
+                TransparencyManager.shared.blurStyle = style
+            }
+            #else
+            _ = raw
             #endif
 
         case .copyOnSelect(let on):
@@ -908,6 +926,13 @@ final class GhosttyConfigImporter {
         case "true", "yes", "on", "1": return true
         case "false", "no", "off", "0": return false
         default: return nil
+        }
+    }
+
+    /// `background-blur = macos-glass-regular|macos-glass-clear`.
+    private static func parseGlassStyle(_ raw: String) -> TransparencyManager.BlurStyle? {
+        TransparencyManager.BlurStyle.allCases.first {
+            $0.ghosttyConfigValue == raw.trimmingCharacters(in: .whitespaces)
         }
     }
 

--- a/rootshell/Core/Migration/MigrationModels.swift
+++ b/rootshell/Core/Migration/MigrationModels.swift
@@ -85,6 +85,8 @@ enum RecognizedPayload: Hashable {
     case backgroundOpacity(Double)
     /// `nil` = blur off, `Double` = radius (Catalyst-only).
     case backgroundBlur(radius: Double?)
+    /// `TransparencyManager.BlurStyle` raw value for `macos-glass-*` (Catalyst-only).
+    case backgroundBlurStyle(String)
 
     case copyOnSelect(Bool)
     /// Stored verbatim in UserDefaults; rootshell expects `on`/`off`/`left`/`right`.

--- a/rootshell/UI/Settings/Appearance/AppearanceDetailSettingsViews.swift
+++ b/rootshell/UI/Settings/Appearance/AppearanceDetailSettingsViews.swift
@@ -161,8 +161,20 @@ struct TransparencySettingsView: View {
                 .padding(.vertical, 4)
                 .themedRow()
 
-                // Show different blur controls based on sandbox mode
-                if TransparencyManager.useSandboxBlur {
+                if TransparencyManager.isGlassAvailable {
+                    Picker("Blur Style", selection: $transparencyManager.blurStyle) {
+                        ForEach(TransparencyManager.BlurStyle.allCases) { style in
+                            Text(style.title).tag(style)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                    .themedRow()
+                }
+
+                // Glass styles blur on their own; radius/toggle only apply to Standard.
+                if transparencyManager.usesGlass {
+                    EmptyView()
+                } else if TransparencyManager.useSandboxBlur {
                     // Sandbox mode: simple toggle (NSVisualEffectView doesn't support custom radius)
                     Toggle("Background Blur", isOn: $transparencyManager.blurEnabled)
                         .padding(.vertical, 4)
@@ -193,7 +205,10 @@ struct TransparencySettingsView: View {
             } header: {
                 Text("Window Transparency")
             } footer: {
-                if TransparencyManager.useSandboxBlur {
+                if transparencyManager.usesGlass {
+                    Text("Controls window transparency. Liquid Glass renders the desktop behind the window through a glass material tinted with the theme background.")
+                        .font(.caption)
+                } else if TransparencyManager.useSandboxBlur {
                     Text("Controls window transparency and blur. Blur uses system vibrancy effect.")
                         .font(.caption)
                 } else {

--- a/rootshell/UI/Settings/SettingsView.swift
+++ b/rootshell/UI/Settings/SettingsView.swift
@@ -755,7 +755,7 @@ struct SettingsSearchEntry: Identifiable, Hashable {
                 subtitle: String(localized: "Appearance"),
                 systemImage: "slider.horizontal.below.rectangle",
                 action: .destination(.transparency),
-                keywords: ["opacity", "blur"],
+                keywords: ["opacity", "blur", "glass"],
                 isSuggested: false
             ),
             .init(

--- a/rootshell/UI/Window/TransparencyManager.swift
+++ b/rootshell/UI/Window/TransparencyManager.swift
@@ -20,13 +20,49 @@ final class TransparencyManager {
     static let useSandboxBlur = false
     #endif
 
+    /// How the window background behind the terminal is blurred.
+    enum BlurStyle: String, CaseIterable, Identifiable {
+        /// CGS radius blur (Standalone) or NSVisualEffectView (App Store).
+        case standard
+        /// macOS 26 Liquid Glass (NSGlassEffectView).
+        case glassRegular
+        case glassClear
+
+        var id: String { rawValue }
+
+        /// Value emitted for ghostty's `background-blur`; nil means numeric radius.
+        var ghosttyConfigValue: String? {
+            switch self {
+            case .standard: return nil
+            case .glassRegular: return "macos-glass-regular"
+            case .glassClear: return "macos-glass-clear"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .standard: return String(localized: "Standard")
+            case .glassRegular: return String(localized: "Glass")
+            case .glassClear: return String(localized: "Clear Glass")
+            }
+        }
+    }
+
+    /// Liquid Glass needs macOS 26; Catalyst's version tracks macOS 26 exactly.
+    static var isGlassAvailable: Bool {
+        if #available(macCatalyst 26.0, *) { return true }
+        return false
+    }
+
     private static let backgroundOpacityKey = "backgroundOpacity"
     private static let backgroundBlurRadiusKey = "backgroundBlurRadius"
     private static let blurEnabledKey = "blurEnabled"
+    private static let blurStyleKey = "blurStyle"
     private static let pinnedSidebarTransparencyEnabledKey = "pinnedSidebarTransparencyEnabled"
     private static let defaultBackgroundOpacity: Double = 0.92
     private static let defaultBackgroundBlurRadius: Double = 30.0
     private static let defaultBlurEnabled: Bool = true
+    private static let defaultBlurStyle: BlurStyle = .standard
     private static let defaultPinnedSidebarTransparencyEnabled: Bool = false
 
     /// Current background opacity (0.0 = fully transparent, 1.0 = opaque)
@@ -56,6 +92,22 @@ final class TransparencyManager {
             transparencyDidChange.send()
         }
     }
+
+    /// Stored blur style preference. Consumers should read `effectiveBlurStyle`.
+    var blurStyle: BlurStyle {
+        didSet {
+            guard blurStyle != oldValue else { return }
+            UserDefaults.standard.set(blurStyle.rawValue, forKey: Self.blurStyleKey)
+            transparencyDidChange.send()
+        }
+    }
+
+    /// `blurStyle` downgraded to `.standard` where glass isn't available.
+    var effectiveBlurStyle: BlurStyle {
+        Self.isGlassAvailable ? blurStyle : .standard
+    }
+
+    var usesGlass: Bool { effectiveBlurStyle != .standard }
 
     /// Whether the pinned vertical tab sidebar uses the window's background
     /// opacity instead of its normal opaque fill.
@@ -103,6 +155,9 @@ final class TransparencyManager {
             self.blurEnabled = Self.defaultBlurEnabled
         }
 
+        self.blurStyle = UserDefaults.standard.string(forKey: Self.blurStyleKey)
+            .flatMap(BlurStyle.init(rawValue:)) ?? Self.defaultBlurStyle
+
         if UserDefaults.standard.object(forKey: Self.pinnedSidebarTransparencyEnabledKey) != nil {
             self.pinnedSidebarTransparencyEnabled = UserDefaults.standard.bool(
                 forKey: Self.pinnedSidebarTransparencyEnabledKey
@@ -132,6 +187,7 @@ final class TransparencyManager {
         backgroundOpacity = Self.defaultBackgroundOpacity
         backgroundBlurRadius = Self.defaultBackgroundBlurRadius
         blurEnabled = Self.defaultBlurEnabled
+        blurStyle = Self.defaultBlurStyle
         pinnedSidebarTransparencyEnabled = Self.defaultPinnedSidebarTransparencyEnabled
     }
 

--- a/rootshell/UI/Window/WindowAccessor.swift
+++ b/rootshell/UI/Window/WindowAccessor.swift
@@ -70,6 +70,7 @@ extension WindowAccessor {
 private struct WindowConfigSignature: Equatable {
     var shouldApplyTransparency: Bool
     var opacity: CGFloat
+    var usesGlass: Bool
     var themeBackgroundHex: String
     var tabCount: Int
     var tabsInTitlebar: Bool
@@ -433,6 +434,7 @@ private class TransparentWindowView: UIView {
         return WindowConfigSignature(
             shouldApplyTransparency: hasActiveSurfaces && opacity < 1.0,
             opacity: opacity,
+            usesGlass: TransparencyManager.shared.usesGlass,
             themeBackgroundHex: ThemeManager.shared.currentThemeInfo?.colors.background ?? "",
             tabCount: SessionTracker.shared.tabCount(forSceneSessionId: sceneSessionId),
             tabsInTitlebar: tabsInTitlebar,
@@ -1362,34 +1364,11 @@ private class TransparentWindowView: UIView {
         )
 
         // Get the theme background color for the title bar
-        if let themeColors = ThemeManager.shared.currentThemeInfo?.colors,
-           let nsColorClass = NSClassFromString("NSColor") as? NSObject.Type {
-            // Parse the hex color and create NSColor
-            let hexColor = themeColors.background.trimmingCharacters(in: .whitespaces)
-                .replacingOccurrences(of: "#", with: "")
-
-            var rgb: UInt64 = 0
-            if Scanner(string: hexColor).scanHexInt64(&rgb) {
-                let r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
-                let g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
-                let b = CGFloat(rgb & 0x0000FF) / 255.0
-                let opacity = TransparencyManager.shared.backgroundOpacity
-
-                // Create NSColor with colorWithRed:green:blue:alpha:
-                let colorSelector = NSSelectorFromString("colorWithRed:green:blue:alpha:")
-                if nsColorClass.responds(to: colorSelector) {
-                    let colorMethod = nsColorClass.method(for: colorSelector)
-                    typealias ColorFunction = @convention(c) (AnyClass, Selector, CGFloat, CGFloat, CGFloat, CGFloat) -> NSObject
-                    let colorFunc = unsafeBitCast(colorMethod, to: ColorFunction.self)
-                    let titlebarColor = colorFunc(nsColorClass, colorSelector, r, g, b, opacity)
-
-                    // Try to set the titlebar background color
-                    // This works on some macOS versions
-                    if window.responds(to: NSSelectorFromString("setTitlebarColor:")) {
-                        window.perform(NSSelectorFromString("setTitlebarColor:"), with: titlebarColor)
-                    }
-                }
-            }
+        if let titlebarColor = Ghostty.App.themeBackgroundNSColor(
+            alpha: TransparencyManager.shared.backgroundOpacity
+        ), window.responds(to: NSSelectorFromString("setTitlebarColor:")) {
+            // Works on some macOS versions only
+            window.perform(NSSelectorFromString("setTitlebarColor:"), with: titlebarColor)
         }
     }
 


### PR DESCRIPTION
Blur Style setting with Standard / Glass / Clear Glass. Glass styles disable the CGS radius and put an NSGlassEffectView in a child window behind the terminal window.