### PR TITLE
feat(tabs): add Ledger and Trough tab styles

### DIFF
--- a/rootshell/Core/Preferences/UserPreferences.swift
+++ b/rootshell/Core/Preferences/UserPreferences.swift
@@ -9,10 +9,14 @@ import Foundation
 
 /// Visual treatment for the horizontal tab bar. Pills preserves the existing
 /// Rootshell appearance; Integrated connects the selected tab to the terminal
-/// and uses browser-style sizing and controls.
+/// and uses browser-style sizing and controls; Ledger is text-only with a
+/// sliding accent indicator on the strip keyline; Trough is a segmented
+/// control: one shared well with the selected tab as a sliding glass knob.
 enum TopTabStyle: String, CaseIterable, Identifiable {
     case pills
     case integrated
+    case ledger
+    case trough
 
     static let storageKey = "topTabStyle"
 
@@ -22,8 +26,16 @@ enum TopTabStyle: String, CaseIterable, Identifiable {
         switch self {
         case .pills: return String(localized: "Pills")
         case .integrated: return String(localized: "Integrated")
+        case .ledger: return String(localized: "Ledger")
+        case .trough: return String(localized: "Trough")
         }
     }
+
+    /// Tabs sit on a keylined strip (edge rule, "+" separator, no AppKit separator).
+    var usesStripLayout: Bool { self == .integrated || self == .ledger }
+
+    /// Equal-width, zero-spacing tab sizing.
+    var usesEqualWidthTabs: Bool { self != .pills }
 
     static func resolve(_ rawValue: String) -> TopTabStyle {
         TopTabStyle(rawValue: rawValue) ?? .pills
@@ -37,6 +49,8 @@ enum TopTabLayout: String, CaseIterable, Identifiable {
     case pills
     case compactPills
     case integrated
+    case ledger
+    case trough
 
     var id: String { rawValue }
 
@@ -45,6 +59,8 @@ enum TopTabLayout: String, CaseIterable, Identifiable {
         case .pills: return String(localized: "Pills")
         case .compactPills: return String(localized: "Compact Pills")
         case .integrated: return String(localized: "Integrated")
+        case .ledger: return String(localized: "Ledger")
+        case .trough: return String(localized: "Trough")
         }
     }
 
@@ -52,6 +68,8 @@ enum TopTabLayout: String, CaseIterable, Identifiable {
         switch self {
         case .pills, .compactPills: return .pills
         case .integrated: return .integrated
+        case .ledger: return .ledger
+        case .trough: return .trough
         }
     }
 
@@ -60,6 +78,8 @@ enum TopTabLayout: String, CaseIterable, Identifiable {
     static func resolve(style: TopTabStyle, compactPills: Bool) -> TopTabLayout {
         switch style {
         case .integrated: return .integrated
+        case .ledger: return .ledger
+        case .trough: return .trough
         case .pills: return compactPills ? .compactPills : .pills
         }
     }

--- a/rootshell/UI/Shared/TabComponents.swift
+++ b/rootshell/UI/Shared/TabComponents.swift
@@ -293,6 +293,7 @@ enum TabMetrics {
     static let closeIconSize: CGFloat = 14
     static let titleInnerPadding: CGFloat = 32
     static let titleFontSize: CGFloat = 17
+    static let troughKnobInset: CGFloat = 4
     #else
     static let tabMaxHeight: CGFloat = 32
     static let tabBarHeight: CGFloat = 44
@@ -302,6 +303,8 @@ enum TabMetrics {
     static let closeIconSize: CGFloat = 10
     static let titleInnerPadding: CGFloat = 20
     static let titleFontSize: CGFloat = 14
+    /// Gap between the trough well and the selected knob riding inside it.
+    static let troughKnobInset: CGFloat = 2
     #endif
 }
 
@@ -318,6 +321,7 @@ struct TabButton: View {
     var secondaryTextColor: Color = .secondary
     var isLightTheme: Bool = false
     var integratedEdgePalette: IntegratedTabEdgePalette = .fallback
+    var indicatorColor: Color = .accentColor  // Ledger selection bar
     let namespace: Namespace.ID?
     let onTap: () -> Void
     let onClose: () -> Void
@@ -339,6 +343,7 @@ struct TabButton: View {
     @State private var isHovered: Bool = false
     @State private var isCloseHovered: Bool = false
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// iOS 27 / macOS 27 desaturate saturated content drawn on Liquid Glass (the
@@ -367,14 +372,25 @@ struct TabButton: View {
     /// - Mac Catalyst: hover only
     /// - iPad: hover OR selected tab (touch fallback)
     private var shouldShowCloseButton: Bool {
-        if style == .integrated {
+        switch style {
+        case .integrated:
             return isSelected || isHovered || tabWidth >= integratedInactiveCloseThreshold
+        case .pills, .ledger, .trough:
+            #if targetEnvironment(macCatalyst)
+            return isHovered
+            #else
+            return isHovered || isSelected
+            #endif
         }
-        #if targetEnvironment(macCatalyst)
-        return isHovered
-        #else
-        return isHovered || isSelected
-        #endif
+    }
+
+    /// Ledger has no hover fill, so the title itself brightens on hover.
+    private var titleColor: Color {
+        if isSelected { return textColor }
+        if style == .ledger, isHovered {
+            return secondaryTextColor.blended(toward: textColor, amount: 0.6)
+        }
+        return secondaryTextColor
     }
 
     private var integratedInactiveCloseThreshold: CGFloat {
@@ -410,7 +426,11 @@ struct TabButton: View {
 
             Text(title)
                 .font(.system(size: TabMetrics.titleFontSize, weight: isSelected ? .medium : .regular))
-                .foregroundColor(isSelected ? textColor : secondaryTextColor)
+                .foregroundColor(titleColor)
+                .animation(
+                    style == .ledger && !reduceMotion ? .easeOut(duration: 0.12) : nil,
+                    value: isHovered
+                )
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
@@ -427,23 +447,31 @@ struct TabButton: View {
             if let shortcut = keyboardShortcut {
                 Text(shortcut)
                     .font(.system(size: 11, weight: .regular))
-                    .foregroundColor(isSelected ? textColor.opacity(0.6) : secondaryTextColor.opacity(0.6))
+                    .foregroundColor(titleColor.opacity(0.6))
                     .fixedSize()
             }
 
             // Health indicator (only show if enabled and health data available)
             if showHealthIndicator, let health = connectionHealth {
-                ConnectionHealthIndicator(health: health, textColor: isSelected ? textColor : secondaryTextColor)
+                ConnectionHealthIndicator(health: health, textColor: titleColor)
                     .fixedSize()
             }
         }
         .frame(minWidth: 0)
     }
 
+    private var closeTargetSize: CGSize {
+        switch style {
+        case .integrated: return CGSize(width: 44, height: TabMetrics.tabBarHeight)
+        case .ledger: return CGSize(width: 28, height: TabMetrics.tabBarHeight)
+        case .pills, .trough: return CGSize(width: TabMetrics.closeButtonSize, height: TabMetrics.closeButtonSize)
+        }
+    }
+
     private var closeButton: some View {
         Button(action: onClose) {
             ZStack {
-                if style == .integrated {
+                if style.usesStripLayout {
                     Circle()
                         .fill((isSelected ? textColor : secondaryTextColor).opacity(isLightTheme ? 0.10 : 0.14))
                         .frame(width: 20, height: 20)
@@ -455,14 +483,11 @@ struct TabButton: View {
                     .font(.system(size: TabMetrics.closeIconSize, weight: .medium))
                     .foregroundColor(isSelected ? textColor : secondaryTextColor)
             }
-            .frame(
-                width: style == .integrated ? 44 : TabMetrics.closeButtonSize,
-                height: style == .integrated ? TabMetrics.tabBarHeight : TabMetrics.closeButtonSize
-            )
+            .frame(width: closeTargetSize.width, height: closeTargetSize.height)
             .offset(y: style == .integrated ? 2 : 0)
         }
         .onHover { hovering in
-            if style == .integrated {
+            if style.usesStripLayout {
                 isCloseHovered = hovering
             }
         }
@@ -476,7 +501,8 @@ struct TabButton: View {
 
     var body: some View {
         Group {
-            if style == .integrated {
+            switch style {
+            case .integrated:
                 HStack(spacing: 4) {
                     titleContent
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -507,7 +533,11 @@ struct TabButton: View {
                     )
                 }
                 .contentShape(Rectangle())
-            } else {
+            case .ledger:
+                ledgerContent
+            case .trough:
+                capsuleContent(inset: TabMetrics.troughKnobInset)
+            case .pills:
                 pillContent
             }
         }
@@ -551,6 +581,12 @@ struct TabButton: View {
     }
 
     private var pillContent: some View {
+        capsuleContent(inset: 0)
+    }
+
+    /// Pill treatment. A non-zero `inset` shrinks the capsule so it rides as
+    /// the knob inside the trough well; the tab's full frame stays tappable.
+    private func capsuleContent(inset: CGFloat) -> some View {
         Group {
             #if os(visionOS)
             // visionOS: HStack layout so close button takes explicit space and never overlaps title
@@ -583,8 +619,8 @@ struct TabButton: View {
         // in the chain and still inherits the parent animation.
         .transaction { $0.animation = nil }
         .padding(.horizontal, TabMetrics.horizontalPadding)
-        .padding(.vertical, TabMetrics.verticalPadding)
-        .frame(maxWidth: .infinity, maxHeight: TabMetrics.tabMaxHeight)
+        .padding(.vertical, TabMetrics.verticalPadding - inset)
+        .frame(maxWidth: .infinity, maxHeight: TabMetrics.tabMaxHeight - inset * 2)
         .modifier(GlassTabBackgroundModifier(
             isSelected: isSelected,
             selectedBackgroundColor: selectedBackgroundColor,
@@ -594,11 +630,107 @@ struct TabButton: View {
             isLightTheme: isLightTheme,
             isHovered: isHovered
         ))
-        .contentShape(Capsule())
+        .padding(.horizontal, inset)
+        .contentShape(inset > 0 ? AnyShape(Rectangle()) : AnyShape(Capsule()))
         #if os(visionOS)
         .contentShape(.hoverEffect, Capsule())
         .hoverEffect(.highlight)
         #endif
+    }
+
+    /// Text-only tab. The close button stays in the tree (hidden via opacity)
+    /// so the title never reflows on hover.
+    private var ledgerContent: some View {
+        HStack(spacing: 4) {
+            titleContent
+                .frame(maxWidth: .infinity, alignment: .leading)
+            closeButton
+        }
+        .transaction { $0.animation = nil }
+        .padding(.leading, TabMetrics.horizontalPadding + 2)
+        .padding(.trailing, 6)
+        .frame(maxWidth: .infinity, maxHeight: TabMetrics.tabBarHeight)
+        .overlay(alignment: .bottom) {
+            LedgerTabIndicator(
+                isSelected: isSelected,
+                color: colorSchemeContrast == .increased ? textColor : indicatorColor,
+                namespace: namespace
+            )
+        }
+        .contentShape(Rectangle())
+        #if os(visionOS)
+        .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .hoverEffect(.highlight)
+        #endif
+    }
+}
+
+/// Ledger selection bar. Full tab width and bottom-aligned so it sits on,
+/// and occludes, the strip keyline under the active tab.
+private struct LedgerTabIndicator: View {
+    let isSelected: Bool
+    let color: Color
+    let namespace: Namespace.ID?
+
+    static let height: CGFloat = 2
+
+    var body: some View {
+        if isSelected {
+            let bar = Rectangle()
+                .fill(color)
+                .frame(height: Self.height)
+                .frame(maxWidth: .infinity)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            if let namespace {
+                bar.matchedGeometryEffect(id: "ledgerSelectedTab", in: namespace)
+            } else {
+                bar
+            }
+        }
+    }
+}
+
+/// Trough well: the shared segmented-control track behind the tab run. Drawn
+/// as a plain theme fill (never glass) so the selected knob's Liquid Glass
+/// is not nested inside another glass surface.
+struct TroughWellBackground: View {
+    let segmentCount: Int
+    let selectedSegment: Int?
+    let segmentWidth: CGFloat
+    let theme: ResolvedTabBarTheme
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var flat: Bool {
+        reduceTransparency || colorSchemeContrast == .increased
+    }
+
+    private var hairline: Color {
+        theme.tabText.opacity(theme.isLight ? 0.12 : 0.16)
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(theme.unselectedBackground.opacity(flat ? 1 : 0.6))
+                .overlay(Capsule().strokeBorder(hairline, lineWidth: 0.5))
+
+            // Segment dividers, dropped on either side of the knob.
+            ForEach(1..<max(segmentCount, 1), id: \.self) { index in
+                let touchesKnob = selectedSegment.map { index == $0 || index == $0 + 1 } ?? false
+                Rectangle()
+                    .fill(hairline)
+                    .frame(width: 0.5, height: TabMetrics.tabMaxHeight / 2)
+                    .offset(x: CGFloat(index) * segmentWidth - 0.25)
+                    .opacity(touchesKnob ? 0 : 1)
+            }
+        }
+        .frame(height: TabMetrics.tabMaxHeight)
+        .frame(maxHeight: .infinity)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
     }
 }
 
@@ -991,6 +1123,8 @@ final class TabStyleContextMenuCoordinator: NSObject, UIContextMenuInteractionDe
                     systemImage: "rectangle.topthird.inset.filled",
                     selectedLayout: selectedLayout
                 ),
+                self.action(for: .ledger, systemImage: "underline", selectedLayout: selectedLayout),
+                self.action(for: .trough, systemImage: "rectangle.split.3x1", selectedLayout: selectedLayout),
             ]
             return UIMenu(children: actions)
         }

--- a/rootshell/UI/Shell/MainView+Body.swift
+++ b/rootshell/UI/Shell/MainView+Body.swift
@@ -161,7 +161,7 @@ extension MainView {
             )
         }
         .overlay(alignment: .leading) {
-            if topTabStyle == .integrated {
+            if topTabStyle.usesStripLayout {
                 Rectangle()
                     .fill(theme.tabText.opacity(theme.isLight ? 0.16 : 0.22))
                     .frame(width: 0.5, height: 18)
@@ -226,7 +226,7 @@ extension MainView {
         // clips the integrated edge across the traffic-light clearance. Outer
         // frame is unchanged, leaving drag-region geometry alone.
         tabBarChromeBackground(theme)
-            .padding(.bottom, topTabStyle == .integrated ? IntegratedTabEdgeMetrics.reservedThickness : 0)
+            .padding(.bottom, topTabStyle.usesStripLayout ? IntegratedTabEdgeMetrics.reservedThickness : 0)
             .frame(width: tabBarLeadingPadding, height: 44)
             .overlay {
                 TabStyleContextMenuRegion(selectedStyleRawValue: $topTabStyleRawValue)

--- a/rootshell/UI/Shell/MainView+TabBarStyling.swift
+++ b/rootshell/UI/Shell/MainView+TabBarStyling.swift
@@ -47,6 +47,7 @@ struct ResolvedTabBarTheme {
     let overrideUnselectedBackground: Color?
     let overrideTabText: Color?
     let overrideTabSecondaryText: Color?
+    let overrideSheetAccent: Color?
 
     static let fallback = ResolvedTabBarTheme(
         themeColors: nil,
@@ -60,7 +61,8 @@ struct ResolvedTabBarTheme {
         overrideSelectedBackground: nil,
         overrideUnselectedBackground: nil,
         overrideTabText: nil,
-        overrideTabSecondaryText: nil
+        overrideTabSecondaryText: nil,
+        overrideSheetAccent: nil
     )
 
     /// Resolved sheet styling for one `MainView.body` evaluation. The crash
@@ -151,6 +153,18 @@ struct ResolvedTabBarTheme {
         if let override = overrideTabSecondaryText { return override }
         guard baseColor != nil else { return .secondary }
         return isLight ? Color(white: 0.4) : Color(white: 0.6)
+    }
+
+    /// Ledger's selection bar is the only selection cue, so it takes the theme
+    /// accent (same source as sheets and the sidebar) rather than the text
+    /// color, which would read as a second keyline.
+    var ledgerIndicator: Color {
+        if let override = overrideSheetAccent { return override }
+        guard baseColor != nil else { return .accentColor }
+        if let accent = themeColors?.vibrantAccentColor {
+            return accent.adjustedSheetTint(on: tabBarBackground)
+        }
+        return tabText
     }
 }
 
@@ -262,7 +276,8 @@ extension MainView {
                 overrideSelectedBackground: nil,
                 overrideUnselectedBackground: nil,
                 overrideTabText: nil,
-                overrideTabSecondaryText: nil
+                overrideTabSecondaryText: nil,
+                overrideSheetAccent: nil
             )
         }
         #if targetEnvironment(macCatalyst)
@@ -288,7 +303,8 @@ extension MainView {
             overrideSelectedBackground: overrides.selectedTabBackground.flatMap { Color(hex: $0) },
             overrideUnselectedBackground: overrides.unselectedTabBackground.flatMap { Color(hex: $0) },
             overrideTabText: overrides.tabText.flatMap { Color(hex: $0) },
-            overrideTabSecondaryText: overrides.tabSecondaryText.flatMap { Color(hex: $0) }
+            overrideTabSecondaryText: overrides.tabSecondaryText.flatMap { Color(hex: $0) },
+            overrideSheetAccent: overrides.sheetAccent.flatMap { Color(hex: $0) }
         )
     }
 

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -187,7 +187,7 @@ struct MainView: View {
 
     var topTabStyle: TopTabStyle { TopTabStyle.resolve(topTabStyleRawValue) }
     var usesCompactTabSpacing: Bool {
-        topTabStyle == .integrated || compactPillTabSpacing
+        topTabStyle.usesEqualWidthTabs || compactPillTabSpacing
     }
 
 #if !targetEnvironment(macCatalyst) && !os(visionOS)
@@ -452,7 +452,7 @@ struct MainView: View {
                                 // Background layer on purpose: the active tab
                                 // occludes the run beneath it, so the line
                                 // reads as rising around that tab.
-                                if topTabStyle == .integrated {
+                                if topTabStyle.usesStripLayout {
                                     IntegratedTabEdgeRuleView(
                                         palette: resolvedTheme.integratedEdgePalette
                                     )

--- a/rootshell/UI/Tabs/TabBar.swift
+++ b/rootshell/UI/Tabs/TabBar.swift
@@ -56,7 +56,7 @@ enum TabBarSizingPolicy {
             return Decision(mode: .singleTab, equalTabWidth: 0, singleTabWidth: 0, scrollingTabWidth: 0)
         }
 
-        if style == .integrated || usesCompactSpacing {
+        if style.usesEqualWidthTabs || usesCompactSpacing {
             let tabCount = CGFloat(items.count)
             let equalWidth = availableWidth / max(tabCount, 1)
             let resolvedWidth = min(integratedMaximumWidth, equalWidth)
@@ -794,25 +794,27 @@ struct TabBar: View {
                 HStack(spacing: usesCompactSpacing ? 0 : 4) {
                     activeScopeMenu
                     compactScopeMenuSpacer
-                    tabItem(
-                        for: tab,
-                        index: rawIndex,
-                        isOnly: true,
-                        gatewayOwnerIDs: gatewayOwnerIDs,
-                        tabWidth: resolvedWidth
-                    )
-                        .frame(width: resolvedWidth)
-                        .contextMenu {
-                            // Full shared menu — a lone visible tab can still be a
-                            // tmux gateway/window. No move targets with one tab.
-                            tabContextMenu(
-                                for: tab,
-                                index: rawIndex,
-                                moveLeftTarget: nil,
-                                moveRightTarget: nil,
-                                includeThemeOverrideClear: true
-                            )
-                        }
+                    troughWell(segmentCount: 1, segmentWidth: resolvedWidth) {
+                        tabItem(
+                            for: tab,
+                            index: rawIndex,
+                            isOnly: true,
+                            gatewayOwnerIDs: gatewayOwnerIDs,
+                            tabWidth: resolvedWidth
+                        )
+                            .frame(width: resolvedWidth)
+                            .contextMenu {
+                                // Full shared menu — a lone visible tab can still be a
+                                // tmux gateway/window. No move targets with one tab.
+                                tabContextMenu(
+                                    for: tab,
+                                    index: rawIndex,
+                                    moveLeftTarget: nil,
+                                    moveRightTarget: nil,
+                                    includeThemeOverrideClear: true
+                                )
+                            }
+                    }
                 }
                 .fixedSize(horizontal: true, vertical: false)
                 .layoutPriority(1)
@@ -877,32 +879,34 @@ struct TabBar: View {
         HStack(spacing: usesCompactSpacing ? 0 : 4) {
             activeScopeMenu
             compactScopeMenuSpacer
-            ForEach(navigationTabs) { tab in
-                let index = tabsModel.index(of: tab.id) ?? 0
-                let moveLeftTarget = moveTargetRawIndex(for: tab, delta: -1)
-                let moveRightTarget = moveTargetRawIndex(for: tab, delta: 1)
-                equalWidthTabFrame(width: tabWidth) {
-                    tabItem(
-                        for: tab,
-                        index: index,
-                        isOnly: false,
-                        gatewayOwnerIDs: gatewayOwnerIDs,
-                        tabWidth: tabWidth
-                    )
-                        .equatable()
-                }
-                    .contentShape(Rectangle())
-                    .id(tab.id)
-                    .modifier(dragModifier(for: tab, index: index))
-                    .contextMenu {
-                        tabContextMenu(
+            troughWell(segmentCount: navigationTabs.count, segmentWidth: tabWidth) {
+                ForEach(navigationTabs) { tab in
+                    let index = tabsModel.index(of: tab.id) ?? 0
+                    let moveLeftTarget = moveTargetRawIndex(for: tab, delta: -1)
+                    let moveRightTarget = moveTargetRawIndex(for: tab, delta: 1)
+                    equalWidthTabFrame(width: tabWidth) {
+                        tabItem(
                             for: tab,
                             index: index,
-                            moveLeftTarget: moveLeftTarget,
-                            moveRightTarget: moveRightTarget,
-                            includeThemeOverrideClear: false
+                            isOnly: false,
+                            gatewayOwnerIDs: gatewayOwnerIDs,
+                            tabWidth: tabWidth
                         )
+                            .equatable()
                     }
+                        .contentShape(Rectangle())
+                        .id(tab.id)
+                        .modifier(dragModifier(for: tab, index: index))
+                        .contextMenu {
+                            tabContextMenu(
+                                for: tab,
+                                index: index,
+                                moveLeftTarget: moveLeftTarget,
+                                moveRightTarget: moveRightTarget,
+                                includeThemeOverrideClear: false
+                            )
+                        }
+                }
             }
         }
         .contentShape(Rectangle())
@@ -959,31 +963,33 @@ struct TabBar: View {
             HStack(spacing: usesCompactSpacing ? 0 : 8) {
                 activeScopeMenu
                 compactScopeMenuSpacer
-                ForEach(navigationTabs) { tab in
-                    let index = tabsModel.index(of: tab.id) ?? 0
-                    let moveLeftTarget = moveTargetRawIndex(for: tab, delta: -1)
-                    let moveRightTarget = moveTargetRawIndex(for: tab, delta: 1)
-                    tabItem(
-                        for: tab,
-                        index: index,
-                        isOnly: false,
-                        gatewayOwnerIDs: gatewayOwnerIDs,
-                        tabWidth: tabWidth
-                    )
-                        .equatable()
-                        .frame(width: tabWidth)
-                        .contentShape(Rectangle())
-                        .id(tab.id)
-                        .modifier(dragModifier(for: tab, index: index))
-                        .contextMenu {
-                            tabContextMenu(
-                                for: tab,
-                                index: index,
-                                moveLeftTarget: moveLeftTarget,
-                                moveRightTarget: moveRightTarget,
-                                includeThemeOverrideClear: true
-                            )
-                        }
+                troughWell(segmentCount: navigationTabs.count, segmentWidth: tabWidth) {
+                    ForEach(navigationTabs) { tab in
+                        let index = tabsModel.index(of: tab.id) ?? 0
+                        let moveLeftTarget = moveTargetRawIndex(for: tab, delta: -1)
+                        let moveRightTarget = moveTargetRawIndex(for: tab, delta: 1)
+                        tabItem(
+                            for: tab,
+                            index: index,
+                            isOnly: false,
+                            gatewayOwnerIDs: gatewayOwnerIDs,
+                            tabWidth: tabWidth
+                        )
+                            .equatable()
+                            .frame(width: tabWidth)
+                            .contentShape(Rectangle())
+                            .id(tab.id)
+                            .modifier(dragModifier(for: tab, index: index))
+                            .contextMenu {
+                                tabContextMenu(
+                                    for: tab,
+                                    index: index,
+                                    moveLeftTarget: moveLeftTarget,
+                                    moveRightTarget: moveRightTarget,
+                                    includeThemeOverrideClear: true
+                                )
+                            }
+                    }
                 }
             }
             .padding(.leading, usesCompactSpacing ? 0 : 8)
@@ -1001,15 +1007,38 @@ struct TabBar: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Compact pills intentionally abut one another, but the scope menu is a
-    /// separate control and should retain the small visual break used by the
-    /// regular pill layout.
+    /// Compact pills and the trough well intentionally abut, but the scope
+    /// menu is a separate control and should retain the small visual break
+    /// used by the regular pill layout.
     @ViewBuilder
     private var compactScopeMenuSpacer: some View {
         if usesCompactSpacing,
-           style == .pills,
+           !style.usesStripLayout,
            activeScopeMenuWidth > 0 {
             Color.clear.frame(width: 4)
+        }
+    }
+
+    /// Trough: the shared well behind the tab run. Other styles get the
+    /// content unwrapped so their layout is untouched.
+    @ViewBuilder
+    private func troughWell<Content: View>(
+        segmentCount: Int,
+        segmentWidth: CGFloat,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if style == .trough {
+            HStack(spacing: 0) { content() }
+                .background {
+                    TroughWellBackground(
+                        segmentCount: segmentCount,
+                        selectedSegment: tabsModel.selectedTabID.flatMap { tabsModel.navigationIndex(of: $0) },
+                        segmentWidth: segmentWidth,
+                        theme: theme
+                    )
+                }
+        } else {
+            content()
         }
     }
 
@@ -1240,6 +1269,7 @@ struct TabBarItem: View, Equatable {
             && lhs.theme.unselectedBackground == rhs.theme.unselectedBackground
             && lhs.theme.tabText == rhs.theme.tabText
             && lhs.theme.tabSecondaryText == rhs.theme.tabSecondaryText
+            && lhs.theme.ledgerIndicator == rhs.theme.ledgerIndicator
     }
 
     var body: some View {
@@ -1255,6 +1285,7 @@ struct TabBarItem: View, Equatable {
             secondaryTextColor: theme.tabSecondaryText,
             isLightTheme: theme.isLight,
             integratedEdgePalette: theme.integratedEdgePalette,
+            indicatorColor: theme.ledgerIndicator,
             namespace: tabNamespace,
             onTap: onTap,
             onClose: onClose,

--- a/rootshell/UI/Window/WindowAccessor.swift
+++ b/rootshell/UI/Window/WindowAccessor.swift
@@ -1353,7 +1353,7 @@ private class TransparentWindowView: UIView {
         )
         configureTitlebarSeparator(
             for: window,
-            hidden: topTabStyle == .integrated && tabsInTitlebar && !tabBarHidden
+            hidden: topTabStyle.usesStripLayout && tabsInTitlebar && !tabBarHidden
         )
         configureWindowDragging(
             for: window,


### PR DESCRIPTION
Ledger: text-only tabs on the keylined strip with a sliding theme-accent indicator bar. Trough: a segmented-control well with the selected tab as an inset glass knob.

Split the "not pills" checks into usesStripLayout (keyline family: Integrated, Ledger) and usesEqualWidthTabs (sizing family: all but Pills). Adds ResolvedTabBarTheme.ledgerIndicator and the two new context-menu actions.