### PR TITLE
Keep hidden keyboard stable across tab swipes and overlays

### DIFF
--- a/rootshell/Features/Effects/EffectManager.swift
+++ b/rootshell/Features/Effects/EffectManager.swift
@@ -357,6 +357,14 @@ final class EffectManager {
         applyKeyboardFrame(KeyboardTracker.shared.keyboardFrame)
     }
 
+    /// Re-adopt the tracker's frame once a preservation latch drops. While
+    /// latched, sub-threshold frames are rejected here but a toolbar-only
+    /// latch accepts them in the tracker, so the two can diverge when an
+    /// overlay's own field showed a full keyboard mid-trip.
+    func resyncKeyboardFrameAfterPreservation() {
+        updateKeyboardHeightFromTracker()
+    }
+
     /// Apply a keyboard frame update, deduping each `@Published` set against
     /// the current value. `@Published` fires `objectWillChange` on every
     /// assignment, equal-or-not, so unconditional writes during keyboard

--- a/rootshell/UI/Keyboard/KeyboardTracker.swift
+++ b/rootshell/UI/Keyboard/KeyboardTracker.swift
@@ -38,6 +38,28 @@ class KeyboardTracker {
     @MainActor
     private(set) var keyboardFrame: CGRect = .zero
 
+    /// True while UIKit has any input view on screen, including a toolbar-only
+    /// or accessory-only layout below the software-keyboard threshold. Those
+    /// layouts hide and re-show through the same keyboard notifications and
+    /// safe-area shuffle as a full keyboard, so the preservation latches must
+    /// cover them too.
+    @MainActor
+    var isAnyInputViewPresented: Bool {
+        isSoftwareKeyboardVisible || visibleKeyboardHeight(for: keyboardFrame) > 0
+    }
+
+    /// Set when a latch armed for a sub-threshold layout. Any visible frame
+    /// then counts as the layout returning, so the re-shown toolbar is not
+    /// mistaken for a still-hidden keyboard and committed away on release.
+    @MainActor private var overlayPreservationCoversInputViewOnly = false
+    @MainActor private var appTransitionPreservationCoversInputViewOnly = false
+
+    @MainActor
+    private func isPreservedLayoutFrameVisible(_ frame: CGRect, inputViewOnly: Bool) -> Bool {
+        if inputViewOnly { return visibleKeyboardHeight(for: frame) > 0 }
+        return isSoftwareKeyboardFrameVisible(frame)
+    }
+
     /// True while the keyboard show/hide animation is in progress
     @MainActor
     private(set) var isKeyboardAnimating: Bool = false
@@ -377,9 +399,10 @@ class KeyboardTracker {
 
     @MainActor
     private func beginAppTransitionKeyboardPreservationIfNeeded(autoClearIfAppStaysActive: Bool) {
-        guard isSoftwareKeyboardVisible else { return }
+        guard isAnyInputViewPresented else { return }
         appTransitionKeyboardPreservationTask?.cancel()
         appTransitionKeyboardPreservationTask = nil
+        appTransitionPreservationCoversInputViewOnly = !isSoftwareKeyboardVisible
         isPreservingSoftwareKeyboardForAppTransition = true
         ignoredHiddenKeyboardFrameDuringPreservation = false
         setKeyboardAnimating(false)
@@ -431,9 +454,13 @@ class KeyboardTracker {
             }
         }
         isPreservingSoftwareKeyboardForAppTransition = false
+        appTransitionPreservationCoversInputViewOnly = false
         ignoredHiddenKeyboardFrameDuringPreservation = false
         appTransitionKeyboardPreservationTask?.cancel()
         appTransitionKeyboardPreservationTask = nil
+        if !isPreservingSoftwareKeyboardForOverlay {
+            EffectManager.shared.resyncKeyboardFrameAfterPreservation()
+        }
     }
 
     // MARK: - Overlay Keyboard Preservation
@@ -459,9 +486,10 @@ class KeyboardTracker {
 
     /// Arm the overlay preservation latch before an overlay-driven first
     /// responder resign hides the software keyboard. Idempotent; no-op when
-    /// no software keyboard is up (nothing to preserve — hardware keyboard
-    /// and pinned-hidden layouts are covered by the terminal's
-    /// toolbar-reserve latch instead). A begin from a second window while
+    /// no input view is up (nothing to preserve). Toolbar-only and
+    /// accessory-only layouts arm it too: the terminal's toolbar-reserve latch
+    /// keeps the padding, but only this latch drops the size and bottom-inset
+    /// pushes from the safe-area shuffle. A begin from a second window while
     /// armed transfers ownership to it (latest wins). The caller passes its
     /// own window — never derived from isKeyWindow scans, which are
     /// unreliable on iPadOS multi-window (see WindowSceneReporter).
@@ -477,7 +505,8 @@ class KeyboardTracker {
             overlayOwnerWindowWasCaptured = window != nil
             return
         }
-        guard isSoftwareKeyboardVisible else { return }
+        guard isAnyInputViewPresented else { return }
+        overlayPreservationCoversInputViewOnly = !isSoftwareKeyboardVisible
         isPreservingSoftwareKeyboardForOverlay = true
         ignoredHiddenKeyboardFrameDuringOverlayPreservation = false
         overlayKeyboardPreservationOwner = owner
@@ -536,12 +565,14 @@ class KeyboardTracker {
     @MainActor
     private func releaseOverlayKeyboardPreservationNow() {
         isPreservingSoftwareKeyboardForOverlay = false
+        overlayPreservationCoversInputViewOnly = false
         ignoredHiddenKeyboardFrameDuringOverlayPreservation = false
         overlayKeyboardPreservationOwner = nil
         overlayKeyboardPreservationOwnerWindow = nil
         overlayOwnerWindowWasCaptured = false
         overlayKeyboardPreservationReleaseTask?.cancel()
         overlayKeyboardPreservationReleaseTask = nil
+        EffectManager.shared.resyncKeyboardFrameAfterPreservation()
         // Terminals drop size pushes while the latch is armed (the container
         // safe-area shuffle when the keyboard physically hides/reshows wobbles
         // their bounds by the home-indicator inset). UIKit never re-fires a
@@ -1095,7 +1126,7 @@ class KeyboardTracker {
             releaseOverlayKeyboardPreservationNow()
             return
         }
-        if isSoftwareKeyboardFrameVisible(keyboardFrameEnd) {
+        if isPreservedLayoutFrameVisible(keyboardFrameEnd, inputViewOnly: overlayPreservationCoversInputViewOnly) {
             // Mirrors updateKeyboardFrame's visible-frame branch: refresh the
             // latched geometry without ending the latch. Release stays with the
             // other handlers so this one has no release path of its own.
@@ -1119,7 +1150,7 @@ class KeyboardTracker {
 
         if overlayKeyboardPreservationIsActive() {
             if overlayKeyboardPreservationOwnerWindowIsActive {
-                guard isSoftwareKeyboardFrameVisible(keyboardFrameEnd) else {
+                guard isPreservedLayoutFrameVisible(keyboardFrameEnd, inputViewOnly: overlayPreservationCoversInputViewOnly) else {
                     ignoredHiddenKeyboardFrameDuringOverlayPreservation = true
                     return
                 }
@@ -1135,7 +1166,7 @@ class KeyboardTracker {
         }
 
         if isPreservingSoftwareKeyboardForAppTransition {
-            guard isSoftwareKeyboardFrameVisible(keyboardFrameEnd) else {
+            guard isPreservedLayoutFrameVisible(keyboardFrameEnd, inputViewOnly: appTransitionPreservationCoversInputViewOnly) else {
                 ignoredHiddenKeyboardFrameDuringPreservation = true
                 Ghostty.logger.debug("KeyboardTracker: Ignored transient app-transition keyboard frame")
                 return
@@ -1197,7 +1228,7 @@ class KeyboardTracker {
             ignoredHiddenKeyboardFrameDuringOverlayPreservation = true
             return true
         }
-        let shouldPreserve = !isSoftwareKeyboardFrameVisible(keyboardFrameEnd)
+        let shouldPreserve = !isPreservedLayoutFrameVisible(keyboardFrameEnd, inputViewOnly: overlayPreservationCoversInputViewOnly)
         if shouldPreserve {
             ignoredHiddenKeyboardFrameDuringOverlayPreservation = true
         }
@@ -1207,7 +1238,7 @@ class KeyboardTracker {
     @MainActor
     private func shouldPreserveKeyboardStateForAppTransition(_ notification: Notification) -> Bool {
         if !isPreservingSoftwareKeyboardForAppTransition {
-            guard isSoftwareKeyboardVisible,
+            guard isAnyInputViewPresented,
                   isAppOrSceneTransitioningAway else {
                 return false
             }
@@ -1219,7 +1250,7 @@ class KeyboardTracker {
             ignoredHiddenKeyboardFrameDuringPreservation = true
             return true
         }
-        let shouldPreserve = !isSoftwareKeyboardFrameVisible(keyboardFrameEnd)
+        let shouldPreserve = !isPreservedLayoutFrameVisible(keyboardFrameEnd, inputViewOnly: appTransitionPreservationCoversInputViewOnly)
         if shouldPreserve {
             ignoredHiddenKeyboardFrameDuringPreservation = true
         }

--- a/rootshell/UI/Keyboard/SoftwareKeyboardHideIntent.swift
+++ b/rootshell/UI/Keyboard/SoftwareKeyboardHideIntent.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+/// User intent to keep the software keyboard hidden, scoped to a window so
+/// tab switches and overlay round trips inside that window re-apply it
+/// instead of re-showing the keyboard. Session-only.
+enum SoftwareKeyboardHideIntent: Equatable {
+    case none
+    /// Hidden via the toolbar chevron. `pinned` (long press) survives terminal
+    /// taps; only the chevron restores it.
+    case hidden(pinned: Bool)
+
+    var isHidden: Bool { self != .none }
+    var isPinned: Bool { self == .hidden(pinned: true) }
+}
+
+@MainActor
+final class SoftwareKeyboardHideIntentStore {
+    static let shared = SoftwareKeyboardHideIntentStore()
+
+    private final class Box {
+        var intent: SoftwareKeyboardHideIntent
+        init(_ intent: SoftwareKeyboardHideIntent) { self.intent = intent }
+    }
+
+    private let intents = NSMapTable<UIWindow, Box>.weakToStrongObjects()
+
+    func intent(for window: UIWindow?) -> SoftwareKeyboardHideIntent {
+        guard let window else { return .none }
+        return intents.object(forKey: window)?.intent ?? .none
+    }
+
+    func set(_ intent: SoftwareKeyboardHideIntent, for window: UIWindow?) {
+        guard let window else { return }
+        if intent == .none {
+            intents.removeObject(forKey: window)
+        } else {
+            intents.setObject(Box(intent), forKey: window)
+        }
+    }
+}

--- a/rootshell/UI/Shell/MainView+TerminalContent.swift
+++ b/rootshell/UI/Shell/MainView+TerminalContent.swift
@@ -667,8 +667,11 @@ extension MainView {
         // previous version gated the reported inset on a "preserved keyboard is
         // physically hidden" flag, and on iOS 27 the flag and the safe-area
         // change stopped landing together, wobbling the terminal both ways.
+        // A toolbar-only / accessory input view subsumes the inset the same
+        // way (expansion is 0 while it is up), so a reserved toolbar gets the
+        // same compensation when an overlay or app switch hides it.
         let preservedKeyboardSafeAreaCompensation: CGFloat =
-            hasDockedKeyboard ? containerBottomSafeAreaExpansion : 0
+            (hasDockedKeyboard || reservesBottomToolbar) ? containerBottomSafeAreaExpansion : 0
 
         // Calculate adjusted offset for terminal positioning (reduced to avoid excess gap)
         let keyboardOffset: CGFloat
@@ -695,7 +698,7 @@ extension MainView {
                 keyboardOffset = max(
                     0,
                     reservedBottomToolbarHeight - windowSafeAreaInsets.bottom
-                )
+                ) + preservedKeyboardSafeAreaCompensation
             } else {
                 // The iPad container already keeps the terminal above the
                 // bottom safe-area strip. Reserve only the toolbar height that
@@ -704,7 +707,7 @@ extension MainView {
                 keyboardOffset = max(
                     0,
                     reservedBottomToolbarHeight - windowSafeAreaInsets.bottom
-                )
+                ) + preservedKeyboardSafeAreaCompensation
             }
         } else {
             keyboardOffset = 0

--- a/rootshell/UI/Terminal/TerminalKeyboardAccessoryController.swift
+++ b/rootshell/UI/Terminal/TerminalKeyboardAccessoryController.swift
@@ -16,6 +16,9 @@ protocol TerminalKeyboardAccessoryHost: AnyObject {
     var keyboardAIAgentOverlayActive: Bool { get }
     var keyboardToolbarOnlyMode: Bool { get }
     var keyboardAccessoryHasBottomSafeAreaSpacer: Bool { get }
+    /// Window whose `SoftwareKeyboardHideIntentStore` entry governs this host.
+    /// nil opts out: the chevron falls back to resigning first responder.
+    var keyboardHideIntentWindow: UIWindow? { get }
 
     @discardableResult
     func keyboardBecomeFirstResponder() -> Bool
@@ -34,6 +37,7 @@ protocol TerminalKeyboardAccessoryHost: AnyObject {
 
 extension TerminalKeyboardAccessoryHost {
     var keyboardAccessoryHasBottomSafeAreaSpacer: Bool { false }
+    var keyboardHideIntentWindow: UIWindow? { nil }
 }
 
 @MainActor
@@ -48,7 +52,20 @@ final class TerminalKeyboardAccessoryController: NSObject {
     var shouldShowKeyboardToolbar = false
     var activeKeyboardModifiers: KeyModifiers = []
     var onActiveKeyboardModifiersChanged: ((KeyModifiers) -> Void)?
-    var keyboardManuallyDismissed = false
+    /// Window-scoped hide intent; hosts without a window (VNC) keep it local.
+    var hideIntent: SoftwareKeyboardHideIntent {
+        guard let window = host?.keyboardHideIntentWindow else { return localHideIntent }
+        return SoftwareKeyboardHideIntentStore.shared.intent(for: window)
+    }
+    private var localHideIntent: SoftwareKeyboardHideIntent = .none
+    private var usesHideIntent: Bool { host?.keyboardHideIntentWindow != nil }
+    private func setHideIntent(_ intent: SoftwareKeyboardHideIntent) {
+        guard let window = host?.keyboardHideIntentWindow else {
+            localHideIntent = intent
+            return
+        }
+        SoftwareKeyboardHideIntentStore.shared.set(intent, for: window)
+    }
     /// Hosting choice captured when toolbar-only mode begins. A detached iPad
     /// keyboard must keep the toolbar in the accessory slot: replacing the
     /// floating keyboard with the accessory as its primary input view preserves
@@ -58,10 +75,21 @@ final class TerminalKeyboardAccessoryController: NSObject {
     private var toolbarOnlyUsesPrimaryInputView = true
     var toolbarOnlyMode = false {
         didSet {
+            guard oldValue != toolbarOnlyMode else { return }
             EffectManager.shared.notifyKeyboardToolbarLayoutChanged()
         }
     }
-    var keyboardPinnedHidden = false
+    /// Toolbar-only mode with the row hidden too (persistentToolbar off):
+    /// first responder is kept so hardware keys still work, but nothing is
+    /// presented at the bottom edge. Never while pinned: terminal taps do not
+    /// restore a pinned keyboard, so the chevron must stay reachable.
+    private(set) var toolbarOnlyHidesToolbar = false {
+        didSet {
+            guard oldValue != toolbarOnlyHidesToolbar else { return }
+            EffectManager.shared.notifyKeyboardToolbarLayoutChanged()
+        }
+    }
+    var keyboardPinnedHidden: Bool { hideIntent.isPinned }
     private(set) var bottomEdgeHomeGestureProtectionEnabled = false {
         didSet {
             guard oldValue != bottomEdgeHomeGestureProtectionEnabled else { return }
@@ -117,6 +145,7 @@ final class TerminalKeyboardAccessoryController: NSObject {
         return host.keyboardIsFirstResponder
             && !host.keyboardAIAgentOverlayActive
             && !keyboardToolbarCollapsed
+            && !(toolbarOnlyMode && toolbarOnlyHidesToolbar)
             && (shouldShowKeyboardToolbar || toolbarOnlyMode)
         #endif
     }
@@ -188,7 +217,8 @@ final class TerminalKeyboardAccessoryController: NSObject {
         if toolbarOnlyMode {
             // A primary toolbar is flush with the edge. The detached-iPad
             // compatibility path stays in the accessory slot and retains the
-            // clearance UIKit supplies below that slot.
+            // clearance UIKit supplies below that slot. No row, no strip.
+            guard !toolbarOnlyHidesToolbar else { return 0 }
             accessoryRestsAtScreenEdge = toolbarOnlyUsesPrimaryInputView
         } else if hardwareAccessoryOwnsKeyboardRegion {
             // A tall accessory-only region can otherwise look like a docked
@@ -283,6 +313,7 @@ final class TerminalKeyboardAccessoryController: NSObject {
         let isVisible = shouldShowKeyboardToolbar
             && !host.keyboardAIAgentOverlayActive
             && !keyboardToolbarCollapsed
+            && !(toolbarOnlyMode && toolbarOnlyHidesToolbar)
         updateBottomEdgeHomeGestureProtection(accessoryIsVisible: isVisible)
         // In the normal toolbar-only path the accessory serves as the primary
         // input view instead (see `inputView`); handing it out from both slots
@@ -311,6 +342,7 @@ final class TerminalKeyboardAccessoryController: NSObject {
         guard let host,
               let accessory = keyboardAccessory,
               shouldShowKeyboardToolbar,
+              !toolbarOnlyHidesToolbar,
               !host.keyboardAIAgentOverlayActive,
               !keyboardToolbarCollapsed else {
             // Toolbar hidden (collapsed to the floating button, or an overlay
@@ -346,14 +378,13 @@ final class TerminalKeyboardAccessoryController: NSObject {
             guard let self else { return }
             if self.toolbarOnlyMode {
                 self.exitToolbarOnlyMode()
+            } else if self.usesHideIntent || UserDefaults.standard.bool(forKey: "persistentToolbar") {
+                self.setHideIntent(.hidden(pinned: false))
+                self.enterToolbarOnlyMode(pinned: false)
             } else {
-                let persistentToolbar = UserDefaults.standard.bool(forKey: "persistentToolbar")
-                if persistentToolbar {
-                    self.enterToolbarOnlyMode()
-                } else {
-                    self.keyboardManuallyDismissed = true
-                    _ = self.host?.keyboardResignFirstResponder()
-                }
+                // Hosts without a hide-intent window (VNC) keep the legacy
+                // resign path.
+                _ = self.host?.keyboardResignFirstResponder()
             }
         }
 
@@ -366,9 +397,8 @@ final class TerminalKeyboardAccessoryController: NSObject {
             if self.keyboardPinnedHidden {
                 self.exitToolbarOnlyMode()
             } else {
-                self.keyboardPinnedHidden = true
-                self.enterToolbarOnlyMode()
-                self.keyboardAccessory?.setDismissButtonPinned(true)
+                self.setHideIntent(.hidden(pinned: true))
+                self.enterToolbarOnlyMode(pinned: true)
             }
         }
 
@@ -569,9 +599,12 @@ final class TerminalKeyboardAccessoryController: NSObject {
         host?.keyboardReloadInputViews()
     }
 
-    func enterToolbarOnlyMode() {
+    func enterToolbarOnlyMode(pinned: Bool = false) {
         _ = emptyInputView
         emptyInputViewHeightConstraint?.constant = 0
+        toolbarOnlyHidesToolbar = usesHideIntent
+            && !pinned
+            && !UserDefaults.standard.bool(forKey: "persistentToolbar")
         #if !os(visionOS) && !targetEnvironment(macCatalyst)
         // Snapshot before changing the input set. Once the software keyboard
         // starts hiding, its placement frame is no longer reliable enough to
@@ -587,17 +620,49 @@ final class TerminalKeyboardAccessoryController: NSObject {
         toolbarOnlyMode = true
         host?.keyboardSetSoftwareKeyboardRequested(false)
         keyboardAccessory?.setDismissButtonShowsRestore(true)
+        keyboardAccessory?.setDismissButtonPinned(pinned)
         host?.keyboardReloadInputViews()
     }
 
     func exitToolbarOnlyMode() {
-        keyboardPinnedHidden = false
+        setHideIntent(.none)
         keyboardAccessory?.setDismissButtonPinned(false)
         toolbarOnlyMode = false
+        toolbarOnlyHidesToolbar = false
         host?.keyboardSetSoftwareKeyboardRequested(true)
         keyboardAccessory?.setDismissButtonShowsRestore(false)
         host?.keyboardReloadInputViews()
         toolbarOnlyUsesPrimaryInputView = true
+    }
+
+    /// Bring this host's applied mode in line with the window's hide intent.
+    /// Idempotent; called before every first-responder acquisition so the
+    /// input view UIKit queries already reflects the intent. Returns true when
+    /// something changed.
+    @discardableResult
+    func reconcileWithHideIntent() -> Bool {
+        guard usesHideIntent else { return false }
+        let intent = hideIntent
+        if !intent.isHidden {
+            guard toolbarOnlyMode else { return false }
+            exitToolbarOnlyMode()
+            return true
+        }
+        let pinned = intent.isPinned
+        guard toolbarOnlyMode else {
+            enterToolbarOnlyMode(pinned: pinned)
+            return true
+        }
+        let hidesToolbar = !pinned && !UserDefaults.standard.bool(forKey: "persistentToolbar")
+        var changed = false
+        if toolbarOnlyHidesToolbar != hidesToolbar {
+            toolbarOnlyHidesToolbar = hidesToolbar
+            changed = true
+        }
+        keyboardAccessory?.setDismissButtonPinned(pinned)
+        keyboardAccessory?.setDismissButtonShowsRestore(true)
+        if changed { host?.keyboardReloadInputViews() }
+        return changed
     }
 
     func resetFocusLossState() {
@@ -607,13 +672,6 @@ final class TerminalKeyboardAccessoryController: NSObject {
         }
         if keyboardToolbarCollapsed {
             keyboardToolbarCollapsed = false
-        }
-    }
-
-    func rearmPinnedHiddenIfNeeded() {
-        if keyboardPinnedHidden && !toolbarOnlyMode {
-            enterToolbarOnlyMode()
-            keyboardAccessory?.setDismissButtonPinned(true)
         }
     }
 
@@ -791,12 +849,10 @@ final class TerminalKeyboardAccessoryController: NSObject {
         let tracker = KeyboardTracker.shared
         let showWithHardware = UserDefaults.standard.bool(forKey: "showToolbarWithHardwareKeyboard")
         let newShouldShow = !tracker.isHardwareKeyboard || tracker.isSoftwareKeyboardVisible || showWithHardware
-        if !newShouldShow && toolbarOnlyMode {
+        if !newShouldShow && toolbarOnlyMode && !usesHideIntent {
             toolbarOnlyMode = false
+            localHideIntent = .none
             keyboardAccessory?.setDismissButtonShowsRestore(false)
-        }
-        if !newShouldShow && keyboardPinnedHidden {
-            keyboardPinnedHidden = false
             keyboardAccessory?.setDismissButtonPinned(false)
         }
         if !newShouldShow && keyboardToolbarCollapsed {
@@ -821,6 +877,7 @@ final class TerminalKeyboardAccessoryController: NSObject {
             shouldShowKeyboardToolbar
                 && host?.keyboardAIAgentOverlayActive != true
                 && !keyboardToolbarCollapsed
+                && !(toolbarOnlyMode && toolbarOnlyHidesToolbar)
         )
         let hardwareAccessoryOnly = hardwareAccessoryOwnsKeyboardRegion
         // toolbarOnlyMode counts as at-screen-edge on its own: the accessory

--- a/rootshell/UI/Terminal/TerminalView+Gestures.swift
+++ b/rootshell/UI/Terminal/TerminalView+Gestures.swift
@@ -1465,10 +1465,10 @@ extension Ghostty.TerminalView {
     #endif
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        // Safety net: if we're logically focused but not first responder, restore it
-        // Skip if user manually dismissed keyboard — they want to scroll freely.
-        // Keyboard will be restored on a deliberate single tap via touchesEnded.
-        if isLogicallyFocused && !isFirstResponder && !keyboardManuallyDismissed {
+        // Safety net: if we're logically focused but not first responder,
+        // restore it. A hidden keyboard stays hidden: becomeFirstResponder()
+        // re-applies the window's hide intent.
+        if isLogicallyFocused && !isFirstResponder {
             Ghostty.logger.debug("touchesBegan: Restoring focus via tap")
             _ = becomeFirstResponder()
         }
@@ -1476,7 +1476,7 @@ extension Ghostty.TerminalView {
         // Track touch start for keyboard restore tap detection. Finger only:
         // iPadOS answers pencil focus with the minimized-keyboard pill instead
         // of a real keyboard, so a pencil tap must not re-arm keyboard state.
-        if (keyboardManuallyDismissed || toolbarOnlyMode) && !keyboardToolbarCollapsed,
+        if toolbarOnlyMode && !keyboardToolbarCollapsed,
            let touch = touches.first,
            touch.type == .direct {
             dismissTapStartPoint = touch.location(in: self)
@@ -1709,22 +1709,6 @@ extension Ghostty.TerminalView {
                 dismissTapStartPoint = nil
                 if distance < 20 {
                     exitToolbarOnlyMode()
-                }
-            }
-        }
-
-        // Restore keyboard on deliberate single tap after manual dismiss.
-        // Only restore if the finger didn't travel far (tap, not scroll).
-        if keyboardManuallyDismissed && !keyboardPinnedHidden && isLogicallyFocused && !isFirstResponder && touch.type == .direct {
-            let allEndTouches = event?.allTouches ?? touches
-            let remaining = allEndTouches.filter { $0.phase != .ended && $0.phase != .cancelled }
-            if remaining.isEmpty, let startPoint = dismissTapStartPoint {
-                let endPoint = touch.location(in: self)
-                let distance = hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y)
-                dismissTapStartPoint = nil
-                if distance < 20 {
-                    keyboardManuallyDismissed = false
-                    _ = becomeFirstResponder()
                 }
             }
         }

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -513,10 +513,6 @@ extension Ghostty {
         }
         var composeText: String = ""
         weak var activeComposeTextView: UITextView?
-        var keyboardManuallyDismissed: Bool {
-            get { keyboardAccessoryController?.keyboardManuallyDismissed ?? false }
-            set { keyboardAccessoryController?.keyboardManuallyDismissed = newValue }
-        }
         var toolbarOnlyMode: Bool {
             get { keyboardAccessoryController?.toolbarOnlyMode ?? false }
             set { keyboardAccessoryController?.toolbarOnlyMode = newValue }
@@ -524,8 +520,7 @@ extension Ghostty {
         // Set by long-pressing the dismiss chevron: keyboard stays hidden across
         // terminal taps and focus changes until the chevron is tapped again.
         var keyboardPinnedHidden: Bool {
-            get { keyboardAccessoryController?.keyboardPinnedHidden ?? false }
-            set { keyboardAccessoryController?.keyboardPinnedHidden = newValue }
+            keyboardAccessoryController?.keyboardPinnedHidden ?? false
         }
         var keyboardToolbarCollapsed: Bool {
             get { keyboardAccessoryController?.keyboardToolbarCollapsed ?? false }
@@ -2041,15 +2036,8 @@ extension Ghostty {
             keyboardAccessoryController.hitTestCollapsedKeyboardToolbarButton(point, with: event)
         }
 
-        /// Suppress the keyboard while keeping the toolbar visible above the
-        /// home indicator. Used by the persistent-toolbar dismiss, the
-        /// pinned-hidden long-press, and re-arming the pin on focus regain.
-        func enterToolbarOnlyMode() {
-            keyboardAccessoryController.enterToolbarOnlyMode()
-        }
-
         /// Restore the full keyboard from toolbar-only mode, clearing the
-        /// pinned-hidden state if set.
+        /// window's hide intent (and pinned state) so other tabs follow.
         func exitToolbarOnlyMode() {
             keyboardAccessoryController.exitToolbarOnlyMode()
         }
@@ -2983,9 +2971,13 @@ extension Ghostty {
                 return false
             }
 
+            // Toolbar-only mode counts too: its input view is below the
+            // tracker's software-keyboard threshold, but losing first
+            // responder drops the toolbar reserve and resizes the terminal.
             let keyboardWasVisibleOrPreserving =
                 tracker.isSoftwareKeyboardVisible ||
-                tracker.isPreservingSoftwareKeyboardForAppTransition
+                tracker.isPreservingSoftwareKeyboardForAppTransition ||
+                (toolbarOnlyMode && isFirstResponder)
             guard keyboardWasVisibleOrPreserving else { return false }
 
             let appOrSceneIsLeaving =
@@ -3409,13 +3401,10 @@ extension Ghostty {
                 return false
             }
 
-            // Re-arm pinned-hidden mode before acquiring first responder so
-            // inputView already returns emptyInputView and the keyboard
-            // never flashes on focus regain.
-            if keyboardPinnedHidden && !toolbarOnlyMode {
-                enterToolbarOnlyMode()
-                keyboardAccessory?.setDismissButtonPinned(true)
-            }
+            // Apply the window's hide intent before acquiring first responder
+            // so inputView already returns the toolbar/empty view and the
+            // keyboard never flashes on tab switch or overlay dismissal.
+            keyboardAccessoryController?.reconcileWithHideIntent()
 
             let result = super.becomeFirstResponder()
 
@@ -3462,10 +3451,9 @@ extension Ghostty {
             }
             #endif
 
-            if toolbarOnlyMode {
-                toolbarOnlyMode = false
-                keyboardAccessory?.setDismissButtonShowsRestore(false)
-            }
+            // toolbarOnlyMode is derived from the window hide intent and
+            // re-applied in becomeFirstResponder(); leaving it set here avoids
+            // a layout invalidation on every overlay open and tab switch.
             if keyboardToolbarCollapsed {
                 keyboardToolbarCollapsed = false
             }
@@ -4348,10 +4336,6 @@ extension Ghostty {
                 return false
             } else {
                 Ghostty.logger.info("focusDidChange(false): Unfocusing terminal")
-                if toolbarOnlyMode {
-                    toolbarOnlyMode = false
-                    keyboardAccessory?.setDismissButtonShowsRestore(false)
-                }
                 if keyboardToolbarCollapsed {
                     keyboardToolbarCollapsed = false
                 }
@@ -4389,6 +4373,8 @@ extension Ghostty.TerminalView: TerminalKeyboardAccessoryHost {
     func keyboardResignFirstResponder() -> Bool {
         resignFirstResponder()
     }
+
+    var keyboardHideIntentWindow: UIWindow? { window }
 
     func keyboardSetSoftwareKeyboardRequested(_ requested: Bool) {
         // TerminalView switches between the system keyboard and its empty


### PR DESCRIPTION
Move the chevron's hide state into a window-scoped intent applied in becomeFirstResponder(), keep first responder in toolbar-only mode, arm the preservation latches for any presented input view, and compensate the container safe-area expansion under a reserved toolbar.