### PR TITLE
fix(automation): open folders reliably from odoc

### DIFF
--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -668,34 +668,59 @@ class CatalystAppDelegate: AppDelegate {
     // MARK: - URL Handling
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        logger.info("AppDelegate received URL: \(url.absoluteString)")
-        return Self.routeAutomationURL(url)
+        return Self.routeAutomationURL(url, source: "appDelegate.open")
     }
 
-    /// Shared by the app- and scene-level URL entry points. Handles
-    /// ssh://, mosh://, and folders (`odoc` from Finder/BBEdit → local
-    /// shell at that folder). Returns false for anything else.
+    /// Shared by the app-, scene- and AppleScript-level entry points. Handles
+    /// ssh://, mosh://, and file URLs (`odoc` from Finder/BBEdit → local shell
+    /// at that folder, or at a file's parent). Returns false for anything else;
+    /// true also covers a delivery the coordinator suppressed as a duplicate.
     @discardableResult
-    static func routeAutomationURL(_ url: URL) -> Bool {
+    static func routeAutomationURL(_ url: URL, source: String) -> Bool {
         if let components = SSHURLParser.parse(url) {
-            logger.info("Parsed SSH URL: \(components.displayString)")
-            AppIntentCoordinator.shared.deposit(.openSSH(components))
+            logger.info("[urlopen] route source=\(source, privacy: .public) kind=ssh")
+            AppIntentCoordinator.shared.depositURLRequest(.openSSH(components), source: source)
             return true
         }
 
         if let components = MoshURLParser.parse(url) {
-            logger.info("Parsed Mosh URL: \(components.displayString)")
-            AppIntentCoordinator.shared.deposit(.openMosh(components))
+            logger.info("[urlopen] route source=\(source, privacy: .public) kind=mosh")
+            AppIntentCoordinator.shared.depositURLRequest(.openMosh(components), source: source)
             return true
         }
 
-        if url.isFileURL, url.isExistingDirectory {
-            logger.info("Opening local shell at folder: \(url.path, privacy: .private)")
-            AppIntentCoordinator.shared.deposit(.openLocalShell(directory: url.path, command: nil))
+        if let directory = shellDirectory(for: url) {
+            logger.info("[urlopen] route source=\(source, privacy: .public) kind=folder path=\(directory, privacy: .private)")
+            AppIntentCoordinator.shared.depositURLRequest(
+                .openLocalShell(directory: directory, command: nil),
+                source: source
+            )
             return true
         }
 
+        logger.info("[urlopen] route source=\(source, privacy: .public) kind=unhandled scheme=\(url.scheme ?? "-", privacy: .public)")
         return false
+    }
+
+    /// A folder opens a shell at itself, a file at its parent. `hasDirectoryPath`
+    /// is lexical, so a LaunchServices folder URL still classifies when the
+    /// sandbox refuses the stat. Returns nil for anything we won't open, which
+    /// lets the caller fall back to its own handling.
+    private static func shellDirectory(for url: URL) -> String? {
+        guard url.isFileURL else { return nil }
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+        if url.isExistingDirectory || url.hasDirectoryPath { return url.path }
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+
+        // Only the standalone build embeds the shell helper, so elsewhere a
+        // file can't become a local shell — leave it to the file-open path.
+        #if STANDALONE
+        return url.deletingLastPathComponent().path
+        #else
+        return nil
+        #endif
     }
 
     // MARK: - Scene Configuration
@@ -1613,7 +1638,7 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         // Handle URLs that launched the app (cold start)
-        handleURLContexts(connectionOptions.urlContexts)
+        handleURLContexts(connectionOptions.urlContexts, source: "scene.willConnect")
     }
 
     /// Detect the visor's UIScene. SwiftUI's `session.configuration.name`
@@ -1671,13 +1696,12 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         // Handle URLs opened while app is running
-        handleURLContexts(URLContexts)
+        handleURLContexts(URLContexts, source: "scene.openURLContexts")
     }
 
