### PR TITLE
Fix TestFlight-reported tab bar context menu crash

### DIFF
--- a/rootshell/UI/Shared/DraggableTabBar.swift
+++ b/rootshell/UI/Shared/DraggableTabBar.swift
@@ -23,15 +23,39 @@ extension View {
 /// SwiftUI shape does not reliably win hit testing over a UIViewRepresentable
 /// terminal beneath it on Catalyst.
 struct CatalystWindowDragRegion: UIViewRepresentable {
+    var tabStyleSelection: Binding<String>?
+
+    init(tabStyleSelection: Binding<String>? = nil) {
+        self.tabStyleSelection = tabStyleSelection
+    }
+
+    func makeCoordinator() -> TabStyleContextMenuCoordinator {
+        TabStyleContextMenuCoordinator()
+    }
+
     func makeUIView(context: Context) -> UIView {
         let view = CatalystWindowDragView()
         view.backgroundColor = .clear
         view.isUserInteractionEnabled = true
         view.accessibilityElementsHidden = true
+        if let tabStyleSelection {
+            context.coordinator.update(
+                selectedStyleRawValue: tabStyleSelection,
+                primaryAction: nil
+            )
+            context.coordinator.install(on: view)
+        }
         return view
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {}
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let tabStyleSelection {
+            context.coordinator.update(
+                selectedStyleRawValue: tabStyleSelection,
+                primaryAction: nil
+            )
+        }
+    }
 }
 
 private final class CatalystWindowDragView: UIView {

--- a/rootshell/UI/Shared/TabComponents.swift
+++ b/rootshell/UI/Shared/TabComponents.swift
@@ -898,49 +898,144 @@ extension View {
 
 // MARK: - Tab Layout Context Menu
 
-/// Adds the lightweight Pills/Compact Pills/Integrated switcher to otherwise
-/// non-tab chrome.
-/// The nearest per-tab context menu still owns secondary clicks on real tabs.
-struct TabStyleSwitchContextMenuModifier: ViewModifier {
+/// A native context-menu source for otherwise SwiftUI-owned tab chrome.
+///
+/// In this tab bar, SwiftUI's `.contextMenu` presentation reaches the root
+/// UIHostingController. Runtime diagnostics show that path intermittently
+/// installing private gravity-well views directly under the controller's root
+/// view. Keeping the interaction and its UIActions on this local UIView avoids
+/// that bridge.
+struct TabStyleContextMenuRegion: UIViewRepresentable {
     @Binding var selectedStyleRawValue: String
-    @AppStorage(UserPreferences.compactPillTabSpacingKey) private var compactPillTabSpacing: Bool = false
+    var primaryAction: (() -> Void)?
+    var accessibilityLabel: String?
 
-    private var selectedStyle: TopTabStyle {
-        TopTabStyle.resolve(selectedStyleRawValue)
+    init(
+        selectedStyleRawValue: Binding<String>,
+        primaryAction: (() -> Void)? = nil,
+        accessibilityLabel: String? = nil
+    ) {
+        _selectedStyleRawValue = selectedStyleRawValue
+        self.primaryAction = primaryAction
+        self.accessibilityLabel = accessibilityLabel
     }
 
-    private var selectedLayout: TopTabLayout {
-        TopTabLayout.resolve(style: selectedStyle, compactPills: compactPillTabSpacing)
+    func makeCoordinator() -> TabStyleContextMenuCoordinator {
+        TabStyleContextMenuCoordinator()
     }
 
-    func body(content: Content) -> some View {
-        content
-            .contentShape(Rectangle())
-            .contextMenu {
-                layoutButton(.pills, systemImage: "capsule")
-                layoutButton(.compactPills, systemImage: "capsule.fill")
-                layoutButton(.integrated, systemImage: "rectangle.topthird.inset.filled")
-            }
+    func makeUIView(context: Context) -> UIControl {
+        let control = UIControl()
+        control.backgroundColor = .clear
+        control.addTarget(
+            context.coordinator,
+            action: #selector(TabStyleContextMenuCoordinator.performPrimaryAction),
+            for: .primaryActionTriggered
+        )
+        context.coordinator.install(on: control)
+        update(control, coordinator: context.coordinator)
+        return control
     }
 
-    private func layoutButton(_ layout: TopTabLayout, systemImage: String) -> some View {
-        Button {
-            selectedStyleRawValue = layout.style.rawValue
-            if layout.style == .pills {
-                compactPillTabSpacing = layout.usesCompactPillSpacing
-            }
-        } label: {
-            Label(
-                layout.displayName,
-                systemImage: selectedLayout == layout ? "checkmark" : systemImage
-            )
-        }
+    func updateUIView(_ uiView: UIControl, context: Context) {
+        update(uiView, coordinator: context.coordinator)
+    }
+
+    private func update(_ control: UIControl, coordinator: TabStyleContextMenuCoordinator) {
+        coordinator.update(
+            selectedStyleRawValue: $selectedStyleRawValue,
+            primaryAction: primaryAction
+        )
+        control.isAccessibilityElement = accessibilityLabel != nil
+        control.accessibilityLabel = accessibilityLabel
+        control.accessibilityTraits = accessibilityLabel == nil ? [] : .button
+        control.accessibilityElementsHidden = accessibilityLabel == nil
     }
 }
 
-extension View {
-    func tabStyleSwitchContextMenu(selection: Binding<String>) -> some View {
-        modifier(TabStyleSwitchContextMenuModifier(selectedStyleRawValue: selection))
+@MainActor
+final class TabStyleContextMenuCoordinator: NSObject, UIContextMenuInteractionDelegate {
+    private var selectedStyleRawValue: Binding<String>?
+    private var primaryAction: (() -> Void)?
+
+    func update(
+        selectedStyleRawValue: Binding<String>,
+        primaryAction: (() -> Void)?
+    ) {
+        self.selectedStyleRawValue = selectedStyleRawValue
+        self.primaryAction = primaryAction
+    }
+
+    func install(on view: UIView) {
+        view.addInteraction(UIContextMenuInteraction(delegate: self))
+    }
+
+    @objc func performPrimaryAction() {
+        primaryAction?()
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard selectedStyleRawValue != nil else { return nil }
+
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self else { return nil }
+            let selectedLayout = self.selectedLayout
+            let actions = [
+                self.action(for: .pills, systemImage: "capsule", selectedLayout: selectedLayout),
+                self.action(for: .compactPills, systemImage: "capsule.fill", selectedLayout: selectedLayout),
+                self.action(
+                    for: .integrated,
+                    systemImage: "rectangle.topthird.inset.filled",
+                    selectedLayout: selectedLayout
+                ),
+            ]
+            return UIMenu(children: actions)
+        }
+    }
+
+    private var selectedLayout: TopTabLayout {
+        TopTabLayout.resolve(
+            style: TopTabStyle.resolve(selectedStyleRawValue?.wrappedValue ?? TopTabStyle.pills.rawValue),
+            compactPills: UserDefaults.standard.bool(forKey: UserPreferences.compactPillTabSpacingKey)
+        )
+    }
+
+    private func action(
+        for layout: TopTabLayout,
+        systemImage: String,
+        selectedLayout: TopTabLayout
+    ) -> UIAction {
+        UIAction(
+            title: layout.displayName,
+            image: UIImage(systemName: systemImage),
+            state: selectedLayout == layout ? .on : .off
+        ) { [weak self] _ in
+            self?.apply(layout)
+        }
+    }
+
+    private func apply(_ layout: TopTabLayout) {
+        guard selectedLayout != layout else { return }
+
+        // Leave the UIContextMenuInteraction callback before changing the tab
+        // hierarchy that contains its source view.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let selectedStyleRawValue else { return }
+            withTransaction(Transaction(animation: nil)) {
+                if layout.style == .pills {
+                    UserDefaults.standard.set(
+                        layout.usesCompactPillSpacing,
+                        forKey: UserPreferences.compactPillTabSpacingKey
+                    )
+                }
+                if selectedStyleRawValue.wrappedValue != layout.style.rawValue {
+                    selectedStyleRawValue.wrappedValue = layout.style.rawValue
+                }
+            }
+        }
     }
 }
 

--- a/rootshell/UI/Shell/MainView+Body.swift
+++ b/rootshell/UI/Shell/MainView+Body.swift
@@ -147,11 +147,18 @@ extension MainView {
 
     @ViewBuilder
     func tabBarAddButton(theme: ResolvedTabBarTheme) -> some View {
-        Button(action: addNewTab) {
+        ZStack {
             Image(systemName: "plus")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(theme.tabText)
                 .frame(width: TabMetrics.tabBarHeight, height: TabMetrics.tabBarHeight)
+                .accessibilityHidden(true)
+
+            TabStyleContextMenuRegion(
+                selectedStyleRawValue: $topTabStyleRawValue,
+                primaryAction: addNewTab,
+                accessibilityLabel: String(localized: "New Tab")
+            )
         }
         .overlay(alignment: .leading) {
             if topTabStyle == .integrated {
@@ -164,43 +171,47 @@ extension MainView {
         }
         .frame(width: TabMetrics.tabBarHeight, height: TabMetrics.tabBarHeight)
         .fixedSize()
-        .tabStyleSwitchContextMenu(selection: $topTabStyleRawValue)
         .layoutPriority(1)
-        .accessibilityLabel("New Tab")
     }
 
     @ViewBuilder
     func tabBarSettingsButton(theme: ResolvedTabBarTheme) -> some View {
-        Button(action: {
-            requestSettingsPresentation()
-        }) {
+        ZStack {
             Image(systemName: "gearshape")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(theme.tabText)
                 .frame(width: TabMetrics.tabBarHeight, height: TabMetrics.tabBarHeight)
+                .accessibilityHidden(true)
+
+            TabStyleContextMenuRegion(
+                selectedStyleRawValue: $topTabStyleRawValue,
+                primaryAction: { requestSettingsPresentation() },
+                accessibilityLabel: String(localized: "Settings")
+            )
         }
         .frame(width: TabMetrics.tabBarHeight, height: TabMetrics.tabBarHeight)
         .fixedSize()
-        .tabStyleSwitchContextMenu(selection: $topTabStyleRawValue)
         .layoutPriority(1)
-        .accessibilityLabel("Settings")
     }
 
     @ViewBuilder
     func integratedTabBarDragRegion() -> some View {
         #if targetEnvironment(macCatalyst)
         if usesTitlebarTabs || hideWindowTitleBar {
-            CatalystWindowDragRegion()
+            CatalystWindowDragRegion(tabStyleSelection: $topTabStyleRawValue)
                 .frame(minWidth: Self.catalystWindowDragWidth, maxWidth: .infinity)
                 .frame(height: TabMetrics.tabBarHeight)
-                .tabStyleSwitchContextMenu(selection: $topTabStyleRawValue)
                 .catalystCursorRegion(.openHand, priority: .titlebar)
                 .accessibilityHidden(true)
         } else {
-            Spacer(minLength: 0)
+            TabStyleContextMenuRegion(selectedStyleRawValue: $topTabStyleRawValue)
+                .frame(minWidth: 0, maxWidth: .infinity)
+                .frame(height: TabMetrics.tabBarHeight)
         }
         #else
-        Spacer(minLength: 0)
+        TabStyleContextMenuRegion(selectedStyleRawValue: $topTabStyleRawValue)
+            .frame(minWidth: 0, maxWidth: .infinity)
+            .frame(height: TabMetrics.tabBarHeight)
         #endif
     }
 
@@ -217,15 +228,17 @@ extension MainView {
         tabBarChromeBackground(theme)
             .padding(.bottom, topTabStyle == .integrated ? IntegratedTabEdgeMetrics.reservedThickness : 0)
             .frame(width: tabBarLeadingPadding, height: 44)
+            .overlay {
+                TabStyleContextMenuRegion(selectedStyleRawValue: $topTabStyleRawValue)
+            }
             .overlay(alignment: .trailing) {
                 if dragWidth > 0 {
-                    CatalystWindowDragRegion()
+                    CatalystWindowDragRegion(tabStyleSelection: $topTabStyleRawValue)
                         .frame(width: dragWidth, height: TabMetrics.tabBarHeight)
                         .catalystCursorRegion(.openHand, priority: .titlebar)
                         .accessibilityHidden(true)
                 }
             }
-            .tabStyleSwitchContextMenu(selection: $topTabStyleRawValue)
         #endif
     }
 }

--- a/rootshell/UI/Shell/MainView+TabBar.swift
+++ b/rootshell/UI/Shell/MainView+TabBar.swift
@@ -145,6 +145,7 @@ extension MainView {
             availableWidth: availableWidth,
             style: topTabStyle,
             usesCompactSpacing: usesCompactTabSpacing,
+            selectedStyleRawValue: $topTabStyleRawValue,
             tabsModel: tabsModel,
             selectedTabIndex: Binding(
                 get: { selectedTabIndex },

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -435,7 +435,11 @@ struct MainView: View {
                                     .layoutPriority(-1)
                                 tabBarSettingsButton(theme: resolvedTheme)
                             } else {
-                                Spacer(minLength: 0)
+                                TabStyleContextMenuRegion(
+                                    selectedStyleRawValue: $topTabStyleRawValue
+                                )
+                                .frame(minWidth: 0, maxWidth: .infinity, maxHeight: .infinity)
+                                .layoutPriority(-1)
                                 tabBarActionButtons(theme: resolvedTheme)
                             }
                         }
@@ -444,7 +448,6 @@ struct MainView: View {
                         .background {
                             ZStack {
                                 tabBarChromeBackground(resolvedTheme)
-                                    .tabStyleSwitchContextMenu(selection: $topTabStyleRawValue)
 
                                 // Background layer on purpose: the active tab
                                 // occludes the run beneath it, so the line
@@ -455,6 +458,9 @@ struct MainView: View {
                                     )
                                 }
                             }
+                            // Visual chrome must not own an interaction behind
+                            // every foreground tab, button, and empty-space menu.
+                            .allowsHitTesting(false)
                         }
                         .overlayPreferenceValue(IntegratedActiveTabBoundsPreferenceKey.self) { bounds in
                             integratedOSCProgressEdge(activeTabBounds: bounds)

--- a/rootshell/UI/Tabs/TabBar.swift
+++ b/rootshell/UI/Tabs/TabBar.swift
@@ -282,6 +282,7 @@ struct TabBar: View {
     let availableWidth: CGFloat
     let style: TopTabStyle
     let usesCompactSpacing: Bool
+    @Binding var selectedStyleRawValue: String
 
     // MARK: - Structural / references
 
@@ -824,6 +825,8 @@ struct TabBar: View {
                 maxWidth: .infinity,
                 alignment: usesCompactSpacing ? .leading : .center
             )
+        } else {
+            emptyTabStyleContextMenuRegion()
         }
     }
 
@@ -835,18 +838,25 @@ struct TabBar: View {
     private func singleTabFlexibleMargin() -> some View {
         #if targetEnvironment(macCatalyst)
         if usesTitlebarTabs {
-            CatalystWindowDragRegion()
+            CatalystWindowDragRegion(tabStyleSelection: $selectedStyleRawValue)
                 .frame(minWidth: 0, maxWidth: .infinity)
                 .frame(height: TabMetrics.tabBarHeight)
                 .layoutPriority(-1)
                 .catalystCursorRegion(.openHand, priority: .titlebar)
                 .accessibilityHidden(true)
         } else {
-            Spacer(minLength: 0)
+            emptyTabStyleContextMenuRegion()
         }
         #else
-        Spacer(minLength: 0)
+        emptyTabStyleContextMenuRegion()
         #endif
+    }
+
+    private func emptyTabStyleContextMenuRegion() -> some View {
+        TabStyleContextMenuRegion(selectedStyleRawValue: $selectedStyleRawValue)
+            .frame(minWidth: 0, maxWidth: .infinity)
+            .frame(maxHeight: .infinity)
+            .layoutPriority(-1)
     }
 
     // MARK: - Equal-width tabs


### PR DESCRIPTION
Replace SwiftUI tab-style context menus with locally hosted UIKit interactions to avoid the ContextMenuBridge and AttributeGraph crash reported by TestFlight. Keep menu hit regions disjoint and defer tab style mutations until after the menu callback completes.