### PR TITLE
Keep compact tab bar controls inside resized windows

### DIFF
--- a/rootshell/UI/Shell/MainView+TabBar.swift
+++ b/rootshell/UI/Shell/MainView+TabBar.swift
@@ -112,10 +112,9 @@ extension MainView {
     /// (varying frames; common root: scene-update transactions blow the
     /// 10s/30s FrontBoard budget when MainView re-evaluates) hinges on
     /// this decoupling.
-    /// The compact track uses a preferred width already clamped to the space
-    /// left after fixed controls. Giving that width to the GeometryReader
-    /// directly prevents SwiftUI from needlessly compressing a lone pill while
-    /// the adjacent titlebar drag region expands into otherwise unused space.
+    /// The compact track caps at the space left after fixed controls. A cap,
+    /// not a fixed width: outer modifiers inset the row below what the proxy
+    /// reports, and a rigid frame pushed the buttons off-window.
     @ViewBuilder
     func tabBarTrack(in geometry: GeometryProxy, theme: ResolvedTabBarTheme) -> some View {
         if usesCompactTabSpacing {
@@ -126,11 +125,8 @@ extension MainView {
                     theme: theme
                 )
             }
-            .frame(
-                width: preferredWidth,
-                height: TabMetrics.tabBarHeight,
-                alignment: .leading
-            )
+            .frame(maxWidth: preferredWidth, alignment: .leading)
+            .frame(height: TabMetrics.tabBarHeight)
         } else {
             tabBarContent(
                 availableWidth: availableTabBarWidth(in: geometry),

--- a/rootshell/UI/Tabs/TabBar.swift
+++ b/rootshell/UI/Tabs/TabBar.swift
@@ -913,6 +913,10 @@ struct TabBar: View {
 
     // MARK: - Scrolling tabs
 
+    /// Keeps the selection spring's overshoot (~4.6% of a travel capped at the
+    /// 240pt tab width) off the ScrollView's clip edge.
+    private static let compactOvershootHeadroom: CGFloat = 12
+
     @ViewBuilder
     private func scrollingView(tabWidth: CGFloat) -> some View {
         let tabs = tabsModel.tabs
@@ -972,7 +976,8 @@ struct TabBar: View {
                         }
                 }
             }
-            .padding(.horizontal, usesCompactSpacing ? 0 : 8)
+            .padding(.leading, usesCompactSpacing ? 0 : 8)
+            .padding(.trailing, usesCompactSpacing ? Self.compactOvershootHeadroom : 8)
             .contentShape(Rectangle())
             .modifier(GlassEffectContainerModifier())
             // Scoped animation for the selection slide. See equalWidthView.


### PR DESCRIPTION
- cap the compact tab track width instead of pinning it, so the add and settings buttons compress into view rather than off-window
- reserve trailing room for the selection spring's overshoot, which the scrolling strip's clip edge otherwise sliced

Fixes #351