### PR TITLE
fix(catalyst): support Continuity Camera paste

### DIFF
--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -8,10 +8,134 @@
 import UIKit
 import os
 import ObjectiveC
+import UniformTypeIdentifiers
 
 #if targetEnvironment(macCatalyst)
 
 private let logger = Logger(subsystem: "com.rootshell", category: "CatalystAppDelegate")
+
+@MainActor
+private final class CatalystContinuityPasteboardBridge {
+    static let shared = CatalystContinuityPasteboardBridge()
+    private weak var target: Ghostty.TerminalView?
+    private var menuIsActive = false
+    private var serviceMayBePending = false
+
+    func arm(for target: Ghostty.TerminalView) {
+        self.target = target
+        menuIsActive = true
+        serviceMayBePending = false
+    }
+
+    func noteResigned(_ target: Ghostty.TerminalView) {
+        guard self.target === target, menuIsActive else { return }
+        // Choosing Insert from iPhone/iPad resigns the UIKit terminal while
+        // AppKit keeps the context interaction alive awaiting the result.
+        serviceMayBePending = true
+    }
+
+    func menuDidEnd(for target: Ghostty.TerminalView) {
+        guard self.target === target else { return }
+        menuIsActive = false
+        // A normal cancellation leaves the terminal as first responder and
+        // clears immediately. A selected Service needs the target until AppKit
+        // performs its later valid-requestor lookup.
+        if !serviceMayBePending || !target.isLogicallyFocused {
+            disarm(for: target)
+        }
+    }
+
+    func disarm(for target: Ghostty.TerminalView) {
+        guard self.target === target else { return }
+        self.target = nil
+        menuIsActive = false
+        serviceMayBePending = false
+    }
+
+    func makeReceiver(sendType: String?, returnType: String?) -> AnyObject? {
+        guard sendType == nil,
+              let target,
+              target.window != nil,
+              let returnType else { return nil }
+        guard Self.isAttachmentType(returnType) else { return nil }
+        return CatalystContinuityPasteboardReceiver(target: target)
+    }
+
+    private static func isAttachmentType(_ type: String) -> Bool {
+        guard let contentType = UTType(type) else { return false }
+        return contentType.conforms(to: .image) || contentType.conforms(to: .pdf)
+    }
+}
+
+/// One requestor per native Services query. The menu bridge can be disarmed as
+/// soon as its menu closes without invalidating the requestor AppKit already
+/// retained for a selected Continuity action.
+@MainActor
+private final class CatalystContinuityPasteboardReceiver: NSObject {
+    private weak var target: Ghostty.TerminalView?
+    private var hasDelivered = false
+
+    init(target: Ghostty.TerminalView) {
+        self.target = target
+        super.init()
+    }
+
+    @objc(readSelectionFromPasteboard:)
+    private func readSelection(from pasteboard: NSObject) -> Bool {
+        guard !hasDelivered, let target, target.window != nil else { return false }
+        hasDelivered = true
+        defer {
+            CatalystContinuityPasteboardBridge.shared.disarm(for: target)
+            self.target = nil
+        }
+        guard let types = pasteboard.value(forKey: "types") as? [String] else {
+            logger.error("Continuity service returned a pasteboard without types")
+            return false
+        }
+
+        logger.info("Continuity service pasteboard types: \(types.joined(separator: "|"), privacy: .public)")
+
+        // A document scan can expose both PDF and an image preview. Keep the
+        // PDF so all pages survive; otherwise normalize the first readable
+        // native image representation to PNG for the UIKit provider.
+        if let pdfType = types.first(where: { type in
+            UTType(type)?.conforms(to: .pdf) == true
+        }), let data = Self.data(from: pasteboard, type: pdfType), !data.isEmpty {
+            target.paste(itemProviders: [Self.provider(data: data, type: UTType.pdf.identifier)])
+            return true
+        }
+
+        for type in types where Self.isImageType(type) {
+            guard let data = Self.data(from: pasteboard, type: type),
+                  let image = UIImage(data: data),
+                  let pngData = image.pngData(),
+                  !pngData.isEmpty else { continue }
+            target.paste(itemProviders: [Self.provider(data: pngData, type: UTType.png.identifier)])
+            return true
+        }
+
+        logger.error("Continuity service supplied no readable image or PDF data")
+        return false
+    }
+
+    private static func isImageType(_ type: String) -> Bool {
+        UTType(type)?.conforms(to: .image) == true
+    }
+
+    private static func data(from pasteboard: NSObject, type: String) -> Data? {
+        let selector = NSSelectorFromString("dataForType:")
+        return pasteboard.perform(selector, with: type)?.takeUnretainedValue() as? Data
+    }
+
+    private static func provider(data: Data, type: String) -> NSItemProvider {
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(forTypeIdentifier: type, visibility: .all) { completion in
+            completion(data, nil)
+            return nil
+        }
+        return provider
+    }
+}
 
 // MARK: - UIApplication Menu Actions Extension
 // These methods are on UIApplication to ensure they're always in the responder chain.
