### PR TITLE
fix(automation): target and surface the window for folder opens

### DIFF
--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -877,16 +877,16 @@ class CatalystAppDelegate: AppDelegate {
     /// at that folder, or at a file's parent). Returns false for anything else;
     /// true also covers a delivery the coordinator suppressed as a duplicate.
     @discardableResult
-    static func routeAutomationURL(_ url: URL, source: String) -> Bool {
+    static func routeAutomationURL(_ url: URL, source: String, deliveredTo scene: UIWindowScene? = nil) -> Bool {
         if let components = SSHURLParser.parse(url) {
             logger.info("[urlopen] route source=\(source, privacy: .public) kind=ssh")
-            AppIntentCoordinator.shared.depositURLRequest(.openSSH(components), source: source)
+            AppIntentCoordinator.shared.depositURLRequest(.openSSH(components), source: source, deliveredTo: scene)
             return true
         }
 
         if let components = MoshURLParser.parse(url) {
             logger.info("[urlopen] route source=\(source, privacy: .public) kind=mosh")
-            AppIntentCoordinator.shared.depositURLRequest(.openMosh(components), source: source)
+            AppIntentCoordinator.shared.depositURLRequest(.openMosh(components), source: source, deliveredTo: scene)
             return true
         }
 
@@ -894,7 +894,8 @@ class CatalystAppDelegate: AppDelegate {
             logger.info("[urlopen] route source=\(source, privacy: .public) kind=folder path=\(directory, privacy: .private)")
             AppIntentCoordinator.shared.depositURLRequest(
                 .openLocalShell(directory: directory, command: nil),
-                source: source
+                source: source,
+                deliveredTo: scene
             )
             return true
         }
@@ -1672,7 +1673,7 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// is behind us. Distinguishes a cold-launch visor zombie (SwiftUI will
     /// still create the main scene on its own) from a Dock-click reopen that
     /// landed on the visor's session (nothing else will open a window).
-    private static var hasActivatedAnyScene = false
+    private(set) static var hasActivatedAnyScene = false
 
     /// A Dock-click reopen with no visible windows can be consumed by the
     /// visor's live-but-hidden scene session: UIKit either reconnects it
@@ -1685,7 +1686,19 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
             $0 is UIWindowScene && !isVisorScene($0)
         }
         guard !hasRegularScene else { return }
+        logger.info("[urlopen] no regular scene; requesting main window \(AppIntentCoordinator.sceneSnapshot(), privacy: .public)")
         UIApplication.shared.requestSceneSessionActivation(nil, userActivity: nil, options: nil, errorHandler: nil)
+    }
+
+    /// The regular (non-visor) scene an external request should land in:
+    /// key window first, then the active one, then any.
+    static func preferredRegularScene() -> UIWindowScene? {
+        let regularScenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { !isVisorScene($0) }
+        return regularScenes.first(where: { $0.keyWindow != nil })
+            ?? regularScenes.first(where: { $0.activationState == .foregroundActive })
+            ?? regularScenes.first
     }
 
     /// Makes a notification or other external event visibly open rootshell.
@@ -1696,14 +1709,8 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
         scene targetScene: UIWindowScene? = nil,
         uiKitActivationAlreadyRequested: Bool = false
     ) {
-        let regularScenes = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .filter { !isVisorScene($0) }
-
         guard let scene = targetScene.flatMap({ isVisorScene($0) ? nil : $0 })
-                ?? regularScenes.first(where: { $0.keyWindow != nil })
-                ?? regularScenes.first(where: { $0.activationState == .foregroundActive })
-                ?? regularScenes.first else {
+                ?? preferredRegularScene() else {
             logger.info("External activation has no regular scene; opening a main window")
             UIApplication.shared.requestSceneSessionActivation(
                 nil,
@@ -1839,7 +1846,7 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         // Handle URLs that launched the app (cold start)
-        handleURLContexts(connectionOptions.urlContexts, source: "scene.willConnect")
+        handleURLContexts(connectionOptions.urlContexts, source: "scene.willConnect", scene: windowScene)
     }
 
     /// Detect the visor's UIScene. SwiftUI's `session.configuration.name`
@@ -1897,12 +1904,12 @@ class CatalystSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         // Handle URLs opened while app is running
-        handleURLContexts(URLContexts, source: "scene.openURLContexts")
+        handleURLContexts(URLContexts, source: "scene.openURLContexts", scene: scene as? UIWindowScene)
     }
 
-    private func handleURLContexts(_ urlContexts: Set<UIOpenURLContext>, source: String) {
+    private func handleURLContexts(_ urlContexts: Set<UIOpenURLContext>, source: String, scene: UIWindowScene?) {
         for context in urlContexts {
-            CatalystAppDelegate.routeAutomationURL(context.url, source: source)
+            CatalystAppDelegate.routeAutomationURL(context.url, source: source, deliveredTo: scene)
         }
     }
 

--- a/rootshell/Features/AppIntents/AppIntentCoordinator.swift
+++ b/rootshell/Features/AppIntents/AppIntentCoordinator.swift
@@ -5,10 +5,11 @@
 //  Buffer between App Intents / URL opens and MainView. Deposit-then-notify
 //  survives the cold-start race (an intent's perform() can run before any
 //  window's onReceive subscription exists, or before Ghostty finishes
-//  initializing). Requests carry no originating window, so delivery is
-//  consume-once with key-window bias: the key window claims immediately,
-//  non-key windows retry after a short delay and claim only if the buffer
-//  still has entries. At most one window ever acts on a request.
+//  initializing). URL/odoc opens are targeted at a scene chosen at deposit
+//  time (Catalyst) and that window is surfaced; Shortcuts requests stay
+//  untargeted and use key-window bias: the key window claims immediately,
+//  non-key windows retry after a short delay. A watchdog releases any
+//  request nobody claimed. At most one window ever acts on a request.
 //
 //  A second, window-targeted buffer backs AppleScript's `create window`:
 //  requests are staged, a fresh scene is requested, and the first empty
@@ -39,19 +40,84 @@ final class AppIntentCoordinator {
         case openMosh(MoshURLComponents)
     }
 
-    private var pending: [IntentRequest] = []
-
-    var hasPending: Bool { !pending.isEmpty }
-
-    func deposit(_ request: IntentRequest) {
-        pending.append(request)
-        NotificationCenter.default.post(name: .appIntentRequestReceived, object: nil)
+    /// A URL open is targeted at the scene chosen at deposit time; Shortcuts
+    /// requests stay untargeted and go to whichever window claims first.
+    private struct PendingRequest {
+        let id = UUID()
+        let request: IntentRequest
+        var targetSceneSessionID: String?
     }
 
-    /// First claimant wins; empties the buffer.
-    func consumeAll() -> [IntentRequest] {
-        defer { pending.removeAll() }
-        return pending
+    private var pending: [PendingRequest] = []
+    private static let unclaimedWatchdogDelay: TimeInterval = 2.5
+
+    /// True when this scene has something to claim (see `consume(forScene:)`).
+    func hasPending(forScene sceneSessionID: String?) -> Bool {
+        !claimable(forScene: sceneSessionID).isEmpty
+    }
+
+    /// This scene's targeted requests, every untargeted one, and any whose
+    /// target scene is no longer connected.
+    private func claimable(forScene sceneSessionID: String?) -> [PendingRequest] {
+        let liveSessionIDs = Set(UIApplication.shared.connectedScenes.map { $0.session.persistentIdentifier })
+        return pending.filter { entry in
+            guard let target = entry.targetSceneSessionID else { return true }
+            return target == sceneSessionID || !liveSessionIDs.contains(target)
+        }
+    }
+
+    func hasTargetedPending(forScene sceneSessionID: String?) -> Bool {
+        guard let sceneSessionID else { return false }
+        return pending.contains { $0.targetSceneSessionID == sceneSessionID }
+    }
+
+    func deposit(_ request: IntentRequest) {
+        deposit(request, targetSceneSessionID: nil)
+    }
+
+    private func deposit(_ request: IntentRequest, targetSceneSessionID: String?) {
+        let entry = PendingRequest(request: request, targetSceneSessionID: targetSceneSessionID)
+        pending.append(entry)
+        NotificationCenter.default.post(name: .appIntentRequestReceived, object: nil)
+        scheduleUnclaimedWatchdog(for: entry.id)
+    }
+
+    /// Claims everything `claimable`; other live scenes' requests stay put.
+    func consume(forScene sceneSessionID: String?) -> [IntentRequest] {
+        let claimed = claimable(forScene: sceneSessionID)
+        pending.removeAll { entry in claimed.contains { $0.id == entry.id } }
+        return claimed.map(\.request)
+    }
+
+    /// A request still pending after the delay had no window claim it (the
+    /// target scene died, never linked, or no regular window exists). Drop
+    /// the target so any window may claim, re-notify, and surface a window.
+    private func scheduleUnclaimedWatchdog(for id: UUID) {
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(Self.unclaimedWatchdogDelay))
+            guard let index = pending.firstIndex(where: { $0.id == id }) else { return }
+            logger.error("[urlopen] unclaimed target=\(self.pending[index].targetSceneSessionID ?? "-", privacy: .public) \(Self.sceneSnapshot(), privacy: .public)")
+            pending[index].targetSceneSessionID = nil
+            NotificationCenter.default.post(name: .appIntentRequestReceived, object: nil)
+            #if targetEnvironment(macCatalyst)
+            if CatalystSceneDelegate.hasActivatedAnyScene {
+                CatalystSceneDelegate.activateMainWindowForExternalEvent()
+            }
+            #endif
+        }
+    }
+
+    /// One-line scene/key summary for the `[urlopen]` diagnostics.
+    static func sceneSnapshot() -> String {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        #if targetEnvironment(macCatalyst)
+        let visor = scenes.filter { CatalystSceneDelegate.isVisorScene($0) }.count
+        #else
+        let visor = 0
+        #endif
+        let key = scenes.filter { $0.keyWindow != nil }.count
+        let active = scenes.filter { $0.activationState == .foregroundActive }.count
+        return "scenes=\(scenes.count) visor=\(visor) key=\(key) active=\(active) appState=\(UIApplication.shared.applicationState.rawValue)"
     }
 
     // MARK: - URL / Apple event deposits
@@ -71,8 +137,10 @@ final class AppIntentCoordinator {
     private static let urlDedupeWindow: TimeInterval = 1.5
 
     /// Returns false when another delivery path already took this request.
+    /// `deliveredTo` is the scene UIKit handed the URL to (cold-start
+    /// `willConnectTo`), which may not be in `connectedScenes` yet.
     @discardableResult
-    func depositURLRequest(_ request: IntentRequest, source: String) -> Bool {
+    func depositURLRequest(_ request: IntentRequest, source: String, deliveredTo: UIWindowScene? = nil) -> Bool {
         let now = Date()
         recentURLDeliveries.removeAll { $0.expiresAt <= now }
 
@@ -93,8 +161,24 @@ final class AppIntentCoordinator {
         }
 
         recentURLDeliveries.append(URLDelivery(key: key, sources: [source], expiresAt: expiresAt))
+
+        // Pick the receiving window now rather than letting every MainView
+        // race on key state, and make sure it is actually on screen. With no
+        // regular window, request one; the new window adopts the request.
+        #if targetEnvironment(macCatalyst)
+        let target = deliveredTo.flatMap { CatalystSceneDelegate.isVisorScene($0) ? nil : $0 }
+            ?? CatalystSceneDelegate.preferredRegularScene()
+        logger.info("[urlopen] deposit source=\(source, privacy: .public) target=\(target?.session.persistentIdentifier ?? "-", privacy: .public) \(Self.sceneSnapshot(), privacy: .public)")
+        deposit(request, targetSceneSessionID: target?.session.persistentIdentifier)
+        // Before the first scene activates, launch itself is bringing up the
+        // window that adopts this; requesting another would open two.
+        if target != nil || CatalystSceneDelegate.hasActivatedAnyScene {
+            CatalystSceneDelegate.activateMainWindowForExternalEvent(scene: target)
+        }
+        #else
         logger.info("[urlopen] deposit source=\(source, privacy: .public)")
         deposit(request)
+        #endif
         return true
     }
 

--- a/rootshell/Features/Automation/AppleScriptCommands.swift
+++ b/rootshell/Features/Automation/AppleScriptCommands.swift
@@ -127,19 +127,12 @@ final class RootshellOpenCommand: NSScriptCommand {
             return nil
         }
 
+        // Window targeting and surfacing happen in the coordinator, shared
+        // with the UIKit delivery paths.
         MainActor.assumeIsolated {
             logger.info("[urlopen] odoc items=\(urls.count)")
-            var routed = false
             for url in urls {
-                if CatalystAppDelegate.routeAutomationURL(url, source: "applescript.open") {
-                    routed = true
-                }
-            }
-            // No reopen event accompanies a document open, so with zero
-            // regular windows the deposit would sit until Cmd-N. The new
-            // window adopts it as its first tab.
-            if routed {
-                CatalystSceneDelegate.openMainWindowIfNoneConnected()
+                CatalystAppDelegate.routeAutomationURL(url, source: "applescript.open")
             }
         }
         return nil

--- a/rootshell/UI/Shell/MainView+EventHandlers.swift
+++ b/rootshell/UI/Shell/MainView+EventHandlers.swift
@@ -218,7 +218,9 @@ extension MainView {
                 // createLocalShellTab() runs synchronously now: performLocalShellAction()
                 // takes its fast path when the helper is already confirmed up.
                 createLocalShellTab()
+                markPlaceholderShell()
             } else {
+                restorationInFlight = pendingState != nil
                 Task { @MainActor in
                     _ = await HelperConnection.shared.ensureHelperRunning()
 
@@ -227,6 +229,10 @@ extension MainView {
                         RestorationHealthTracker.shared.markRestorationStarted()
                         Ghostty.logger.info("Restoring window state: \(savedState.tabs.count) tabs")
                         self.restoreWindowState(savedState)
+                        self.restorationInFlight = false
+                        // A folder open that arrived during the restore was
+                        // held back; it follows the restored tabs.
+                        self.adoptPendingIntentRequestsAsFirstContent()
                     } else if self.adoptPendingIntentRequestsAsFirstContent() {
                         // On cold launch the URL often lands during the helper
                         // await above, after the synchronous claim missed it.

--- a/rootshell/UI/Shell/MainView+IntentRequests.swift
+++ b/rootshell/UI/Shell/MainView+IntentRequests.swift
@@ -22,7 +22,18 @@ extension MainView {
         // A request claimed here would open its tab off-screen; the visor's
         // terminal comes from VisorController alone.
         guard !isVisorWindow else { return }
-        guard AppIntentCoordinator.shared.hasPending else { return }
+        guard AppIntentCoordinator.shared.hasPending(forScene: windowSceneSessionID) else { return }
+        // Saved tabs come first; the post-restore adopt claims this request.
+        guard !restorationInFlight else {
+            Ghostty.logger.info("[urlopen] deferred until restore completes window=\(windowId, privacy: .public)")
+            return
+        }
+
+        // A request targeted at this scene is ours regardless of key state.
+        if AppIntentCoordinator.shared.hasTargetedPending(forScene: windowSceneSessionID) {
+            dispatchIntentRequests(retriesRemaining: retriesRemaining)
+            return
+        }
 
         // The hidden visor scene stays connected once summoned. Counting it
         // would push a lone visible window into the deferred branch below and
@@ -37,7 +48,7 @@ extension MainView {
         if windowScenes.count > 1 && !windowIsKeyWindow {
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 700_000_000)
-                guard AppIntentCoordinator.shared.hasPending else { return }
+                guard AppIntentCoordinator.shared.hasPending(forScene: windowSceneSessionID) else { return }
                 dispatchIntentRequests(retriesRemaining: retriesRemaining)
             }
             return
@@ -62,9 +73,9 @@ extension MainView {
             return
         }
 
-        let claimed = AppIntentCoordinator.shared.consumeAll()
+        let claimed = AppIntentCoordinator.shared.consume(forScene: windowSceneSessionID)
         guard !claimed.isEmpty else { return }
-        Ghostty.logger.info("[urlopen] claim window=\(windowId, privacy: .public) key=\(windowIsKeyWindow) count=\(claimed.count)")
+        Ghostty.logger.info("[urlopen] claim window=\(windowId, privacy: .public) scene=\(windowSceneSessionID ?? "-", privacy: .public) key=\(windowIsKeyWindow) count=\(claimed.count) helper=\(HelperConnection.shared.isKnownRunning) \(AppIntentCoordinator.sceneSnapshot(), privacy: .public)")
         dispatchClaimedIntentRequests(claimed)
     }
 
@@ -75,8 +86,8 @@ extension MainView {
     /// fall back to its default shell.
     @discardableResult
     func adoptPendingIntentRequestsAsFirstContent() -> Bool {
-        guard !isVisorWindow, AppIntentCoordinator.shared.hasPending else { return false }
-        let requests = AppIntentCoordinator.shared.consumeAll()
+        guard !isVisorWindow, AppIntentCoordinator.shared.hasPending(forScene: windowSceneSessionID) else { return false }
+        let requests = AppIntentCoordinator.shared.consume(forScene: windowSceneSessionID)
         guard !requests.isEmpty else { return false }
         Ghostty.logger.info("[urlopen] adopt-as-first window=\(windowId, privacy: .public) count=\(requests.count)")
         dispatchClaimedIntentRequests(requests)
@@ -113,5 +124,24 @@ extension MainView {
                 handleMoshURL(components)
             }
         }
+        replacePlaceholderShellIfFresh()
+    }
+
+    /// Remembers the default shell a fresh window just opened.
+    func markPlaceholderShell() {
+        guard terminals.count == 1, let tab = terminals.first else { return }
+        placeholderShell = (tab.id, Date())
+    }
+
+    /// The window was spawned for an external event and its default shell
+    /// is a placeholder: once the requested tab exists, drop the shell.
+    private func replacePlaceholderShellIfFresh() {
+        defer { placeholderShell = nil }
+        guard let placeholderShell,
+              Date().timeIntervalSince(placeholderShell.createdAt) < 2,
+              terminals.count > 1,
+              let index = terminals.firstIndex(where: { $0.id == placeholderShell.tabID }) else { return }
+        Ghostty.logger.info("[urlopen] replacing placeholder shell window=\(windowId, privacy: .public)")
+        closeTab(at: index)
     }
 }

--- a/rootshell/UI/Shell/MainView+TabManagement.swift
+++ b/rootshell/UI/Shell/MainView+TabManagement.swift
@@ -90,6 +90,7 @@ extension MainView {
                     // Helper is active - create local shell directly
                     Ghostty.logger.info("Helper is running, creating local shell on launch")
                     self.createLocalShellTab()
+                    self.markPlaceholderShell()
                 } else {
                     // Helper not available - show connection sheet
                     Ghostty.logger.info("Helper not available, showing connection sheet on launch")

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -55,6 +55,13 @@ struct MainView: View {
     var isVisorWindow: Bool { windowId == "visor" }
     @State var isWindowFocused: Bool = false
     @State var windowIsKeyWindow: Bool = false
+    /// The default shell a fresh window opened before any request reached it.
+    /// A URL open landing right after (SwiftUI spawns the scene first, then
+    /// delivers onOpenURL) replaces it instead of trailing it.
+    @State var placeholderShell: (tabID: UUID, createdAt: Date)?
+    /// True while saved tabs are being restored; a URL open that lands
+    /// meanwhile waits so it follows the restored tabs instead of preceding them.
+    @State var restorationInFlight = false
     @State var lifecycleScenePhase: ScenePhase = {
         switch UIApplication.shared.applicationState {
         case .active:
@@ -535,6 +542,9 @@ struct MainView: View {
                             // which case onAppear's own call will apply it).
                             if newID != nil {
                                 tryApplyPendingGeometry()
+                                // A URL open targeted at this scene may have
+                                // been deposited before the link resolved.
+                                consumePendingIntentRequests()
                             }
                             #endif
                         }


### PR DESCRIPTION
On macOS 15 the sdef `open` command never runs for `open -b`; the folder arrives through a SwiftUI-spawned scene's onOpenURL after the window's default shell exists, and the key-window fan-out could leave the request unclaimed until the next launch.

Pick the receiving scene at deposit time, surface it, and claim targeted requests without the key-window race. A watchdog releases any request nobody claims. A folder open landing right after a fresh window replaces its placeholder shell, and one landing during window restoration waits so it follows the restored tabs. Every [urlopen] log line now carries a scene snapshot.