-    private func handleURLContexts(_ urlContexts: Set<UIOpenURLContext>) {
+    private func handleURLContexts(_ urlContexts: Set<UIOpenURLContext>, source: String) {
         for context in urlContexts {
-            logger.info("Received URL: \(context.url.absoluteString)")
-            CatalystAppDelegate.routeAutomationURL(context.url)
+            CatalystAppDelegate.routeAutomationURL(context.url, source: source)
         }
     }
 

--- a/rootshell/App/RootShellApp.swift
+++ b/rootshell/App/RootShellApp.swift
@@ -183,11 +183,13 @@ struct RootShellApp: App {
                     }
                     // Handle ssh:// and ssh: URLs
                     else if let components = SSHURLParser.parse(url) {
-                        AppIntentCoordinator.shared.deposit(.openSSH(components))
+                        AppIntentCoordinator.shared.depositURLRequest(
+                            .openSSH(components), source: "app.onOpenURL")
                     }
                     // Handle mosh:// and mosh: URLs
                     else if let components = MoshURLParser.parse(url) {
-                        AppIntentCoordinator.shared.deposit(.openMosh(components))
+                        AppIntentCoordinator.shared.depositURLRequest(
+                            .openMosh(components), source: "app.onOpenURL")
                     }
                 }
                 .onContinueUserActivity(TrzszTransferActivity.activityType) { activity in

--- a/rootshell/Core/FileOpen/FileOpenCoordinator.swift
+++ b/rootshell/Core/FileOpen/FileOpenCoordinator.swift
@@ -9,8 +9,9 @@
 //  event carries the receiving MainView's window ID, so global notification
 //  fan-out cannot let a different window steal the editor tab.
 //
-//  iOS/iPadOS/visionOS only: on macOS the coordinator turns file URLs into
-//  an unsupported-platform alert (registration is shared through Info.plist).
+//  iOS/iPadOS/visionOS only: on macOS a file becomes a local shell at its
+//  folder (CatalystAppDelegate), or this unsupported-platform alert in the
+//  variants that ship no helper.
 //
 
 import Foundation
@@ -49,6 +50,8 @@ final class FileOpenCoordinator {
 
     func handleIncomingFileURL(_ url: URL, targetWindowID: String) {
         #if targetEnvironment(macCatalyst)
+        // Reached only for a file macOS won't turn into a local shell (no
+        // bundled helper outside the standalone build).
         let path = url.path
         let filename = url.lastPathComponent
         let message = String(

--- a/rootshell/Features/AppIntents/AppIntentCoordinator.swift
+++ b/rootshell/Features/AppIntents/AppIntentCoordinator.swift
@@ -17,6 +17,9 @@
 
 import Foundation
 import UIKit
+import os
+
+private let logger = Logger(subsystem: "com.rootshell", category: "AppIntentCoordinator")
 
 extension Notification.Name {
     /// Posted after an intent request was deposited.
@@ -49,6 +52,63 @@ final class AppIntentCoordinator {
     func consumeAll() -> [IntentRequest] {
         defer { pending.removeAll() }
         return pending
+    }
+
+    // MARK: - URL / Apple event deposits
+
+    /// One open reaches us through several paths at once (odoc command, scene
+    /// urlContexts, app- and window-level .onOpenURL). Each invocation gets a
+    /// record that accumulates the paths which delivered it; a delivery is a
+    /// twin only if some record is still waiting on that path, so a path with
+    /// nothing left to answer is a deliberate second invocation.
+    private struct URLDelivery {
+        let key: String
+        var sources: Set<String>
+        var expiresAt: Date
+    }
+
+    private var recentURLDeliveries: [URLDelivery] = []
+    private static let urlDedupeWindow: TimeInterval = 1.5
+
+    /// Returns false when another delivery path already took this request.
+    @discardableResult
+    func depositURLRequest(_ request: IntentRequest, source: String) -> Bool {
+        let now = Date()
+        recentURLDeliveries.removeAll { $0.expiresAt <= now }
+
+        // Keyed on the resolved request, not the url, so /tmp and /tmp/
+        // collapse to one tab.
+        let key = Self.dedupeKey(for: request)
+        let expiresAt = now.addingTimeInterval(Self.urlDedupeWindow)
+
+        // Oldest record still awaiting this path claims the delivery (FIFO), so
+        // interleaved invocations pair off in order.
+        if let index = recentURLDeliveries.firstIndex(where: {
+            $0.key == key && !$0.sources.contains(source)
+        }) {
+            recentURLDeliveries[index].sources.insert(source)
+            recentURLDeliveries[index].expiresAt = expiresAt
+            logger.info("[urlopen] suppressed duplicate source=\(source, privacy: .public)")
+            return false
+        }
+
+        recentURLDeliveries.append(URLDelivery(key: key, sources: [source], expiresAt: expiresAt))
+        logger.info("[urlopen] deposit source=\(source, privacy: .public)")
+        deposit(request)
+        return true
+    }
+
+    private static func dedupeKey(for request: IntentRequest) -> String {
+        switch request {
+        case .openProfile(let profileRequest):
+            return "profile|\(profileRequest.profileID)"
+        case .openLocalShell(let directory, let command):
+            return "shell|\(directory ?? "")|\(command ?? "")"
+        case .openSSH(let components):
+            return "ssh|\(components.displayString)"
+        case .openMosh(let components):
+            return "mosh|\(components.displayString)"
+        }
     }
 
     // MARK: - New-window requests

--- a/rootshell/Features/Automation/AppleScriptCommands.swift
+++ b/rootshell/Features/Automation/AppleScriptCommands.swift
@@ -129,8 +129,17 @@ final class RootshellOpenCommand: NSScriptCommand {
 
         MainActor.assumeIsolated {
             logger.info("[urlopen] odoc items=\(urls.count)")
+            var routed = false
             for url in urls {
-                _ = CatalystAppDelegate.routeAutomationURL(url, source: "applescript.open")
+                if CatalystAppDelegate.routeAutomationURL(url, source: "applescript.open") {
+                    routed = true
+                }
+            }
+            // No reopen event accompanies a document open, so with zero
+            // regular windows the deposit would sit until Cmd-N. The new
+            // window adopts it as its first tab.
+            if routed {
+                CatalystSceneDelegate.openMainWindowIfNoneConnected()
             }
         }
         return nil

--- a/rootshell/Features/Automation/AppleScriptCommands.swift
+++ b/rootshell/Features/Automation/AppleScriptCommands.swift
@@ -12,6 +12,9 @@
 //
 
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.rootshell", category: "Automation")
 
 extension URL {
     /// True for a file URL whose path exists and is a directory.
@@ -107,6 +110,45 @@ final class RootshellCreateWindowCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         performAutomationCommand(self) { AppIntentCoordinator.shared.depositForNewWindow($0) }
         return nil
+    }
+}
+
+/// `open`: the `odoc` Apple event behind Finder's Open With, `open -b`, and a
+/// Dock drop. Handling it here is what makes the folder open deterministic —
+/// declaring the command in the sdef claims the event for Cocoa Scripting, so
+/// without an implementation class the system dispatched it to a no-op.
+@objc(RootshellOpenCommand)
+final class RootshellOpenCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let urls = Self.fileURLs(from: directParameter)
+        guard !urls.isEmpty else {
+            scriptErrorNumber = NSArgumentsWrongScriptError
+            scriptErrorString = "Expected a file or folder to open."
+            return nil
+        }
+
+        MainActor.assumeIsolated {
+            logger.info("[urlopen] odoc items=\(urls.count)")
+            for url in urls {
+                _ = CatalystAppDelegate.routeAutomationURL(url, source: "applescript.open")
+            }
+        }
+        return nil
+    }
+
+    /// The direct parameter arrives as a URL, a path string, or a list of either.
+    private static func fileURLs(from parameter: Any?) -> [URL] {
+        switch parameter {
+        case let url as URL:
+            return [url]
+        case let path as String:
+            let expanded = (path as NSString).expandingTildeInPath
+            return expanded.isEmpty ? [] : [URL(fileURLWithPath: expanded)]
+        case let list as [Any]:
+            return list.flatMap { fileURLs(from: $0) }
+        default:
+            return []
+        }
     }
 }
 

--- a/rootshell/Resources/Rootshell.sdef
+++ b/rootshell/Resources/Rootshell.sdef
@@ -4,7 +4,10 @@
 
 	<suite name="Standard Suite" code="????" description="Common commands for most applications.">
 		<command name="open" code="aevtodoc" description="Open a folder in a new local shell tab.">
-			<direct-parameter description="The folder to open." type="file"/>
+			<cocoa class="RootshellOpenCommand"/>
+			<direct-parameter description="The file or folder to open.">
+				<type type="file" list="yes"/>
+			</direct-parameter>
 		</command>
 	</suite>
 

--- a/rootshell/UI/Shell/MainView+ChangeHandlers.swift
+++ b/rootshell/UI/Shell/MainView+ChangeHandlers.swift
@@ -37,12 +37,22 @@ extension MainView {
             // window may receive at all, and narrowing it makes iPadOS spawn
             // a new empty window for anything outside the set — including
             // plain app-icon activations and ssh/mosh/rootshell URLs.
-            .handlesExternalEvents(preferring: ["file://"], allowing: ["*"])
+            // These are the SCENE's activation conditions, so the hidden visor
+            // must not advertise itself as a file:// target.
+            .handlesExternalEvents(
+                preferring: isVisorWindow ? ["visor-terminal"] : ["file://"],
+                allowing: isVisorWindow ? ["visor-terminal"] : ["*"]
+            )
             .onOpenURL { url in
                 guard url.isFileURL else { return }
                 #if targetEnvironment(macCatalyst)
-                // Folders become a shell tab via CatalystSceneDelegate.
-                if url.isExistingDirectory { return }
+                // A folder (or a file's folder) is a shell tab, not a document.
+                // The scene delegate may deliver the same open; deposits dedupe.
+                // Whatever the router declines falls through to the file path.
+                Ghostty.logger.info("[urlopen] onOpenURL window=\(windowId, privacy: .public)")
+                if CatalystAppDelegate.routeAutomationURL(url, source: "mainView.onOpenURL") {
+                    return
+                }
                 #endif
                 FileOpenCoordinator.shared.handleIncomingFileURL(
                     url,

--- a/rootshell/UI/Shell/MainView+ConnectionSheet.swift
+++ b/rootshell/UI/Shell/MainView+ConnectionSheet.swift
@@ -384,9 +384,16 @@ extension MainView {
     #if !CHINA_BUILD
     func handleVPNIntent() {
         // VPN intent notifications are global; with multiple windows only
-        // the key window should open Settings > VPN.
-        let windowScenes = UIApplication.shared.connectedScenes
+        // the key window should open Settings > VPN. The hidden visor never
+        // should, and its connected scene must not inflate the count.
+        guard !isVisorWindow else { return }
+        let connected = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
+        #if targetEnvironment(macCatalyst)
+        let windowScenes = connected.filter { !CatalystSceneDelegate.isVisorScene($0) }
+        #else
+        let windowScenes = connected
+        #endif
         if windowScenes.count > 1 && !windowIsKeyWindow {
             return
         }

--- a/rootshell/UI/Shell/MainView+EventHandlers.swift
+++ b/rootshell/UI/Shell/MainView+EventHandlers.swift
@@ -211,6 +211,9 @@ extension MainView {
                 // AppleScript `create window`: the staged request is this
                 // window's content, so skip the default local shell.
                 dispatchClaimedIntentRequests([newWindowRequest])
+            } else if pendingState == nil, adoptPendingIntentRequestsAsFirstContent() {
+                // A folder/URL open that landed before this window appeared is
+                // this window's content.
             } else if pendingState == nil, HelperConnection.shared.isKnownRunning {
                 // createLocalShellTab() runs synchronously now: performLocalShellAction()
                 // takes its fast path when the helper is already confirmed up.
@@ -224,6 +227,9 @@ extension MainView {
                         RestorationHealthTracker.shared.markRestorationStarted()
                         Ghostty.logger.info("Restoring window state: \(savedState.tabs.count) tabs")
                         self.restoreWindowState(savedState)
+                    } else if self.adoptPendingIntentRequestsAsFirstContent() {
+                        // On cold launch the URL often lands during the helper
+                        // await above, after the synchronous claim missed it.
                     } else {
                         // Normal fresh start - helper is already running from above
                         self.checkHelperAndCreateInitialTab()

--- a/rootshell/UI/Shell/MainView+IntentRequests.swift
+++ b/rootshell/UI/Shell/MainView+IntentRequests.swift
@@ -19,10 +19,21 @@ extension MainView {
     /// window wins; if no window is key (cold-start foregrounding), the
     /// deferred pass still claims — a request is never dropped.
     func consumePendingIntentRequests(retriesRemaining: Int = 20) {
+        // A request claimed here would open its tab off-screen; the visor's
+        // terminal comes from VisorController alone.
+        guard !isVisorWindow else { return }
         guard AppIntentCoordinator.shared.hasPending else { return }
 
-        let windowScenes = UIApplication.shared.connectedScenes
+        // The hidden visor scene stays connected once summoned. Counting it
+        // would push a lone visible window into the deferred branch below and
+        // let the visor race it for the request.
+        let connected = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
+        #if targetEnvironment(macCatalyst)
+        let windowScenes = connected.filter { !CatalystSceneDelegate.isVisorScene($0) }
+        #else
+        let windowScenes = connected
+        #endif
         if windowScenes.count > 1 && !windowIsKeyWindow {
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 700_000_000)
@@ -51,7 +62,25 @@ extension MainView {
             return
         }
 
-        dispatchClaimedIntentRequests(AppIntentCoordinator.shared.consumeAll())
+        let claimed = AppIntentCoordinator.shared.consumeAll()
+        guard !claimed.isEmpty else { return }
+        Ghostty.logger.info("[urlopen] claim window=\(windowId, privacy: .public) key=\(windowIsKeyWindow) count=\(claimed.count)")
+        dispatchClaimedIntentRequests(claimed)
+    }
+
+    /// Catalyst empty-window bring-up: a request deposited before this window
+    /// appeared is this window's content, so it becomes the FIRST tab instead
+    /// of a default shell followed by a second one. Claim and dispatch are one
+    /// MainActor step; `false` means nothing was pending and the caller must
+    /// fall back to its default shell.
+    @discardableResult
+    func adoptPendingIntentRequestsAsFirstContent() -> Bool {
+        guard !isVisorWindow, AppIntentCoordinator.shared.hasPending else { return false }
+        let requests = AppIntentCoordinator.shared.consumeAll()
+        guard !requests.isEmpty else { return false }
+        Ghostty.logger.info("[urlopen] adopt-as-first window=\(windowId, privacy: .public) count=\(requests.count)")
+        dispatchClaimedIntentRequests(requests)
+        return true
     }
 
     /// Routes already-claimed requests (AppleScript `create window` hands a
@@ -76,6 +105,7 @@ extension MainView {
             case .openProfile(let profileRequest):
                 handleProfileIntent(profileRequest)
             case .openLocalShell(let directory, let command):
+                Ghostty.logger.info("[urlopen] dispatch window=\(windowId, privacy: .public) dir=\(directory ?? "-", privacy: .private)")
                 createLocalShellTab(intentDirectory: directory, startupCommand: command)
             case .openSSH(let components):
                 handleSSHURL(components)

--- a/rootshell/UI/Shell/MainView+TabManagement.swift
+++ b/rootshell/UI/Shell/MainView+TabManagement.swift
@@ -446,6 +446,8 @@ extension MainView {
     /// that doesn't exist falls back to HOME inside the session.
     /// `startupCommand` (AppleScript) is typed into the shell once it starts.
     func createLocalShellTab(intentDirectory: String?, startupCommand: String? = nil) {
+        // Backstop: automation must never materialize a tab in the hidden visor.
+        guard !isVisorWindow else { return }
         performLocalShellAction(description: "open a local shell tab") {
             let resolved = intentDirectory
                 .flatMap { Self.resolveIntentDirectory($0) }

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -50,6 +50,9 @@ struct MainView: View {
     @SceneStorage("windowId") var sceneWindowId: String = UUID().uuidString
     var overrideWindowId: String? = nil
     var windowId: String { overrideWindowId ?? sceneWindowId }
+    /// The visor's hidden panel: it must never claim work meant for a window
+    /// the user can see.
+    var isVisorWindow: Bool { windowId == "visor" }
     @State var isWindowFocused: Bool = false
     @State var windowIsKeyWindow: Bool = false
     @State var lifecycleScenePhase: ScenePhase = {


### PR DESCRIPTION
The sdef claimed aevt/odoc for Cocoa Scripting with no implementation class, so the event was dispatched to a no-op. Add RootshellOpenCommand, keep the hidden visor out of the request path, and dedupe deposits across delivery paths.