### PR TITLE
fix(tssh): restore focus reporting instead of injecting focus-in on resume

### DIFF
--- a/rootshell.xcodeproj/project.pbxproj
+++ b/rootshell.xcodeproj/project.pbxproj
@@ -6543,7 +6543,7 @@
 			repositoryURL = "https://github.com/kitknox/ghosttykit-rootshell.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.2.6;
+				version = 0.2.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/rootshell.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rootshell.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kitknox/ghosttykit-rootshell.git",
       "state" : {
-        "revision" : "0697a2127d9f743b3eb211029dca9fc240b59c96",
-        "version" : "0.2.6"
+        "revision" : "6db406c7fbb76aa85dadbe157c49004d432b28ac",
+        "version" : "0.2.7"
       }
     },
     {

--- a/rootshell/Core/Persistence/ScrollbackPersistenceManager.swift
+++ b/rootshell/Core/Persistence/ScrollbackPersistenceManager.swift
@@ -90,6 +90,10 @@ final class ScrollbackPersistenceManager {
         scrollbackDirectory.appendingPathComponent("\(uuid.uuidString).cursorkeys.enc")
     }
 
+    private func focusEventModeURL(for uuid: UUID) -> URL {
+        scrollbackDirectory.appendingPathComponent("\(uuid.uuidString).focusevent.enc")
+    }
+
     // MARK: - Init
 
     private init() {
@@ -250,6 +254,7 @@ final class ScrollbackPersistenceManager {
         let isAlternate: Bool
         let isMouseCaptured: Bool
         let isCursorKeyMode: Bool
+        let isFocusEventMode: Bool
     }
 
     /// Gather terminal references for background save. MainActor, no I/O.
@@ -266,6 +271,7 @@ final class ScrollbackPersistenceManager {
             let isAlternate = ghostty_surface_is_alternate_active(surface)
             let isMouseCaptured = ghostty_surface_mouse_captured(surface)
             let isCursorKeyMode = ghostty_surface_cursor_key_mode(surface)
+            let isFocusEventMode = ghostty_surface_focus_event_mode(surface)
 
             let isAtPrompt: Bool = {
                 #if targetEnvironment(macCatalyst)
@@ -285,7 +291,8 @@ final class ScrollbackPersistenceManager {
                 isAtPrompt: isAtPrompt,
                 isAlternate: isAlternate,
                 isMouseCaptured: isMouseCaptured,
-                isCursorKeyMode: isCursorKeyMode
+                isCursorKeyMode: isCursorKeyMode,
+                isFocusEventMode: isFocusEventMode
             ))
         }
 
@@ -342,6 +349,7 @@ final class ScrollbackPersistenceManager {
         hasher.combine(ref.isAtPrompt)
         hasher.combine(ref.isMouseCaptured)
         hasher.combine(ref.isCursorKeyMode)
+        hasher.combine(ref.isFocusEventMode)
         let contentHash = hasher.finalize()
         let alreadySaved = lastSavedHashes.withLock { $0[ref.uuid] == contentHash }
         guard !alreadySaved else { return }
@@ -352,6 +360,7 @@ final class ScrollbackPersistenceManager {
         let encryptedAtPromptFlag: Data?
         let encryptedMouseFlag: Data?
         let encryptedCursorKeyFlag: Data?
+        let encryptedFocusEventFlag: Data?
         do {
             encryptedData = try ScrollbackEncryptionManager.encrypt(data, using: encryptionKey)
             encryptedAltFlag = ref.isAlternate
@@ -364,6 +373,9 @@ final class ScrollbackPersistenceManager {
                 ? try ScrollbackEncryptionManager.encrypt(Data([1]), using: encryptionKey)
                 : nil
             encryptedCursorKeyFlag = ref.isCursorKeyMode
+                ? try ScrollbackEncryptionManager.encrypt(Data([1]), using: encryptionKey)
+                : nil
+            encryptedFocusEventFlag = ref.isFocusEventMode
                 ? try ScrollbackEncryptionManager.encrypt(Data([1]), using: encryptionKey)
                 : nil
         } catch {
@@ -380,6 +392,7 @@ final class ScrollbackPersistenceManager {
         let promptFlagURL = scrollbackDir.appendingPathComponent("\(ref.uuid.uuidString).atprompt.enc")
         let mouseFlagURL = scrollbackDir.appendingPathComponent("\(ref.uuid.uuidString).mousecapture.enc")
         let cursorKeyFlagURL = scrollbackDir.appendingPathComponent("\(ref.uuid.uuidString).cursorkeys.enc")
+        let focusEventFlagURL = scrollbackDir.appendingPathComponent("\(ref.uuid.uuidString).focusevent.enc")
 
         do {
             try FileManager.default.createDirectory(at: scrollbackDir, withIntermediateDirectories: true)
@@ -405,6 +418,11 @@ final class ScrollbackPersistenceManager {
                 try encryptedCursorKeyFlag.write(to: cursorKeyFlagURL, options: .atomic)
             } else {
                 try? FileManager.default.removeItem(at: cursorKeyFlagURL)
+            }
+            if let encryptedFocusEventFlag {
+                try encryptedFocusEventFlag.write(to: focusEventFlagURL, options: .atomic)
+            } else {
+                try? FileManager.default.removeItem(at: focusEventFlagURL)
             }
 
             // Record the hash only after the write succeeds — a failed save
@@ -473,6 +491,7 @@ final class ScrollbackPersistenceManager {
         let isAlternate = ghostty_surface_is_alternate_active(surface)
         let isMouseCaptured = ghostty_surface_mouse_captured(surface)
         let isCursorKeyMode = ghostty_surface_cursor_key_mode(surface)
+        let isFocusEventMode = ghostty_surface_focus_event_mode(surface)
 
         // Check if the local shell is at a prompt (for seamless restore)
         let isAtPrompt: Bool = {
@@ -522,6 +541,7 @@ final class ScrollbackPersistenceManager {
         hasher.combine(isAtPrompt)
         hasher.combine(isMouseCaptured)
         hasher.combine(isCursorKeyMode)
+        hasher.combine(isFocusEventMode)
         let contentHash = hasher.finalize()
         let alreadySaved = Self.lastSavedHashes.withLock { $0[uuid] == contentHash }
         guard !alreadySaved else { return }
@@ -532,6 +552,7 @@ final class ScrollbackPersistenceManager {
         let encryptedAtPromptFlag: Data?
         let encryptedMouseFlag: Data?
         let encryptedCursorKeyFlag: Data?
+        let encryptedFocusEventFlag: Data?
         do {
             encryptedData = try ScrollbackEncryptionManager.shared.encrypt(data)
             encryptedAltFlag = isAlternate
@@ -546,6 +567,9 @@ final class ScrollbackPersistenceManager {
             encryptedCursorKeyFlag = isCursorKeyMode
                 ? try ScrollbackEncryptionManager.shared.encrypt(Data([1]))
                 : nil
+            encryptedFocusEventFlag = isFocusEventMode
+                ? try ScrollbackEncryptionManager.shared.encrypt(Data([1]))
+                : nil
         } catch {
             Self.logger.warning("Encryption failed for \(uuid.uuidString.prefix(8)), skipping save: \(error.localizedDescription)")
             return
@@ -557,6 +581,7 @@ final class ScrollbackPersistenceManager {
         let atPromptFlagURL = atPromptFlagURL(for: uuid)
         let mouseFlagURL = mouseCaptureURL(for: uuid)
         let cursorKeyFlagURL = cursorKeyModeURL(for: uuid)
+        let focusEventFlagURL = focusEventModeURL(for: uuid)
 
         // Write atomically on a utility queue
         let directory = scrollbackDirectory
@@ -589,6 +614,12 @@ final class ScrollbackPersistenceManager {
                     try encryptedCursorKeyFlag.write(to: cursorKeyFlagURL, options: .atomic)
                 } else {
                     try? FileManager.default.removeItem(at: cursorKeyFlagURL)
+                }
+                // Save or remove encrypted focus event mode flag
+                if let encryptedFocusEventFlag {
+                    try encryptedFocusEventFlag.write(to: focusEventFlagURL, options: .atomic)
+                } else {
+                    try? FileManager.default.removeItem(at: focusEventFlagURL)
                 }
 
                 // Record the hash only after the write succeeds — failures
@@ -753,6 +784,21 @@ final class ScrollbackPersistenceManager {
         return data.first == 1
     }
 
+    // MARK: - Focus Event Mode Query
+
+    /// Check if focus event reporting (DEC mode 1004) was active when scrollback was last saved.
+    func wasFocusEventModeActive(for uuid: UUID) -> Bool {
+        let url = focusEventModeURL(for: uuid)
+        guard let combined = try? Data(contentsOf: url), !combined.isEmpty else {
+            return false
+        }
+        guard let data = try? ScrollbackEncryptionManager.shared.decrypt(combined) else {
+            try? FileManager.default.removeItem(at: url)
+            return false
+        }
+        return data.first == 1
+    }
+
     // MARK: - Cleanup
 
     /// Remove scrollback files for terminals not in the active set, if older than threshold.
@@ -777,6 +823,8 @@ final class ScrollbackPersistenceManager {
                 uuidString = String(filename.dropLast(".mousecapture.enc".count))
             } else if filename.hasSuffix(".cursorkeys.enc") {
                 uuidString = String(filename.dropLast(".cursorkeys.enc".count))
+            } else if filename.hasSuffix(".focusevent.enc") {
+                uuidString = String(filename.dropLast(".focusevent.enc".count))
             } else if filename.hasSuffix(".altscreen") {
                 // Legacy unencrypted flag
                 uuidString = String(filename.dropLast(".altscreen".count))

--- a/rootshell/UI/Terminal/TerminalView+Session.swift
+++ b/rootshell/UI/Terminal/TerminalView+Session.swift
@@ -283,18 +283,22 @@ extension Ghostty.TerminalView {
     }
 
     /// Build the mode-restoration trailer for a resumed trzsz session and inject
-    /// it via `restoreScrollbackAfterAnimation(trailer:)`. Also sends focus-in
-    /// to the remote so TUI apps un-grey their cursor.
+    /// it via `restoreScrollbackAfterAnimation(trailer:)`.
     ///
     /// The trailer carries the DECSETs the resumed remote TUI expects to be
-    /// active (alt screen, mouse capture, cursor key mode, bracketed paste,
-    /// cursor shape reset). Appended atomically to the saved scrollback inside
-    /// the restore gate, the byte stream becomes:
+    /// active (alt screen, mouse capture, cursor key mode, focus reporting,
+    /// bracketed paste, cursor shape reset). Appended atomically to the saved
+    /// scrollback inside the restore gate, the byte stream becomes:
     ///
     ///     saved-scrollback → trailer → buffered-live → live
     ///
     /// No live data can race ahead of the mode-set bytes, so by the time the
     /// server's redraw is parsed, ghostty's modes are already correct.
+    ///
+    /// Focus is never injected directly: DECSET 1004 makes ghostty report the
+    /// surface's real focus state to the remote, so a `tail -f` shell (mode
+    /// off) receives nothing. A tmux gateway skips the trailer entirely; tmux
+    /// owns pane focus and raw bytes would corrupt its control channel.
     ///
     /// Used by both the top-level `.trzsz` `.running` handler and the embedded
     /// `.shellLaunchedTrzsz` path (via `LocalShellSession.onEmbeddedTrzszReady`).
@@ -360,6 +364,13 @@ extension Ghostty.TerminalView {
             if ScrollbackPersistenceManager.shared.wasCursorKeyModeActive(for: self.uuid) {
                 bytes.append(Data("\u{1b}[?1h".utf8))
             }
+            // The live surface covers same-process reconnects whose flag was
+            // never persisted. Parsing 1004h makes ghostty emit focus-in/out.
+            let focusReporting = ScrollbackPersistenceManager.shared.wasFocusEventModeActive(for: self.uuid)
+                || (surface.map { ghostty_surface_focus_event_mode($0) } ?? false)
+            if focusReporting {
+                bytes.append(Data("\u{1b}[?1004h".utf8))
+            }
             // Virtually all TUI apps that use alternate screen also enable bracketed paste.
             if wasAltScreen {
                 bytes.append(Data("\u{1b}[?2004h".utf8))
@@ -411,20 +422,9 @@ extension Ghostty.TerminalView {
             // other path where the gate has already been flushed normally.
             restoreScrollbackAfterAnimation(trailer: trailer)
         }
-
-        // Send focus-in (\x1b[I) directly to the remote session. We can't use
-        // ghostty_surface_set_focus because the fresh surface doesn't have mode
-        // 1004 (focus reporting) enabled yet — all terminal modes reset on
-        // surface creation. Sending directly via sendInput bypasses the mode
-        // check and tells apps like Helix the terminal is focused, restoring
-        // their normal cursor. Goes via the input channel, not bufferedWriter,
-        // so it can't race with display output ordering.
-        if trzszSession.wasResumed {
-            trzszSession.sendInput(Data("\u{1b}[I".utf8))
-            // A restored tmux gateway is armed by the scrollback-gate release
-            // path above, after its saved ANSI bytes drain and before buffered
-            // live control records are allowed into Ghostty.
-        }
+        // A restored tmux gateway is armed by the scrollback-gate release path
+        // above, after its saved ANSI bytes drain and before buffered live
+        // control records are allowed into Ghostty.
     }
 
     /// Ensures the restore replay's final cursor positioning is rendered after

--- a/rootshell/rootshell-Bridging-Header.h
+++ b/rootshell/rootshell-Bridging-Header.h
@@ -84,6 +84,9 @@ int ghostty_surface_response_read_fd(void* surface);
 /// When false, arrow keys should send CSI sequences (\x1b[A, etc.)
 bool ghostty_surface_cursor_key_mode(void* surface);
 
+/// Returns whether focus event reporting (DEC mode 1004) is active.
+bool ghostty_surface_focus_event_mode(void* surface);
+
 /// Returns the total number of rows in the primary screen (including scrollback).
 uintptr_t ghostty_surface_total_rows(void* surface);
 


### PR DESCRIPTION
Persist DEC mode 1004 with the other terminal modes and restore it in the resume trailer, so ghostty reports the surface's real focus state only to apps that asked for it. Drops the unconditional ESC[I, which echoed as ^[[I in plain shells and landed on the tmux -CC control channel. Pin GhosttyKit 0.2.7 for ghostty_surface_focus_event_mode.