@@ -433,6 +557,11 @@ class CatalystAppDelegate: AppDelegate {
         // scenePhase and UIApplication.didBecomeActiveNotification don't fire reliably
         setupWorkspaceActivationObserver()
         setupApplicationHideObserver()
+        // AppKit owns Continuity Camera's Services handoff even in Catalyst.
+        // Install after launch, once the native NSApplication subclass exists.
+        DispatchQueue.main.async { [weak self] in
+            self?.installContinuityPasteboardInterposer()
+        }
         #if STANDALONE
         setupVisorAutohideObserver()
         // Deferred: the UIKit shim installs the NSApplication delegate as
@@ -460,6 +589,78 @@ class CatalystAppDelegate: AppDelegate {
         }
 
         return true
+    }
+
+    @MainActor
+    static func armContinuityPasteboardReceiver(for terminal: Ghostty.TerminalView) {
+        CatalystContinuityPasteboardBridge.shared.arm(for: terminal)
+    }
+
+    @MainActor
+    static func noteContinuityPasteboardTargetResigned(_ terminal: Ghostty.TerminalView) {
+        CatalystContinuityPasteboardBridge.shared.noteResigned(terminal)
+    }
+
+    @MainActor
+    static func continuityPasteboardMenuDidEnd(for terminal: Ghostty.TerminalView) {
+        CatalystContinuityPasteboardBridge.shared.menuDidEnd(for: terminal)
+    }
+
+    private static var continuityPasteboardInterposerInstalled = false
+
+    /// Override NSApplication's Services requestor lookup for the narrow case
+    /// UIKit fails to bridge: a no-input service returning an image or PDF to
+    /// the terminal whose context menu is currently open.
+    private func installContinuityPasteboardInterposer() {
+        guard !Self.continuityPasteboardInterposerInstalled else { return }
+        let selector = NSSelectorFromString("validRequestorForSendType:returnType:")
+        guard let nsAppClass = NSClassFromString("NSApplication") as? NSObject.Type,
+              let sharedApp = nsAppClass.value(forKey: "sharedApplication") as? NSObject,
+              let applicationClass = object_getClass(sharedApp),
+              let inheritedMethod = class_getInstanceMethod(applicationClass, selector) else {
+            logger.warning("Could not install Continuity Services pasteboard receiver")
+            return
+        }
+
+        let originalIMP = method_getImplementation(inheritedMethod)
+        typealias ValidRequestorFunc = @convention(c) (
+            NSObject, Selector, NSString?, NSString?
+        ) -> AnyObject?
+
+        let block: @convention(block) (
+            NSObject, NSString?, NSString?
+        ) -> AnyObject? = { application, sendType, returnType in
+            if let receiver = MainActor.assumeIsolated({
+                CatalystContinuityPasteboardBridge.shared.makeReceiver(
+                    sendType: sendType as String?,
+                    returnType: returnType as String?
+                )
+            }) {
+                logger.info(
+                    "Routing native Services result to terminal (return type: \((returnType as String?) ?? "nil", privacy: .public))"
+                )
+                return receiver
+            }
+
+            return unsafeBitCast(originalIMP, to: ValidRequestorFunc.self)(
+                application,
+                selector,
+                sendType,
+                returnType
+            )
+        }
+
+        let replacement = imp_implementationWithBlock(block)
+        // Add an override when the implementation is inherited; replacing the
+        // Method returned for an inherited selector would mutate NSResponder
+        // globally. If this concrete NSApplication subclass already overrides
+        // it, replace only that implementation.
+        if !class_addMethod(applicationClass, selector, replacement, "@@:@@"),
+           let concreteMethod = class_getInstanceMethod(applicationClass, selector) {
+            method_setImplementation(concreteMethod, replacement)
+        }
+        Self.continuityPasteboardInterposerInstalled = true
+        logger.info("Installed Continuity Services pasteboard receiver")
     }
 
     private func setupApplicationHideObserver() {

--- a/rootshell/Features/Transfer/Attachments/PasteAttachment.swift
+++ b/rootshell/Features/Transfer/Attachments/PasteAttachment.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import UniformTypeIdentifiers
+import os
 
 /// Represents a non-text attachment detected on the clipboard
 struct PasteAttachment: Sendable {
@@ -25,14 +26,19 @@ struct PasteAttachment: Sendable {
     }
 }
 
-/// Loads non-text paste content suitable for SFTP upload.
+/// Loads non-text paste content for SFTP upload or local path materialization.
 enum PasteAttachmentDetector {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "rootshell",
+        category: "PasteAttachment"
+    )
 
     /// Load paste-control item providers without reading UIPasteboard.general.
     /// Completion is always delivered on the main queue.
     static func load(from providers: [NSItemProvider], completion: @escaping ([PasteAttachment]) -> Void) {
         let candidates = providers.enumerated().filter {
-            $0.element.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+            $0.element.canLoadObject(ofClass: UIImage.self)
+                || $0.element.hasItemConformingToTypeIdentifier(UTType.image.identifier)
                 || $0.element.hasItemConformingToTypeIdentifier(UTType.pdf.identifier)
         }
         guard !candidates.isEmpty else {
@@ -45,45 +51,17 @@ enum PasteAttachmentDetector {
         var attachments = Array<PasteAttachment?>(repeating: nil, count: providers.count)
 
         for (index, provider) in candidates {
-            if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier),
-               provider.canLoadObject(ofClass: UIImage.self) {
-                group.enter()
-                _ = provider.loadObject(ofClass: UIImage.self) { image, error in
-                    guard error == nil, let image = image as? UIImage else {
-                        group.leave()
-                        return
-                    }
-                    DispatchQueue.main.async {
-                        let attachment = imageAttachment(from: image)
-                        lock.lock()
-                        attachments[index] = attachment
-                        lock.unlock()
-                        group.leave()
-                    }
+            group.enter()
+            loadAttachment(from: provider) { attachment in
+                if let attachment {
+                    lock.lock()
+                    attachments[index] = attachment
+                    lock.unlock()
+                } else {
+                    let types = provider.registeredTypeIdentifiers.joined(separator: "|")
+                    logger.error("Failed to decode pasted attachment with types: \(types, privacy: .public)")
                 }
-                continue
-            }
-
-            if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
-                group.enter()
-                provider.loadDataRepresentation(forTypeIdentifier: UTType.pdf.identifier) { data, error in
-                    guard error == nil, let data else {
-                        group.leave()
-                        return
-                    }
-                    DispatchQueue.main.async {
-                        let attachment = PasteAttachment(
-                            data: data,
-                            suggestedName: generateName(extension: "pdf"),
-                            uti: .pdf,
-                            thumbnail: nil
-                        )
-                        lock.lock()
-                        attachments[index] = attachment
-                        lock.unlock()
-                        group.leave()
-                    }
-                }
+                group.leave()
             }
         }
 
@@ -94,9 +72,135 @@ enum PasteAttachmentDetector {
 
     // MARK: - Private
 
-    private static func imageAttachment(from image: UIImage) -> PasteAttachment {
+    private static func loadAttachment(
+        from provider: NSItemProvider,
+        completion: @escaping (PasteAttachment?) -> Void
+    ) {
+        let hasImage = provider.canLoadObject(ofClass: UIImage.self)
+            || provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        let hasPDF = provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier)
+
+        // Prefer a real PDF over an image preview so multi-page Continuity
+        // document scans keep every page.
+        if hasPDF {
+            loadPDF(from: provider) { attachment in
+                if let attachment {
+                    completion(attachment)
+                } else if hasImage {
+                    loadImage(from: provider, completion: completion)
+                } else {
+                    completion(nil)
+                }
+            }
+            return
+        }
+
+        if hasImage {
+            loadImage(from: provider, completion: completion)
+        } else {
+            completion(nil)
+        }
+    }
+
+    private static func loadImage(
+        from provider: NSItemProvider,
+        completion: @escaping (PasteAttachment?) -> Void
+    ) {
+        guard provider.canLoadObject(ofClass: UIImage.self) else {
+            loadImageData(from: provider, completion: completion)
+            return
+        }
+
+        _ = provider.loadObject(ofClass: UIImage.self) { image, error in
+            DispatchQueue.main.async {
+                if let image = image as? UIImage,
+                   let attachment = imageAttachment(from: image) {
+                    completion(attachment)
+                    return
+                }
+
+                if let error {
+                    logger.warning("UIImage provider load failed; trying data representation: \(error.localizedDescription, privacy: .public)")
+                }
+                loadImageData(from: provider, completion: completion)
+            }
+        }
+    }
+
+    private static func loadImageData(
+        from provider: NSItemProvider,
+        completion: @escaping (PasteAttachment?) -> Void
+    ) {
+        let imageTypes = provider.registeredTypeIdentifiers.filter {
+            UTType($0)?.conforms(to: .image) == true
+        }
+        loadImageData(from: provider, typeIdentifiers: imageTypes, at: 0, completion: completion)
+    }
+
+    private static func loadImageData(
+        from provider: NSItemProvider,
+        typeIdentifiers: [String],
+        at index: Int,
+        completion: @escaping (PasteAttachment?) -> Void
+    ) {
+        guard index < typeIdentifiers.count else {
+            completion(nil)
+            return
+        }
+
+        provider.loadDataRepresentation(forTypeIdentifier: typeIdentifiers[index]) { data, error in
+            DispatchQueue.main.async {
+                if let data,
+                   let image = UIImage(data: data),
+                   let attachment = imageAttachment(from: image) {
+                    completion(attachment)
+                    return
+                }
+
+                if let error {
+                    logger.warning("Image data provider load failed: \(error.localizedDescription, privacy: .public)")
+                }
+                loadImageData(
+                    from: provider,
+                    typeIdentifiers: typeIdentifiers,
+                    at: index + 1,
+                    completion: completion
+                )
+            }
+        }
+    }
+
+    private static func loadPDF(
+        from provider: NSItemProvider,
+        completion: @escaping (PasteAttachment?) -> Void
+    ) {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) else {
+            completion(nil)
+            return
+        }
+
+        provider.loadDataRepresentation(forTypeIdentifier: UTType.pdf.identifier) { data, error in
+            DispatchQueue.main.async {
+                guard let data, !data.isEmpty else {
+                    if let error {
+                        logger.warning("PDF provider load failed: \(error.localizedDescription, privacy: .public)")
+                    }
+                    completion(nil)
+                    return
+                }
+                completion(PasteAttachment(
+                    data: data,
+                    suggestedName: generateName(extension: "pdf"),
+                    uti: .pdf,
+                    thumbnail: nil
+                ))
+            }
+        }
+    }
+
+    private static func imageAttachment(from image: UIImage) -> PasteAttachment? {
         let name = generateName(extension: "png")
-        let data = image.pngData() ?? Data()
+        guard let data = image.pngData(), !data.isEmpty else { return nil }
         let thumbnail = generateThumbnail(from: image)
         return PasteAttachment(
             data: data,

--- a/rootshell/UI/Terminal/TerminalView+Gestures.swift
+++ b/rootshell/UI/Terminal/TerminalView+Gestures.swift
@@ -922,6 +922,11 @@ extension Ghostty.TerminalView {
         // only content. Keep the strict UTI reader used before this refactor.
         if let text = pasteboard.getOpinionatedStringContents(), !text.isEmpty {
             _ = insertPastedText(text)
+            return
+        }
+        let itemProviders = pasteboard.itemProviders
+        if !itemProviders.isEmpty {
+            paste(itemProviders: itemProviders)
         }
         return
         #else
@@ -948,6 +953,11 @@ extension Ghostty.TerminalView {
     }
 
     override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
+        // Let UIKit validate object-backed identifiers such as
+        // `com.apple.uikit.image`. Those identifiers are part of UIImage's
+        // paste configuration on Catalyst but do not conform to public.image.
+        if super.canPaste(itemProviders) { return true }
+
         let acceptsText = itemProviders.contains { provider in
             provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
                 || provider.hasItemConformingToTypeIdentifier(UTType.url.identifier)
@@ -955,9 +965,9 @@ extension Ghostty.TerminalView {
         }
         if acceptsText { return true }
 
-        guard attachmentUploadSSHConfig != nil else { return false }
         return itemProviders.contains { provider in
-            provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+            provider.canLoadObject(ofClass: UIImage.self)
+                || provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
                 || provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier)
         }
     }
@@ -965,13 +975,21 @@ extension Ghostty.TerminalView {
     override func paste(itemProviders: [NSItemProvider]) {
         guard canPaste(itemProviders) else { return }
 
+        let typeSummary = itemProviders
+            .map { $0.registeredTypeIdentifiers.joined(separator: "|") }
+            .joined(separator: " ; ")
+        Ghostty.logger.info("paste(itemProviders:) offered types: \(typeSummary)")
+
+        let containsAttachments = itemProviders.contains {
+            $0.canLoadObject(ofClass: UIImage.self)
+                || $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                || $0.hasItemConformingToTypeIdentifier(UTType.pdf.identifier)
+        }
+
         // Match the existing terminal-paste preference order: attachments for
         // SSH sessions, URLs/file URLs, then plain text.
         if let sshConfig = attachmentUploadSSHConfig,
-           itemProviders.contains(where: {
-               $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                   || $0.hasItemConformingToTypeIdentifier(UTType.pdf.identifier)
-           }) {
+           containsAttachments {
             PasteAttachmentDetector.load(from: itemProviders) { [weak self] items in
                 guard let self else { return }
                 if !items.isEmpty {
@@ -986,7 +1004,118 @@ extension Ghostty.TerminalView {
             return
         }
 
+        // Preserve Finder/file paste semantics for local terminals: use an
+        // existing URL when the provider offers one. Continuity Camera items
+        // normally have no usable URL and fall back to materializing their
+        // image/PDF data in our temporary directory.
+        if containsAttachments {
+            guard canMaterializeAttachmentsLocally else {
+                pasteUsableRemoteRepresentationOrShowAttachmentAlert(from: itemProviders)
+                return
+            }
+            let urlProviders = itemProviders.filter {
+                $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+                    || $0.hasItemConformingToTypeIdentifier(UTType.url.identifier)
+            }
+            if !urlProviders.isEmpty {
+                loadPastedURLs(from: urlProviders) { [weak self] text in
+                    guard let self else { return }
+                    if let text, !text.isEmpty {
+                        _ = self.insertPastedText(text)
+                    } else {
+                        self.loadLocalPastedAttachments(from: itemProviders)
+                    }
+                }
+            } else {
+                loadLocalPastedAttachments(from: itemProviders)
+            }
+            return
+        }
+
         loadTextPaste(from: itemProviders)
+    }
+
+    /// Remote backends without an upload transport cannot use local attachment
+    /// paths, but a mixed provider may still contain independently useful
+    /// content. Preserve a web URL or plain text before rejecting the image.
+    private func pasteUsableRemoteRepresentationOrShowAttachmentAlert(
+        from providers: [NSItemProvider]
+    ) {
+        let urlProviders = providers.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.url.identifier)
+        }
+
+        func tryPlainText() {
+            self.loadPastedPlainText(from: providers) { [weak self] inserted in
+                guard let self, !inserted else { return }
+                self.showUnsupportedRemoteAttachmentAlert()
+            }
+        }
+
+        guard !urlProviders.isEmpty else {
+            tryPlainText()
+            return
+        }
+
+        loadPastedNonFileURLs(from: urlProviders) { [weak self] text in
+            guard let self else { return }
+            if let text, !text.isEmpty, self.insertPastedText(text) {
+                return
+            }
+            tryPlainText()
+        }
+    }
+
+    private func loadLocalPastedAttachments(from providers: [NSItemProvider]) {
+        PasteAttachmentDetector.load(from: providers) { [weak self] attachments in
+            guard let self else { return }
+            guard !attachments.isEmpty else {
+                self.loadPastedPlainText(from: providers)
+                return
+            }
+            self.materializeLocalPastedAttachments(attachments)
+        }
+    }
+
+    private func showUnsupportedRemoteAttachmentAlert() {
+        Ghostty.logger.warning(
+            "Ignoring pasted attachment for unsupported remote session: \(self.connectionConfig.lifecycleDebugKind)"
+        )
+        guard let presenter = self.findPresenterViewController(),
+              presenter.presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: String(localized: "Attachment Paste Unavailable"),
+            message: String(localized: "This remote session does not support uploading pasted attachments."),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String(localized: "OK"), style: .default))
+        presenter.present(alert, animated: true)
+    }
+
+    private func materializeLocalPastedAttachments(_ attachments: [PasteAttachment]) {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let urls = attachments.compactMap { attachment -> URL? in
+                guard !attachment.data.isEmpty else { return nil }
+                let url = temporaryDirectory.appendingPathComponent(attachment.suggestedName)
+                do {
+                    try attachment.data.write(to: url, options: .atomic)
+                    return url
+                } catch {
+                    Ghostty.logger.warning("Failed to materialize pasted attachment: \(error.localizedDescription)")
+                    return nil
+                }
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !urls.isEmpty else { return }
+                let text = urls
+                    .map { Ghostty.Shell.escape($0.path) }
+                    .joined(separator: " ")
+                _ = self.insertPastedText(text, recordHistory: false)
+            }
+        }
     }
 
     private func loadTextPaste(
@@ -1044,7 +1173,76 @@ extension Ghostty.TerminalView {
         }
     }
 
-    private func loadPastedPlainText(from providers: [NSItemProvider]) {
+    private func loadPastedNonFileURLs(
+        from providers: [NSItemProvider],
+        completion: @escaping (String?) -> Void
+    ) {
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var values = Array<String?>(repeating: nil, count: providers.count)
+
+        for (index, provider) in providers.enumerated() {
+            group.enter()
+            loadPastedNonFileURL(from: provider) { url in
+                defer { group.leave() }
+                guard let url else { return }
+                lock.lock()
+                values[index] = url.absoluteString
+                lock.unlock()
+            }
+        }
+
+        group.notify(queue: .main) {
+            let text = values.compactMap { $0 }.joined(separator: " ")
+            completion(text.isEmpty ? nil : text)
+        }
+    }
+
+    private func loadPastedNonFileURL(
+        from provider: NSItemProvider,
+        completion: @escaping (URL?) -> Void
+    ) {
+        func usableURL(from item: Any?) -> URL? {
+            let url: URL?
+            if let value = item as? URL {
+                url = value
+            } else if let value = item as? String {
+                url = URL(string: value)
+            } else if let value = item as? Data {
+                url = URL(dataRepresentation: value, relativeTo: nil)
+            } else {
+                url = nil
+            }
+            guard let url, !url.isFileURL, url.scheme != nil else { return nil }
+            return url
+        }
+
+        func loadItemFallback() {
+            provider.loadItem(
+                forTypeIdentifier: UTType.url.identifier,
+                options: nil
+            ) { item, _ in
+                completion(usableURL(from: item))
+            }
+        }
+
+        guard provider.canLoadObject(ofClass: URL.self) else {
+            loadItemFallback()
+            return
+        }
+        _ = provider.loadObject(ofClass: URL.self) { url, error in
+            if error == nil, let url = usableURL(from: url) {
+                completion(url)
+            } else {
+                loadItemFallback()
+            }
+        }
+    }
+
+    private func loadPastedPlainText(
+        from providers: [NSItemProvider],
+        completion: ((Bool) -> Void)? = nil
+    ) {
         let preferredTypes = [
             UTType.utf8PlainText.identifier,
             UTType.utf16PlainText.identifier,
@@ -1068,19 +1266,31 @@ extension Ghostty.TerminalView {
             }
         }
 
-        loadPastedPlainText(candidates: candidates, at: 0)
+        loadPastedPlainText(candidates: candidates, at: 0, completion: completion)
     }
 
     private func loadPastedPlainText(
         candidates: [(provider: NSItemProvider, typeIdentifier: String)],
-        at index: Int
+        at index: Int,
+        completion: ((Bool) -> Void)?
     ) {
-        guard index < candidates.count else { return }
+        guard index < candidates.count else {
+            completion?(false)
+            return
+        }
         let candidate = candidates[index]
 
         func tryNextCandidate() {
             DispatchQueue.main.async { [weak self] in
-                self?.loadPastedPlainText(candidates: candidates, at: index + 1)
+                guard let self else {
+                    completion?(false)
+                    return
+                }
+                self.loadPastedPlainText(
+                    candidates: candidates,
+                    at: index + 1,
+                    completion: completion
+                )
             }
         }
 
@@ -1090,7 +1300,12 @@ extension Ghostty.TerminalView {
                 return
             }
             DispatchQueue.main.async { [weak self] in
-                self?.insertPastedText(text)
+                guard let self else {
+                    completion?(false)
+                    return
+                }
+                let inserted = self.insertPastedText(text)
+                completion?(inserted)
             }
         }
 
@@ -1188,21 +1403,10 @@ extension Ghostty.TerminalView {
             // the iOS paste-permission dialog on every app switch. The real
             // content read happens later in paste(_:), when the user invokes it.
             if UIPasteboard.general.hasPasteableContentWithoutPrompt { return true }
-            // There is no prompt-free hasPDF predicate. An SSH target can
-            // accept image/PDF providers, so leave the system keyboard command
-            // enabled and validate providers only after invocation. While
-            // building a transient touch menu, use only the metadata item count:
-            // it keeps empty pasteboards disabled while allowing PDF-only
+            // There is no prompt-free hasPDF predicate. The metadata-only item
+            // count keeps empty pasteboards disabled while allowing image/PDF
             // content without reading provider types during menu validation.
-            if attachmentUploadSSHConfig != nil {
-                #if !targetEnvironment(macCatalyst)
-                if editMenuInteraction != nil {
-                    return UIPasteboard.general.numberOfItems > 0
-                }
-                #endif
-                return true
-            }
-            return false
+            return UIPasteboard.general.numberOfItems > 0
         }
         if action == #selector(selectAll(_:)) {
             return surface != nil
@@ -1465,6 +1669,25 @@ extension Ghostty.TerminalView {
         }
 #endif
         return nil
+    }
+
+    /// Whether a path inside this app's temporary directory is meaningful to
+    /// the shell receiving input. Non-SSH remote backends have no attachment
+    /// transport, so inserting a Catalyst sandbox path would be unusable.
+    var canMaterializeAttachmentsLocally: Bool {
+        let effectiveTerminal: Ghostty.TerminalView
+        if let binding = tmuxPaneBinding {
+            guard let gateway = ghosttyApp?.surfaceView(for: binding.parentSurface),
+                  gateway.uuid == binding.parentUUID else { return false }
+            effectiveTerminal = gateway
+        } else {
+            effectiveTerminal = self
+        }
+
+        if case .local = effectiveTerminal.connectionConfig.unwrappedConfig {
+            return true
+        }
+        return false
     }
 
     /// Present the attachment upload confirmation sheet
@@ -2257,6 +2480,13 @@ extension Ghostty.TerminalView: UIContextMenuInteractionDelegate {
             return nil
         }
 
+        #if targetEnvironment(macCatalyst)
+        // The native Services menu is assembled after this callback. Remember
+        // the initiating terminal so Continuity Camera's AppKit pasteboard
+        // result can be routed back to the correct local or remote session.
+        CatalystAppDelegate.armContinuityPasteboardReceiver(for: self)
+        #endif
+
         // Probe for link before building menu
         let probedLink = probeForLink(at: location)
 
@@ -2264,6 +2494,24 @@ extension Ghostty.TerminalView: UIContextMenuInteractionDelegate {
             self?.buildContextMenu(linkURL: probedLink)
         }
     }
+
+    #if targetEnvironment(macCatalyst)
+    public func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        willEndFor configuration: UIContextMenuConfiguration,
+        animator: (any UIContextMenuInteractionAnimating)?
+    ) {
+        let disarm = { [weak self] in
+            guard let self else { return }
+            CatalystAppDelegate.continuityPasteboardMenuDidEnd(for: self)
+        }
+        if let animator {
+            animator.addCompletion(disarm)
+        } else {
+            disarm()
+        }
+    }
+    #endif
 
     /// Build the full context menu with all terminal actions
     private func buildContextMenu(

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -1344,14 +1344,13 @@ extension Ghostty {
             // UIPasteControl and the system edit menu deliver paste contents as
             // item providers. Declaring the accepted types lets UIKit validate
             // paste without rootshell probing the general pasteboard first.
-            let terminalPasteConfiguration = UIPasteConfiguration()
-            terminalPasteConfiguration.acceptableTypeIdentifiers = [
+            let terminalPasteConfiguration = UIPasteConfiguration(forAccepting: UIImage.self)
+            terminalPasteConfiguration.addAcceptableTypeIdentifiers([
                 UTType.fileURL.identifier,
                 UTType.url.identifier,
-                UTType.image.identifier,
                 UTType.pdf.identifier,
                 UTType.plainText.identifier,
-            ]
+            ])
             pasteConfiguration = terminalPasteConfiguration
             refreshPanePresentationTitle()
 
@@ -3549,6 +3548,9 @@ extension Ghostty {
             let result = super.resignFirstResponder()
             if result {
                 EffectManager.shared.notifyKeyboardToolbarLayoutChanged()
+                #if targetEnvironment(macCatalyst)
+                CatalystAppDelegate.noteContinuityPasteboardTargetResigned(self)
+                #endif
             }
 
             // Sync Ghostty surface focus when UIKit resigns us


### PR DESCRIPTION
- bridge AppKit Services image and PDF results into terminal paste handling
- upload captures over SSH and materialize paths only for local shells
- preserve usable URL and text content for unsupported remote backends
- scope Services routing to the active context-menu handoff