### PR TITLE
Add "Only When in Background" push setting

### DIFF
--- a/rootshell/Features/Push/PushNotificationRouter.swift
+++ b/rootshell/Features/Push/PushNotificationRouter.swift
@@ -218,6 +218,11 @@ enum PushNotificationRouter {
             return []
         }
         guard let (header, decryptedLocally) = decryptedHeader(from: content.userInfo) else { return [.banner, .list] }
+        // willPresent only runs while the app is foreground, so this is the "device can already alert" case.
+        if header.kind == "agent", UserDefaults.standard.bool(forKey: PushRegistrationManager.backgroundOnlyKey) {
+            logger.info("suppressed: background-only and app is foreground")
+            return []
+        }
         if decryptedLocally {
             let eid = PushEnvelope(userInfo: content.userInfo)?.eid ?? UUID().uuidString
             Task { await presentLocally(header, eid: eid, sound: content.sound) }
@@ -229,8 +234,8 @@ enum PushNotificationRouter {
         if let resolved {
             // Explicit `send`/`test` notifications always show; agent events are
             // suppressed only when the pane is on screen or screen detection
-            // already fired. The Agent Notifications policy governs screen
-            // detection, not pushes.
+            // already fired (or always, with "Only When in Background" on).
+            // The Agent Notifications policy governs screen detection, not pushes.
             if header.kind == "agent" {
                 if isViewed(resolved) {
                     logger.info("suppressed: pane is being viewed")

--- a/rootshell/Features/Push/PushRegistrationManager.swift
+++ b/rootshell/Features/Push/PushRegistrationManager.swift
@@ -31,6 +31,7 @@ final class PushRegistrationManager {
     static let enabledKey = "pushNotificationsEnabled"
     static let sendersKey = "pushPairedSenders"
     static let revokedKey = "pushRevokedSenders"
+    static let backgroundOnlyKey = "pushAgentBackgroundOnly"
 
     enum State: Equatable {
         case disabled
@@ -43,6 +44,10 @@ final class PushRegistrationManager {
     private(set) var state: State = .disabled
     private(set) var senders: [PushPairedSender] = []
     private(set) var isBusy = false
+    /// Agent pushes are dropped while the app is foreground; explicit sends still show.
+    var agentBackgroundOnly: Bool {
+        didSet { UserDefaults.standard.set(agentBackgroundOnly, forKey: Self.backgroundOnlyKey) }
+    }
 
     @ObservationIgnored private let keychain = PushConfiguration.keychain
     @ObservationIgnored private var apnsToken: Data?
@@ -52,6 +57,7 @@ final class PushRegistrationManager {
     private init() {
         let defaults = UserDefaults.standard
         isEnabled = defaults.bool(forKey: Self.enabledKey)
+        agentBackgroundOnly = defaults.bool(forKey: Self.backgroundOnlyKey)
         senders = (defaults.data(forKey: Self.sendersKey)).flatMap { try? JSONDecoder().decode([PushPairedSender].self, from: $0) } ?? []
         revoked = Set(defaults.stringArray(forKey: Self.revokedKey) ?? [])
         if isEnabled { state = credentials == nil ? .waitingForToken : .registered }

--- a/rootshell/Features/Push/Settings/PushNotificationSettingsView.swift
+++ b/rootshell/Features/Push/Settings/PushNotificationSettingsView.swift
@@ -44,6 +44,21 @@ struct PushNotificationSettingsView: View {
 
             if manager.state == .registered {
                 Section {
+                    Toggle(isOn: Binding(
+                        get: { manager.agentBackgroundOnly },
+                        set: { manager.agentBackgroundOnly = $0 }
+                    )) {
+                        HStack(spacing: 12) {
+                            SettingsIcon(systemName: "moon.zzz")
+                            Text("Only When in Background")
+                        }
+                    }
+                    .themedRow()
+                } footer: {
+                    Text("Agent notifications are shown only while rootshell is in the background on this device. Explicit `rootshell-notify send` messages always show.")
+                }
+
+                Section {
                     ForEach(manager.senders) { sender in
                         HStack(spacing: 12) {
                             SettingsIcon(systemName: sender.stale ? "exclamationmark.triangle" : "desktopcomputer")


### PR DESCRIPTION
Agent pushes are dropped in willPresent when the setting is on, so only devices that can't otherwise alert show them. Explicit send/test messages are unaffected.