### PR TITLE
fix(push): preserve decrypted content on redelivery

### DIFF
--- a/Packages/RootshellPushKit/Tests/RootshellPushKitTests/VectorTests.swift
+++ b/Packages/RootshellPushKit/Tests/RootshellPushKitTests/VectorTests.swift
@@ -78,9 +78,13 @@ final class VectorTests: XCTestCase {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: dir) }
         let state = PushSharedState(container: dir)
-        let record = PushEventRecord(eid: "e1", status: nil, agent: nil, thread: nil, route: nil)
+        let record = PushEventRecord(eid: "e1", status: "done", agent: "codex", thread: "first", route: nil)
         XCTAssertTrue(state.claim(record))
-        XCTAssertFalse(state.claim(record))
+        let redelivery = PushEventRecord(eid: "e1", status: "failed", agent: "claude-code", thread: "retry", route: nil)
+        XCTAssertFalse(state.claim(redelivery))
+        // A repeated delivery is bookkeeping-only: it must not replace the
+        // original event record used for notification arbitration.
+        XCTAssertEqual(state.load(), [record])
         XCTAssertTrue(state.claim(PushEventRecord(eid: "e2", status: nil, agent: nil, thread: nil, route: nil)))
         XCTAssertEqual(state.load().map(\.eid), ["e1", "e2"])
         state.release(eid: "e1")

--- a/PushNotificationService/NotificationService.swift
+++ b/PushNotificationService/NotificationService.swift
@@ -106,11 +106,13 @@ nonisolated final class NotificationService: UNNotificationServiceExtension {
         content.userInfo = info
         decrypted = content
 
-        // Relay retries and replays carry the same eid; only the first copy is shown.
-        guard shared.claim(PushEventRecord(header: header, eid: envelope.eid)) else {
-            decrypted = nil
-            finish(silence(content, reason: "duplicate"))
-            return
+        // APNs uses eid as the collapse id, so a relay retry updates the same
+        // notification. Keep the claim as one-shot ledger bookkeeping, but
+        // never replace already-decrypted content with a blank notification:
+        // iOS can resurface the original encrypted placeholder while applying
+        // that collapsed update.
+        if !shared.claim(PushEventRecord(header: header, eid: envelope.eid)) {
+            Self.logger.info("redelivered eid=\(self.eid, privacy: .public): keeping decrypted content")
         }
 
         if header.kind == "agent", policy.showsAgentLogos {

--- a/rootshell/Features/Push/PushNotificationRouter.swift
+++ b/rootshell/Features/Push/PushNotificationRouter.swift
@@ -100,11 +100,12 @@ enum PushNotificationRouter {
         if let dict = try? header.userInfoDictionary() {
             content.userInfo = [PushConfiguration.headerUserInfoKey: dict]
         }
-        // Relay retries and replays carry the same eid; only the first copy is shown.
-        guard shared.claim(PushEventRecord(header: header, eid: eid)) else {
-            logger.info("dropped duplicate eid=\(eid, privacy: .public)")
-            await removeRawDelivered(eid: eid)
-            return
+        // The stable local identifier below makes retries idempotent. The
+        // claim only controls ledger bookkeeping; a duplicate must still
+        // replace any raw encrypted notification with decrypted content.
+        let createdClaim = shared.claim(PushEventRecord(header: header, eid: eid))
+        if !createdClaim {
+            logger.info("replacing redelivered eid=\(eid, privacy: .public) with decrypted content")
         }
         // A suppressed remote push still lands in Notification Center history on
         // macOS. Drop the raw copy before posting the decrypted one so the two
@@ -115,7 +116,7 @@ enum PushNotificationRouter {
             try await UNUserNotificationCenter.current().add(request)
         } catch {
             logger.error("local re-post failed: \(String(describing: error), privacy: .public)")
-            shared.release(eid: eid)
+            if createdClaim { shared.release(eid: eid) }
             return
         }
     }


### PR DESCRIPTION
Treat duplicate event claims as ledger bookkeeping instead of blanking collapsed APNs redeliveries. Keep local reposts idempotent and decrypted.