### PR TITLE
fix(tmux): restore the active tab before background recovery

### DIFF
--- a/rootshell.xcodeproj/project.pbxproj
+++ b/rootshell.xcodeproj/project.pbxproj
@@ -6543,7 +6543,7 @@
 			repositoryURL = "https://github.com/kitknox/ghosttykit-rootshell.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.2.5;
+				version = 0.2.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/rootshell.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rootshell.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kitknox/ghosttykit-rootshell.git",
       "state" : {
-        "revision" : "a3fdd67a82ee3b18e63154ac0c9cd893abded36a",
-        "version" : "0.2.5"
+        "revision" : "0697a2127d9f743b3eb211029dca9fc240b59c96",
+        "version" : "0.2.6"
       }
     },
     {

--- a/rootshell/Features/SSH/Session/RemoteExecProbe.swift
+++ b/rootshell/Features/SSH/Session/RemoteExecProbe.swift
@@ -103,7 +103,7 @@ enum RemoteExecProbe {
         #if targetEnvironment(macCatalyst)
         if sessionOwner.connectionConfig.underlyingSSHConfig == nil { return true }
         #endif
-        if sessionOwner.session is TrzszSession { return true }
+        if TmuxController.gatewayTrzszSession(for: sessionOwner.session) != nil { return true }
         #if canImport(Citadel)
         if let citadel = sessionOwner.session as? CitadelSSHSession, citadel.client != nil {
             return true
@@ -160,7 +160,7 @@ enum RemoteExecProbe {
         // child of the same tsshd as the pane's shell. A separate connection
         // would cost an extra authentication and, worse, land outside that
         // process tree — where nothing can identify which pane it belongs to.
-        if let trzsz = sessionOwner.session as? TrzszSession {
+        if let trzsz = TmuxController.gatewayTrzszSession(for: sessionOwner.session) {
             // A timed-out call is released to the CALLER but keeps running on
             // the transport, so without this a stalled command would have
             // another queued behind it every retry, without bound. One

--- a/rootshell/Features/Tmux/TmuxController.swift
+++ b/rootshell/Features/Tmux/TmuxController.swift
@@ -3518,11 +3518,27 @@ final class TmuxController {
     /// already ~one-per-reconnect, so the unconditional call is cheap.
     func resetForDiscard(outputLines: Int, outputBytes: Int) {
         guard !ownerSurfaceFreed else { return }
+        let selectedWindowIds = windowTabs.keys.filter { isActiveWindow(windowId: $0) }
+        // A controller can project tmux windows into multiple app windows, each
+        // with its own selected tab. Prefer the one whose pane actually owns
+        // focus in the key UIWindow. If there is exactly one local selection it
+        // is unambiguous; otherwise let Ghostty fall back to tmux's server-active
+        // window rather than choosing an arbitrary Dictionary entry.
+        let focusedWindowIds = selectedWindowIds.filter { windowId in
+            guard let focusedPane = windowTabs[windowId]?.focusedPane else { return false }
+            return focusedPane.isFirstResponder
+                || (focusedPane.window?.isKeyWindow == true && focusedPane.isLogicallyFocused)
+        }
+        let preferredWindowId = focusedWindowIds.count == 1
+            ? focusedWindowIds[0]
+            : (selectedWindowIds.count == 1 ? selectedWindowIds[0] : nil)
         TmuxDebugLogger.shared.event(
             "RESET",
-            "discard-triggered reset outLines=\(outputLines) outBytes=\(outputBytes) gw=\(uuidPrefix)")
+            "discard-triggered reset outLines=\(outputLines) outBytes=\(outputBytes) "
+            + "preferredWindow=\(preferredWindowId.map(String.init) ?? "server-active") gw=\(uuidPrefix)")
         ResumeDebugLogger.shared.log(
-            "[\(uuidPrefix)] tmux -CC output discard (lines=\(outputLines) bytes=\(outputBytes)) → surface reset")
+            "[\(uuidPrefix)] tmux -CC output discard (lines=\(outputLines) bytes=\(outputBytes)) "
+            + "→ active-first surface reset preferredWindow=\(preferredWindowId.map(String.init) ?? "server-active")")
         // Full reset + pane recapture: every pane repaints on our order.
         // Suppressing the gateway covers the panes (they check parentUUID).
         TerminalBellSuppressor.suppress(
@@ -3532,7 +3548,11 @@ final class TmuxController {
         // their pre-outage state and would read the recapture's own churn as
         // a fresh "needs your input".
         TerminalBellSuppressor.suppressRebuild(ownerTerminalUUID)
-        ghostty_surface_tmux_reset(ownerSurface)
+        if let preferredWindowId, preferredWindowId >= 0 {
+            ghostty_surface_tmux_reset_prioritized(ownerSurface, UInt(preferredWindowId))
+        } else {
+            ghostty_surface_tmux_reset(ownerSurface)
+        }
     }
 
     /// Emit one STATE line (Swift-side counters) plus a ZIG line (the core
@@ -3691,6 +3711,21 @@ enum TmuxWindowRegistry {
             }
         }
         return nil
+    }
+
+    /// The one restored placeholder selected locally for this gateway. A cold
+    /// viewer has no controller/windowTabs yet, so this is the only point where
+    /// the persisted active tab can be carried into active-first recovery.
+    /// Multiple selected candidates across scenes are deliberately ambiguous.
+    static func selectedAwaitingWindow(ownerTerminalUUID owner: UUID) -> Int? {
+        let candidates = liveModels().compactMap { _, model -> Int? in
+            guard let selectedID = model.selectedTabID,
+                  let tab = model.tabs.first(where: { $0.id == selectedID }),
+                  tab.awaitingTmuxReconcile,
+                  tab.owningGatewayTerminalUUID == owner else { return nil }
+            return tab.pendingTmuxWindowId
+        }
+        return candidates.count == 1 ? candidates[0] : nil
     }
 
     @discardableResult
@@ -3992,6 +4027,87 @@ extension Ghostty.TerminalView {
         }
     }
 
+    /// Finish a restored gateway's output gate only after saved ANSI restoration
+    /// has drained and the Ghostty IO thread has entered tmux control mode.
+    @MainActor
+    func releaseRestoredTmuxOutputGateWhenViewerIsArmed() {
+        guard restoredWasTmuxGateway else {
+            outputPipeline.finishScrollbackRestoreGate()
+            TerminalBellSuppressor.suppress(uuid, untilDrained: outputPipeline)
+            didQueueScrollbackRestoreReplay()
+            return
+        }
+        guard !tmuxResumeGateReleaseScheduled else { return }
+        tmuxResumeGateReleaseScheduled = true
+
+        // Restored tmux gateways deliberately skip replaying their hidden
+        // gateway scrollback/mode trailer: projected panes are authoritatively
+        // rebuilt from tmux, and a pipe-drained byte is not necessarily parsed
+        // before this mailbox message. Arm immediately, wait for the IO thread's
+        // active flag, then release tssh bytes into the control parser.
+        tmuxResumeGateReleaseTask?.cancel()
+        tmuxResumeGateReleaseTask = Task { @MainActor [weak self] in
+            guard let self, !Task.isCancelled else { return }
+
+            self.maybeResumeTmuxControlMode()
+            // The foreground watchdog normally resolves this within ~12s. Use
+            // a much larger independent bound here so a wedged mailbox cannot
+            // leave a 5ms polling task alive forever. Poll slowly while the
+            // transport is frozen in the background to avoid needless wakeups.
+            let maxArmPolls = 12_000
+            var armPolls = 0
+            while !Task.isCancelled {
+                guard let surface = self.surface else {
+                    self.tmuxResumeGateReleaseScheduled = false
+                    self.tmuxResumeGateReleaseTask = nil
+                    return
+                }
+                if !self.tmuxResumeRequested {
+                    // Deferred user cancellation armed and immediately aborted
+                    // the viewer. Drop the held control records rather than
+                    // ever replaying them through the ordinary shell parser.
+                    self.outputPipeline.cancelScrollbackRestoreGate()
+                    self.tmuxResumeGateReleaseScheduled = false
+                    self.tmuxResumeGateReleaseTask = nil
+                    return
+                }
+                if ghostty_surface_tmux_active(surface) {
+                    TmuxDebugLogger.shared.event(
+                        "RESUME",
+                        "viewer armed; releasing gated tssh output gw=\(self.uuid.uuidString.prefix(8))")
+                    self.outputPipeline.finishScrollbackRestoreGate()
+                    TerminalBellSuppressor.suppress(self.uuid, untilDrained: self.outputPipeline)
+                    self.didQueueScrollbackRestoreReplay()
+                    self.scrollbackWrittenAwaitingTrailer = false
+                    self.tmuxResumeGateReleaseScheduled = false
+                    self.tmuxResumeGateReleaseTask = nil
+                    return
+                }
+                armPolls += 1
+                if armPolls >= maxArmPolls {
+                    let shortID = self.uuid.uuidString.prefix(8)
+                    Ghostty.logger.warning("tmux viewer arming poll timed out; reverting gateway \(shortID) to a plain shell")
+                    TmuxDebugLogger.shared.event(
+                        "RESUME",
+                        "ARM TIMEOUT; sending resume_abort gw=\(shortID)")
+                    ghostty_surface_tmux_resume_abort(surface)
+                    self.tmuxResumeWatchdog?.cancel()
+                    self.tmuxResumeWatchdog = nil
+                    self.removeAwaitingTmuxPlaceholders()
+                    self.outputPipeline.cancelScrollbackRestoreGate()
+                    self.tmuxResumeGateReleaseScheduled = false
+                    self.tmuxResumeGateReleaseTask = nil
+                    return
+                }
+                try? await Task.sleep(
+                    for: Ghostty.isTransportFrozenByBackground
+                        ? .milliseconds(100)
+                        : .milliseconds(5)
+                )
+            }
+        }
+    }
+
     /// Re-enter tmux control mode on a RESTORED gateway whose tssh session has
     /// just resumed the live pty. The live `tmux -CC` keeps streaming the control
     /// protocol, but this fresh surface never saw the `ESC P 1000 p` preamble, so
@@ -4005,8 +4121,8 @@ extension Ghostty.TerminalView {
     /// probe) until a reconcile arrives (which cancels the watchdog in
     /// `applyTmuxReconcile`), then give up: abort and drop the placeholder tabs so
     /// the gateway returns to a normal shell. One-shot via `tmuxResumeRequested`;
-    /// a no-op unless this terminal was a saved gateway. Called from BOTH the
-    /// top-level trzsz `.running` path and the embedded/shell-launched trzsz path.
+    /// a no-op unless this terminal was a saved gateway. Called after the saved
+    /// terminal stream drains but before its gated live tssh bytes are released.
     @MainActor
     func maybeResumeTmuxControlMode() {
         guard restoredWasTmuxGateway, !tmuxResumeRequested, let surface else { return }
@@ -4023,8 +4139,16 @@ extension Ghostty.TerminalView {
         }
 
         TmuxDebugLogger.shared.marker("RESUME START gw=\(uuid.uuidString.prefix(8))")
-        TmuxDebugLogger.shared.event("RESUME", "initial probe sent")
-        ghostty_surface_tmux_resume(surface)
+        let preferredWindow = TmuxWindowRegistry.selectedAwaitingWindow(
+            ownerTerminalUUID: uuid)
+        TmuxDebugLogger.shared.event(
+            "RESUME",
+            "initial probe sent preferredWindow=\(preferredWindow.map(String.init) ?? "server-active")")
+        if let preferredWindow, preferredWindow >= 0 {
+            ghostty_surface_tmux_resume_prioritized(surface, UInt(preferredWindow))
+        } else {
+            ghostty_surface_tmux_resume(surface)
+        }
 
         // Probe-retry watchdog: re-send the probe every 1.5s until a reconcile
         // arrives (tmuxController != nil) or we exhaust the attempts (~12s).

--- a/rootshell/UI/Shell/MainView+Lifecycle.swift
+++ b/rootshell/UI/Shell/MainView+Lifecycle.swift
@@ -1373,8 +1373,13 @@ extension MainView {
         // flip the gate. New bytes from then on flow normally; the existing
         // chunked replay infrastructure handles the per-terminal @Published
         // catch-up.
-        let trzszSessions: [TrzszSession] = terminals.flatMap { $0.splitTree.terminalLeaves }
-            .compactMap { $0.session as? TrzszSession }
+        // Drain the visible tab's roaming transport first. For a tmux gateway
+        // this may be a direct TrzszSession or a shell-launched tssh session
+        // embedded in LocalShellSession; use the same resolver as discard
+        // recovery so both shapes get the active-first latency path. De-dupe by
+        // identity because a projected tmux window can expose multiple leaves
+        // backed by the same gateway transport.
+        let trzszSessions = uniqueGatewayTrzszSessions(from: [visibleSplits, otherSplits])
         LifecycleDebugLogger.shared.checkpoint("FG.drain.scheduled", ms: nil, [
             ("trzszSessions", trzszSessions.count),
             ("resumeBody_ms", String(format: "%.2f", (CFAbsoluteTimeGetCurrent() - resumeStart) * 1000)),
@@ -1386,6 +1391,35 @@ extension MainView {
         // above proved no BG happened between schedule and now, so it equals
         // the live value.)
         drainTrzszSessionsThenOpenGate(remaining: trzszSessions, bodyEpoch: scheduledAtBgEpoch)
+    }
+
+    /// Resolve direct and shell-embedded tssh transports in group order while
+    /// returning each shared gateway session once. Passing visible leaves as the
+    /// first group preserves the foreground critical-path ordering.
+    @MainActor
+    private func uniqueGatewayTrzszSessions(
+        from groups: [[Ghostty.TerminalView]]
+    ) -> [TrzszSession] {
+        var seen = Set<ObjectIdentifier>()
+        return groups.flatMap { leaves in
+            leaves.compactMap { leaf in
+                let gateway: Ghostty.TerminalView
+                if let binding = leaf.tmuxPaneBinding {
+                    // Projected panes intentionally have no TerminalSession.
+                    // Resolve their owning gateway through the pointer-value
+                    // registry, then verify its stable UUID to reject a stale
+                    // parentSurface whose address has been reused.
+                    guard let parent = ghosttyApp.surfaceView(for: binding.parentSurface),
+                          parent.uuid == binding.parentUUID else { return nil }
+                    gateway = parent
+                } else {
+                    gateway = leaf
+                }
+                guard let session = TmuxController.gatewayTrzszSession(for: gateway.session),
+                      seen.insert(ObjectIdentifier(session)).inserted else { return nil }
+                return session
+            }
+        }
     }
 
     /// Drain one tssh session per runloop tick, then flip the background
@@ -1473,7 +1507,9 @@ extension MainView {
             // method doc on `replayBackgroundPathIfAny()`.
             NetworkReachabilityMonitor.shared.replayBackgroundPathIfAny()
 
-            for session in self.terminals.flatMap({ $0.splitTree.terminalLeaves }).compactMap({ $0.session as? TrzszSession }) {
+            for session in self.uniqueGatewayTrzszSessions(
+                from: [self.terminals.flatMap { $0.splitTree.terminalLeaves }]
+            ) {
                 session.flushBackgroundedOutputFully()
             }
 

--- a/rootshell/UI/Terminal/TerminalSurfaceController.swift
+++ b/rootshell/UI/Terminal/TerminalSurfaceController.swift
@@ -519,9 +519,6 @@ final class TerminalSurfaceController: NSObject {
         }
 
         let needsRestore = host.surfacePendingScrollbackRestoreForLayout
-        if needsRestore {
-            host.surfacePendingScrollbackRestoreForLayout = false
-        }
 
         if previousScale == nil || previousScale != scale {
             setContentScaleAndSize(
@@ -559,7 +556,15 @@ final class TerminalSurfaceController: NSObject {
         Ghostty.TerminalView.ghosttyAPIQueue.async {
             Task { @MainActor in
                 hostRef.surfaceUpdatePTYSize()
-                if needsRestore {
+                if needsRestore && hostRef.surfacePendingScrollbackRestoreForLayout {
+                    // Claim the deferred restore only when this main-actor
+                    // callback actually runs. Clearing it before the IO/main
+                    // queue hops lets a concurrent transport `.running` event
+                    // mistake "queued" for "already restored" and replay at
+                    // stale dimensions; a second queued size callback could
+                    // then replay it again. ROOTSHELL-TMUX
+                    // (id=layout-restore-main-actor-claim)
+                    hostRef.surfacePendingScrollbackRestoreForLayout = false
                     hostRef.surfaceRunLayoutDeferredScrollbackRestore()
                 }
             }
@@ -574,7 +579,8 @@ final class TerminalSurfaceController: NSObject {
             ghostty_surface_set_size(surfacePtr, framebufferWidth, framebufferHeight)
             Task { @MainActor in
                 hostRef.surfaceUpdatePTYSize()
-                if needsRestore {
+                if needsRestore && hostRef.surfacePendingScrollbackRestoreForLayout {
+                    hostRef.surfacePendingScrollbackRestoreForLayout = false
                     hostRef.surfaceRunLayoutDeferredScrollbackRestore()
                 }
             }
@@ -597,7 +603,8 @@ final class TerminalSurfaceController: NSObject {
         Ghostty.TerminalView.ghosttyAPIQueue.async {
             Task { @MainActor in
                 hostRef.surfaceUpdatePTYSize()
-                if needsRestore {
+                if needsRestore && hostRef.surfacePendingScrollbackRestoreForLayout {
+                    hostRef.surfacePendingScrollbackRestoreForLayout = false
                     hostRef.surfaceRunLayoutDeferredScrollbackRestore()
                 }
             }
@@ -611,7 +618,8 @@ final class TerminalSurfaceController: NSObject {
             ghostty_surface_set_size(surfacePtr, framebufferWidth, framebufferHeight)
             Task { @MainActor in
                 hostRef.surfaceUpdatePTYSize()
-                if needsRestore {
+                if needsRestore && hostRef.surfacePendingScrollbackRestoreForLayout {
+                    hostRef.surfacePendingScrollbackRestoreForLayout = false
                     hostRef.surfaceRunLayoutDeferredScrollbackRestore()
                 }
             }

--- a/rootshell/UI/Terminal/TerminalView+Session.swift
+++ b/rootshell/UI/Terminal/TerminalView+Session.swift
@@ -196,9 +196,21 @@ extension Ghostty.TerminalView {
     /// their mode-restore sequences. The post-drain render+mouse-capture sync
     /// is also scheduled in that fallback path.
     func restoreScrollbackAfterAnimation(trailer: Data? = nil) {
+        if restoredWasTmuxGateway {
+            // The gateway is hidden while its projected panes are rebuilt from
+            // authoritative tmux captures. Do not replay its saved ANSI or mode
+            // trailer: pipe drain does not acknowledge parser consumption, so
+            // those bytes could cross the asynchronous control-mode boundary.
+            pendingScrollbackRestore = false
+            releaseRestoredTmuxOutputGateWhenViewerIsArmed()
+            return
+        }
         if pendingScrollbackRestore {
             pendingScrollbackRestore = false
-            ScrollbackPersistenceManager.shared.restoreScrollback(for: self, trailer: trailer)
+            ScrollbackPersistenceManager.shared.restoreScrollback(
+                for: self,
+                trailer: trailer
+            )
             return
         }
         if let trailer, !trailer.isEmpty {
@@ -241,6 +253,18 @@ extension Ghostty.TerminalView {
         let trailer = pendingResumeTrailer
         pendingResumeTrailer = nil
 
+        if restoredWasTmuxGateway {
+            // Projected panes own the useful persisted content. Keep remote
+            // control records gated, skip the hidden gateway's ANSI replay,
+            // and arm only once the embedded tssh session is running.
+            if embeddedTrzszReachedRunning {
+                releaseRestoredTmuxOutputGateWhenViewerIsArmed()
+            } else {
+                scrollbackWrittenAwaitingTrailer = true
+            }
+            return
+        }
+
         // Keep the gate open only when we expect a trailer to arrive later
         // (shellLaunchedTrzsz restoration, embedded trzsz hasn't reached
         // `.running` yet). If `.running` already fired, the trailer is in
@@ -274,10 +298,55 @@ extension Ghostty.TerminalView {
     ///
     /// Used by both the top-level `.trzsz` `.running` handler and the embedded
     /// `.shellLaunchedTrzsz` path (via `LocalShellSession.onEmbeddedTrzszReady`).
-    /// Always calls `restoreScrollbackAfterAnimation`, even when
-    /// `trzszSession.wasResumed == false`, so any pending scrollback restore
-    /// still completes for the fresh-attach case.
+    /// When transport resume falls back to a fresh spawn, abandons any restored
+    /// tmux projection and rejoins the ordinary saved-scrollback flow. Layout-
+    /// deferred restores remain deferred until the correctly sized callback.
+    /// A fresh shell must never be armed as a synthetic tmux control stream.
     func applyResumeTrailer(for trzszSession: TrzszSession) {
+        // A restored tmux projection is valid only when tssh actually resumed
+        // the old PTY. On fresh-spawn fallback the bytes already waiting in the
+        // restore gate are a normal shell banner/prompt, not tmux control
+        // records. Clear the gateway identity first so the ordinary restore
+        // path replays saved ANSI and then releases those live shell bytes.
+        // ROOTSHELL-TMUX (id=tmux-fresh-transport-fallback)
+        if restoredWasTmuxGateway && !trzszSession.wasResumed {
+            embeddedTrzszReachedRunning = true
+            tmuxResumeGateReleaseTask?.cancel()
+            tmuxResumeGateReleaseTask = nil
+            tmuxResumeGateReleaseScheduled = false
+            tmuxResumeWatchdog?.cancel()
+            tmuxResumeWatchdog = nil
+            removeAwaitingTmuxPlaceholders()
+            pendingResumeTrailer = nil
+            TmuxDebugLogger.shared.event(
+                "RESUME",
+                "transport fell back to fresh spawn; restoring as plain shell gw=\(uuid.uuidString.prefix(8))")
+
+            // The layout token remains true until a size callback claims it on
+            // the main actor. If `.running` wins that race, leave the gate and
+            // scrollback untouched; the sized callback will now take the normal
+            // (non-tmux) path exactly once. ROOTSHELL-TMUX
+            // (id=tmux-fresh-transport-fallback)
+            if pendingScrollbackRestoreForLayout {
+                scrollbackWrittenAwaitingTrailer = false
+                return
+            }
+
+            if scrollbackWrittenAwaitingTrailer {
+                // Layout already ran while the terminal still looked like a
+                // restored gateway, so it intentionally skipped hidden-gateway
+                // ANSI. We now know this is a fresh shell and can restore at
+                // the established dimensions before releasing its live bytes.
+                scrollbackWrittenAwaitingTrailer = false
+                ScrollbackPersistenceManager.shared.restoreScrollback(for: self)
+            } else {
+                // Top-level `.trzsz` restoration uses the non-layout pending
+                // flag; its ordinary helper atomically clears and finishes it.
+                restoreScrollbackAfterAnimation()
+            }
+            return
+        }
+
         var trailer: Data? = nil
         if trzszSession.wasResumed {
             var bytes = Data()
@@ -322,15 +391,21 @@ extension Ghostty.TerminalView {
             // then. Now we can write the trailer behind the scrollback and
             // finish the gate, producing the desired stream:
             //     saved-scrollback → trailer → buffered-server-output → live
-            if let trailer, !trailer.isEmpty {
+            if !restoredWasTmuxGateway, let trailer, !trailer.isEmpty {
                 outputPipeline.writeDirect(trailer)
             }
-            outputPipeline.finishScrollbackRestoreGate()
-            // Everything the gate buffered while we waited for `.running`
-            // lands now — hold the mute until it has actually drained.
-            TerminalBellSuppressor.suppress(uuid, untilDrained: outputPipeline)
-            didQueueScrollbackRestoreReplay()
             scrollbackWrittenAwaitingTrailer = false
+            if restoredWasTmuxGateway {
+                // The buffered server bytes are tmux control records. The core
+                // viewer must be armed before these records leave the gate.
+                releaseRestoredTmuxOutputGateWhenViewerIsArmed()
+            } else {
+                outputPipeline.finishScrollbackRestoreGate()
+                // Everything the gate buffered while we waited for `.running`
+                // lands now — hold the mute until it has actually drained.
+                TerminalBellSuppressor.suppress(uuid, untilDrained: outputPipeline)
+                didQueueScrollbackRestoreReplay()
+            }
         } else {
             // Top-level `.trzsz` (pendingScrollbackRestore-driven) or any
             // other path where the gate has already been flushed normally.
@@ -346,12 +421,9 @@ extension Ghostty.TerminalView {
         // so it can't race with display output ordering.
         if trzszSession.wasResumed {
             trzszSession.sendInput(Data("\u{1b}[I".utf8))
-            // If this restored terminal was a tmux -CC control-mode gateway,
-            // re-enter control mode now that the live pty is reattached. No-op
-            // unless restoredWasTmuxGateway. This is the single trigger point for
-            // BOTH the direct-trzsz `.running` path and the embedded/
-            // shell-launched trzsz path (onEmbeddedTrzszReady) — all call this.
-            maybeResumeTmuxControlMode()
+            // A restored tmux gateway is armed by the scrollback-gate release
+            // path above, after its saved ANSI bytes drain and before buffered
+            // live control records are allowed into Ghostty.
         }
     }
 

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -673,6 +673,15 @@ extension Ghostty {
         /// in `applyTmuxReconcile`.
         var tmuxResumeWatchdog: Task<Void, Never>?
 
+        /// Keeps restored tssh output behind the scrollback gate until Ghostty
+        /// has actually created its tmux viewer. The hidden gateway's saved ANSI
+        /// replay is skipped; projected panes are rebuilt from tmux. Without
+        /// this handshake, a fast roaming reattach can
+        /// feed raw `%output` records to the ordinary shell parser before the
+        /// asynchronous resume mailbox message is consumed.
+        var tmuxResumeGateReleaseScheduled = false
+        var tmuxResumeGateReleaseTask: Task<Void, Never>?
+
         /// Whether the local shell has an active long-running task (helix, vim, sftp, scp, ping)
         var hasActiveLocalTask: Bool = false
 
@@ -1519,6 +1528,9 @@ extension Ghostty {
             outputMonitorTask = nil
             transferAttachTask?.cancel()
             transferAttachTask = nil
+            tmuxResumeGateReleaseTask?.cancel()
+            tmuxResumeGateReleaseTask = nil
+            tmuxResumeGateReleaseScheduled = false
             outputPipeline.cancel()
             scrollIndicatorHideWorkItem?.cancel()
             scrollIndicatorHideWorkItem = nil


### PR DESCRIPTION
Prioritize the visible tssh gateway and selected tmux window during foreground and cold-launch recovery.

Keep restored control output gated until the viewer is armed, handle fresh transport fallback safely, and make layout-deferred scrollback restoration idempotent.