### PR TITLE
perf(theme): parse themes on demand instead of all 451 at launch

### DIFF
--- a/rootshell/Core/Ghostty/Ghostty.swift
+++ b/rootshell/Core/Ghostty/Ghostty.swift
@@ -34,13 +34,9 @@ enum Ghostty {
         let resourcePath = resourceURL.path
         let themesPath = (resourcePath as NSString).appendingPathComponent("themes")
 
-        // Verify themes directory exists
-        if FileManager.default.fileExists(atPath: themesPath) {
-            logger.info("Found themes directory at: \(themesPath)")
-            if let themes = try? FileManager.default.contentsOfDirectory(atPath: themesPath) {
-                logger.info("   Available themes: \(themes.count)")
-            }
-        } else {
+        // Verify themes directory exists. Deliberately no directory enumeration
+        // here — ThemeManager already walks these files, off the main thread.
+        if !FileManager.default.fileExists(atPath: themesPath) {
             logger.error("Themes directory not found at: \(themesPath)")
         }
 

--- a/rootshell/Core/Migration/GhosttyConfigImporter.swift
+++ b/rootshell/Core/Migration/GhosttyConfigImporter.swift
@@ -633,9 +633,9 @@ final class GhosttyConfigImporter {
                 default: break
                 }
             }
-            let allThemes = Set(ThemeManager.shared.availableThemes.map { $0.name })
             if let day = dayName, let night = nightName,
-               allThemes.contains(day), allThemes.contains(night) {
+               ThemeManager.shared.themeInfo(for: day) != nil,
+               ThemeManager.shared.themeInfo(for: night) != nil {
                 plan.recognized.append(
                     RecognizedChange(
                         category: .theme, key: "theme",
@@ -653,8 +653,7 @@ final class GhosttyConfigImporter {
         }
 
         // Plain name
-        let allThemes = Set(ThemeManager.shared.availableThemes.map { $0.name })
-        if allThemes.contains(value) {
+        if ThemeManager.shared.themeInfo(for: value) != nil {
             plan.recognized.append(
                 RecognizedChange(
                     category: .theme, key: "theme",

--- a/rootshell/Core/Theme/CustomThemeManager.swift
+++ b/rootshell/Core/Theme/CustomThemeManager.swift
@@ -194,11 +194,10 @@ class CustomThemeManager: ObservableObject {
         }
         if conflicts { return .conflictsWithCustom }
 
-        // Check if it shadows a built-in theme
-        let builtIn = ThemeManager.shared.availableThemes.first {
-            $0.name == trimmed && !$0.isCustom
-        }
-        if builtIn != nil { return .shadowsBuiltIn }
+        // Check if it shadows a built-in theme. A file probe, not a catalog scan:
+        // this runs on every keystroke in the editor and must be correct even
+        // before the background load lands.
+        if ThemeManager.shared.builtInThemeExists(named: trimmed) { return .shadowsBuiltIn }
 
         return .valid
     }

--- a/rootshell/Core/Theme/FavoriteThemesManager.swift
+++ b/rootshell/Core/Theme/FavoriteThemesManager.swift
@@ -48,9 +48,10 @@ class FavoriteThemesManager: ObservableObject {
 
     /// Get all favorite themes as ThemeInfo objects, sorted alphabetically
     func favoriteThemes() -> [ThemeManager.ThemeInfo] {
-        let allThemes = ThemeManager.shared.availableThemes
-        return allThemes
-            .filter { favoriteThemeIds.contains($0.id) }
+        // Resolved one name at a time: this runs during SwiftUI body evaluation,
+        // so it must not wait on (or trigger) the full catalog load.
+        favoriteThemeIds
+            .compactMap { ThemeManager.shared.themeInfo(for: $0) }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 

--- a/rootshell/Core/Theme/ThemeManager.swift
+++ b/rootshell/Core/Theme/ThemeManager.swift
@@ -42,7 +42,7 @@ final class ThemeManager {
     /// caught the main thread inside `swift_cvw_initWithCopy` →
     /// `initializeWithCopy for ThemeManager.ThemeInfo` →
     /// `Array.subscript.read` during a scene-update transaction. Each
-    /// `availableThemes[i]` and `themesByFamily[…][i]` access copied the
+    /// `availableThemes[i]` access copied the
     /// struct (URL + ThemeColors with palette array). Reference semantics
     /// reduce per-access cost to a refcount op and remove the bridging
     /// `_ContiguousArrayStorage` paths the crash log captured. All properties
@@ -57,13 +57,23 @@ final class ThemeManager {
         let isLight: Bool  // Pre-computed based on background luminance
         let isCustom: Bool
 
-        struct ThemeColors: Equatable {
+        /// The stored properties and memberwise init are `nonisolated` so the
+        /// background theme parse can build these off the main thread. The
+        /// computed accent helpers below stay main-actor isolated.
+        struct ThemeColors: Equatable, Sendable {
             let background: String
             let foreground: String
             let cursor: String
             let palette: [String]  // 16 palette colors (ANSI 0-15)
 
-            static let `default` = ThemeColors(
+            nonisolated init(background: String, foreground: String, cursor: String, palette: [String]) {
+                self.background = background
+                self.foreground = foreground
+                self.cursor = cursor
+                self.palette = palette
+            }
+
+            nonisolated static let `default` = ThemeColors(
                 background: "#1e1e2e",
                 foreground: "#cdd6f4",
                 cursor: "#f5e0dc",
@@ -108,7 +118,8 @@ final class ThemeManager {
             }
         }
 
-        init(name: String, filePath: URL, colors: ThemeColors, isCustom: Bool = false) {
+        /// `nonisolated`: built off the main thread by the background theme parse.
+        nonisolated init(name: String, filePath: URL, colors: ThemeColors, isCustom: Bool = false) {
             self.id = name
             self.name = name
             self.displayName = name
@@ -134,7 +145,7 @@ final class ThemeManager {
 
         /// Extract theme family from name
         /// Examples: "Catppuccin Mocha" -> "Catppuccin", "Dracula" -> "Dracula"
-        static func extractFamily(from name: String) -> String {
+        nonisolated static func extractFamily(from name: String) -> String {
             // Common patterns for theme families
             let components = name.split(separator: " ")
 
@@ -155,16 +166,31 @@ final class ThemeManager {
 
     private static let themeKey = "selectedTheme"
 
-    /// All available themes
+    /// All available themes. Empty until the background load lands; no launch
+    /// path reads it, and the views that do read it observe this manager.
     private(set) var availableThemes: [ThemeInfo] = []
 
-    /// Themes grouped by family
-    private(set) var themesByFamily: [String: [ThemeInfo]] = [:]
-
-    /// O(1) lookup index rebuilt with `availableThemes`. Internal cache —
-    /// excluded from observation so refilling it during `loadThemes()` doesn't
-    /// invalidate views that only read the `current*` properties.
+    /// Name → theme. Before the background load lands this holds only the themes
+    /// actually asked for; afterwards it is the complete index. Internal cache —
+    /// excluded from observation so refilling it doesn't invalidate views that
+    /// only read the `current*` properties.
     @ObservationIgnored private var themesByName: [String: ThemeInfo] = [:]
+
+    /// Names with no resolvable theme file. Negative-cached because
+    /// `MainView+TabBarStyling` calls `themeInfo(for:)` per body evaluation.
+    @ObservationIgnored private var unresolvableThemeNames: Set<String> = []
+
+    /// Built-in themes from the background load, retained so `reloadThemes()`
+    /// can re-merge custom themes without re-parsing the whole bundle. `nil`
+    /// until that load lands.
+    @ObservationIgnored private var builtInThemes: [ThemeInfo]?
+
+    /// The in-flight (or finished) off-main-thread parse. Retained so cold paths
+    /// can await it instead of re-parsing the bundle on the main actor.
+    @ObservationIgnored private var builtInLoad: Task<[ThemeInfo], Never>?
+
+    /// Bundled themes directory, resolved once at init.
+    @ObservationIgnored private let themesDirectory: URL?
 
     /// Cached ThemeInfo for `currentTheme`. Updated when either the theme
     /// selection or the available themes change. This cache exists to avoid
@@ -178,7 +204,9 @@ final class ThemeManager {
     var currentTheme: String {
         didSet {
             guard oldValue != currentTheme else { return }
-            currentThemeInfo = themesByName[currentTheme]
+            // Must go through the lazy path: DayNightThemeManager writes this
+            // during launch, long before the full catalog lands.
+            currentThemeInfo = themeInfo(for: currentTheme)
             guard ProtectedDataGuard.isAvailable else { return }
             saveTheme()
             themeDidChange.send(currentTheme)
@@ -196,8 +224,13 @@ final class ThemeManager {
             self.currentTheme = "Catppuccin Mocha"
         }
 
-        // Load all themes from bundle
-        loadThemes()
+        self.themesDirectory = Self.locateThemesDirectory()
+
+        // Parse exactly one theme file at launch. This init runs inside
+        // Ghostty.App.init() — i.e. before RootShellApp.init()'s body — so the
+        // full catalog (450+ files) is built off the main thread instead.
+        self.currentThemeInfo = themeInfo(for: currentTheme)
+        startBackgroundLoad()
     }
 
     /// Save current theme to UserDefaults
@@ -205,26 +238,72 @@ final class ThemeManager {
         UserDefaults.standard.set(currentTheme, forKey: Self.themeKey)
     }
 
-    /// Apply the current theme to a Ghostty configuration
-    /// - Parameter config: The configuration to apply the theme to
-    /// - Returns: true if theme was applied successfully, false otherwise
-    func applyTheme(to config: Ghostty.Config) -> Bool {
-        return config.setTheme(currentTheme)
+    /// Get ThemeInfo for a specific theme name, parsing the single backing file
+    /// on a miss. The theme name is the file name, so the path is derivable
+    /// without enumerating the whole directory.
+    func themeInfo(for name: String) -> ThemeInfo? {
+        if let cached = themesByName[name] { return cached }
+        guard !unresolvableThemeNames.contains(name) else { return nil }
+
+        // Custom themes shadow built-ins of the same name.
+        if let custom = CustomThemeManager.shared.customThemes.first(where: { $0.name == name }) {
+            let info = ThemeInfo(customTheme: custom)
+            themesByName[name] = info
+            return info
+        }
+
+        guard let url = builtInThemeURL(for: name),
+              let colors = Self.parseThemeFile(at: url) else {
+            unresolvableThemeNames.insert(name)
+            return nil
+        }
+
+        let info = ThemeInfo(name: name, filePath: url, colors: colors)
+        themesByName[name] = info
+        return info
     }
 
-    /// Get ThemeInfo for a specific theme name
-    func themeInfo(for name: String) -> ThemeInfo? {
-        return themesByName[name]
+    /// Path for a bundled theme. Names reach us from persisted UserDefaults
+    /// (tab/window overrides), so reject path traversal.
+    private func builtInThemeURL(for name: String) -> URL? {
+        guard let themesDirectory, !name.isEmpty, name != "..",
+              !name.contains("/"), !name.contains("\\") else { return nil }
+        return themesDirectory.appendingPathComponent(name)
+    }
+
+    /// Whether a bundled theme file with this name exists. One `stat`, so callers
+    /// that only need an existence answer don't have to wait for the catalog.
+    func builtInThemeExists(named name: String) -> Bool {
+        guard let url = builtInThemeURL(for: name) else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// Await the full catalog. Only the views that render the entire theme list
+    /// need this; everything else resolves single names via `themeInfo(for:)`.
+    /// Awaits the existing background parse rather than redoing it on the main
+    /// actor, and is a no-op once that parse has landed.
+    func ensureThemesLoaded() async {
+        guard builtInThemes == nil, let builtInLoad else { return }
+        applyLoadedThemes(await builtInLoad.value)
     }
 
     /// Reload all themes (built-in + custom). Called by CustomThemeManager after changes.
     func reloadThemes() {
-        loadThemes()
+        // Drop the lazy caches so renamed/edited custom themes aren't served stale.
+        themesByName.removeAll()
+        unresolvableThemeNames.removeAll()
+        guard builtInThemes != nil else {
+            // Still parsing; that load will merge the new custom themes when it lands.
+            Task { await ensureThemesLoaded() }
+            return
+        }
+        rebuildCatalog()
     }
 
     // MARK: - Theme Loading
 
-    private func loadThemes() {
+    /// Locate the bundled themes directory. Called once from `init`.
+    nonisolated private static func locateThemesDirectory() -> URL? {
         let fileManager = FileManager.default
 
         // Try multiple possible locations for themes directory
@@ -248,104 +327,97 @@ final class ThemeManager {
                 .appendingPathComponent("themes")
         ]
 
-        var themesURL: URL?
+        for path in possiblePaths.compactMap({ $0 }) where fileManager.fileExists(atPath: path.path) {
+            Ghostty.logger.info("✓ Found themes directory at: \(path.path)")
+            return path
+        }
+
+        Ghostty.logger.error("Failed to find themes directory in bundle. Checked paths:")
         for path in possiblePaths.compactMap({ $0 }) {
-            Ghostty.logger.info("Checking for themes at: \(path.path)")
-            if fileManager.fileExists(atPath: path.path) {
-                themesURL = path
-                Ghostty.logger.info("✓ Found themes directory at: \(path.path)")
-                break
-            }
+            Ghostty.logger.error("  - \(path.path)")
+        }
+        return nil
+    }
+
+    /// Parse every bundled theme file. Runs off the main thread.
+    nonisolated private static func loadBuiltInThemes(from directory: URL) -> [ThemeInfo] {
+        let keys: [URLResourceKey] = [.isRegularFileKey]
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles]
+        ) else {
+            Ghostty.logger.error("Failed to enumerate themes at: \(directory.path)")
+            return []
         }
 
-        guard let themesURL = themesURL else {
-            Ghostty.logger.error("Failed to find themes directory in bundle. Checked paths:")
-            for path in possiblePaths.compactMap({ $0 }) {
-                Ghostty.logger.error("  - \(path.path)")
-            }
-            return
+        var themes: [ThemeInfo] = []
+        themes.reserveCapacity(files.count)
+        for fileURL in files {
+            // `contentsOfDirectory` already prefetched this — no extra stat.
+            guard (try? fileURL.resourceValues(forKeys: Set(keys)))?.isRegularFile == true else { continue }
+            // The file name is the theme name.
+            let colors = parseThemeFile(at: fileURL) ?? .default
+            themes.append(ThemeInfo(name: fileURL.lastPathComponent, filePath: fileURL, colors: colors))
         }
+        return themes
+    }
 
-        do {
-            let themeFiles = try fileManager.contentsOfDirectory(
-                at: themesURL,
-                includingPropertiesForKeys: [.isRegularFileKey],
-                options: [.skipsHiddenFiles]
-            )
-
-            Ghostty.logger.info("Found \(themeFiles.count) files in themes directory")
-
-            var themes: [ThemeInfo] = []
-
-            for fileURL in themeFiles {
-                // Skip directories
-                var isDirectory: ObjCBool = false
-                guard fileManager.fileExists(atPath: fileURL.path, isDirectory: &isDirectory),
-                      !isDirectory.boolValue else {
-                    continue
-                }
-
-                // Use the file name as the theme name
-                let themeName = fileURL.lastPathComponent
-
-                // Parse the theme file to extract colors
-                let colors = parseThemeFile(at: fileURL)
-
-                let themeInfo = ThemeInfo(
-                    name: themeName,
-                    filePath: fileURL,
-                    colors: colors
-                )
-
-                themes.append(themeInfo)
-            }
-
-            // Sort themes alphabetically by name
-            themes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-
-            // Merge custom themes
-            let customThemes = CustomThemeManager.shared.customThemes.map { ThemeInfo(customTheme: $0) }
-            // Remove any built-in themes that are shadowed by custom themes
-            let customNames = Set(customThemes.map(\.name))
-            themes = themes.filter { !customNames.contains($0.name) }
-            themes.append(contentsOf: customThemes)
-
-            // Sort themes alphabetically by name
-            themes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-
-            self.availableThemes = themes
-
-            // Rebuild name index and refresh the cached current theme info.
-            var index: [String: ThemeInfo] = [:]
-            index.reserveCapacity(themes.count)
-            for theme in themes {
-                index[theme.name] = theme
-            }
-            self.themesByName = index
-            self.currentThemeInfo = index[currentTheme]
-
-            // Group by family
-            var grouped: [String: [ThemeInfo]] = [:]
-            for theme in themes {
-                grouped[theme.family, default: []].append(theme)
-            }
-
-            // Sort each family's themes alphabetically
-            for (family, familyThemes) in grouped {
-                grouped[family] = familyThemes.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-            }
-
-            self.themesByFamily = grouped
-
-            let customCount = customThemes.count
-            Ghostty.logger.info("Loaded \(themes.count) themes (\(customCount) custom) from \(grouped.count) families")
-
-        } catch {
-            Ghostty.logger.error("Failed to load themes: \(error)")
+    /// Kick off the full catalog build. Only `currentTheme` is resolved
+    /// synchronously at launch; `availableThemes` lands whenever this finishes.
+    private func startBackgroundLoad() {
+        guard let themesDirectory else { return }
+        let load = Task.detached(priority: .utility) {
+            ThemeManager.loadBuiltInThemes(from: themesDirectory)
+        }
+        builtInLoad = load
+        Task { [weak self] in
+            let themes = await load.value
+            self?.applyLoadedThemes(themes)
         }
     }
 
-    private func parseThemeFile(at url: URL) -> ThemeInfo.ThemeColors {
+    private func applyLoadedThemes(_ themes: [ThemeInfo]) {
+        // `ensureThemesLoaded()` may have applied these already.
+        guard builtInThemes == nil else { return }
+        builtInThemes = themes
+        rebuildCatalog()
+    }
+
+    /// Merge custom themes over the built-ins and publish the result.
+    private func rebuildCatalog() {
+        guard let builtIn = builtInThemes else { return }
+
+        let customThemes = CustomThemeManager.shared.customThemes.map { ThemeInfo(customTheme: $0) }
+        let customNames = Set(customThemes.map(\.name))
+        var themes = builtIn.filter { !customNames.contains($0.name) }
+        themes.append(contentsOf: customThemes)
+        themes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        // Reuse instances the lazy path already handed out, so landing the full
+        // catalog doesn't churn `currentThemeInfo`'s identity and re-render the
+        // tab bar for an identical theme.
+        themes = themes.map { themesByName[$0.name] ?? $0 }
+
+        var index: [String: ThemeInfo] = [:]
+        index.reserveCapacity(themes.count)
+        for theme in themes {
+            index[theme.name] = theme
+        }
+        themesByName = index
+        unresolvableThemeNames.removeAll()
+
+        if currentThemeInfo !== index[currentTheme] {
+            currentThemeInfo = index[currentTheme]
+        }
+        availableThemes = themes
+
+        Ghostty.logger.info("Loaded \(themes.count) themes (\(customThemes.count) custom)")
+    }
+
+    /// Returns `nil` when the file can't be read, which is how `themeInfo(for:)`
+    /// tells an unknown theme name from a parsed one.
+    nonisolated private static func parseThemeFile(at url: URL) -> ThemeInfo.ThemeColors? {
         do {
             let content = try String(contentsOf: url, encoding: .utf8)
 
@@ -402,7 +474,7 @@ final class ThemeManager {
 
         } catch {
             Ghostty.logger.error("Failed to parse theme file \(url.lastPathComponent): \(error)")
-            return .default
+            return nil
         }
     }
 }

--- a/rootshell/UI/Overlays/ThemePickerOverlay.swift
+++ b/rootshell/UI/Overlays/ThemePickerOverlay.swift
@@ -44,6 +44,9 @@ struct ThemePickerOverlay: View {
             .onAppear {
                 isSearchFocused = true
             }
+            // Awaits the background parse if the picker is opened before it
+            // lands; normally it has already finished and this returns at once.
+            .task { await themeManager.ensureThemesLoaded() }
     }
 
     private var pickerContent: some View {

--- a/rootshell/UI/Settings/Appearance/ColorSwatchView.swift
+++ b/rootshell/UI/Settings/Appearance/ColorSwatchView.swift
@@ -185,7 +185,9 @@ extension Color {
 
     /// Calculate relative luminance (0.0 = dark, 1.0 = light)
     /// Uses the formula from WCAG 2.0
-    var luminance: CGFloat {
+    /// `nonisolated`: pure color math, called off the main thread by ThemeManager's
+    /// background theme parse.
+    nonisolated var luminance: CGFloat {
         let uiColor = UIColor(self)
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
@@ -306,7 +308,9 @@ extension Color {
     /// colors which can vary per-cell. Outside the terminal surface (swatches, accent derivation,
     /// sheet tints) we approximate with the theme's global foreground/background — the best
     /// available stand-in for UI preview purposes.
-    static func resolveKeywordColor(_ value: String, foreground: String, background: String) -> String {
+    /// `nonisolated`: pure string mapping, called off the main thread by
+    /// ThemeManager's background theme parse.
+    nonisolated static func resolveKeywordColor(_ value: String, foreground: String, background: String) -> String {
         switch value.lowercased().trimmingCharacters(in: .whitespaces) {
         case "cell-foreground": return foreground
         case "cell-background": return background

--- a/rootshell/UI/Settings/Appearance/ThemeSettingsView.swift
+++ b/rootshell/UI/Settings/Appearance/ThemeSettingsView.swift
@@ -63,6 +63,9 @@ struct ThemeSettingsView: View {
                 themeGrid
             }
         }
+        // Awaits the background parse if the browser is opened before it lands;
+        // normally it has already finished and this returns immediately.
+        .task { await themeManager.ensureThemesLoaded() }
         .background((sheetThemeColors?.background ?? Color(uiColor: .systemGroupedBackground)).ignoresSafeArea())
         .navigationTitle("Theme")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
ThemeManager parsed every bundled theme on the main thread during app init, though only the selected one is needed then. Resolve themes by name and parse on demand; build the full catalog off the main actor for the two views that list them all.

Removes themesByFamily and applyTheme(to:), which had no readers.