### PR TITLE
Add drag-to-rearrange split panes

### DIFF
--- a/rootshell/Core/Terminal/SplitTree.swift
+++ b/rootshell/Core/Terminal/SplitTree.swift
@@ -81,6 +81,7 @@ struct SplitTree<ViewType: UIView & Identifiable> {
 
     enum SplitError: Error {
         case viewNotFound
+        case invalidMove
     }
 
     enum NewDirection {
@@ -135,6 +136,16 @@ extension SplitTree {
         return .init(
             root: try root.insert(view: view, at: at, direction: direction),
             zoomed: nil)
+    }
+
+    /// Relocate a live leaf without ever publishing a tree missing that leaf.
+    /// Removing first also collapses its old parent before splitting the target.
+    func moving(view: ViewType, to destination: ViewType, direction: NewDirection) throws -> Self {
+        guard view !== destination, zoomed == nil else { throw SplitError.invalidMove }
+        guard contains(view), contains(destination), let source = root?.node(view: view) else {
+            throw SplitError.viewNotFound
+        }
+        return try remove(source).insert(view: view, at: destination, direction: direction)
     }
 
     /// Find a node containing a view with the specified ID.

--- a/rootshell/UI/Shell/MainView+Focus.swift
+++ b/rootshell/UI/Shell/MainView+Focus.swift
@@ -59,6 +59,11 @@ extension MainView {
         // is a no-op when no overlay is up.
         pane?.setOverlayOwnsKeyboard(isAnySheetPresented)
         if let current, let pane, current === pane {
+            // Logical focus can survive while UIKit focus is lost (for example
+            // when a pane is reparented after a drop). Reacquire it even when
+            // the focused-pane pointer did not change.
+            pane.isLogicallyFocused = true
+            _ = pane.focusDidChange(true)
             // Same-pane re-focus (e.g. tapping the already-focused tmux pane):
             // still re-assert tmux's active window/pane. With the core's
             // automatic select-pane echo gone, this is the user's only way to

--- a/rootshell/UI/Shell/MainView+Splits.swift
+++ b/rootshell/UI/Shell/MainView+Splits.swift
@@ -14,6 +14,60 @@ import os
 
 extension MainView {
 
+    func handlePaneMove(tabID: UUID, source: SplitPaneView, destination: SplitPaneView, zone: PaneDropZone) {
+        guard let index = terminals.firstIndex(where: { $0.id == tabID }),
+              index == selectedTabIndex, !isAnySheetPresented, appTabSwipeState == nil,
+              !tabExpose.isActive, tabsModel.fullScreenPaneID == nil else { return }
+        let tab = terminals[index]
+        guard !tab.paneMove.isPending, tab.splitTree.zoomed == nil,
+              tab.splitTree.contains(source), tab.splitTree.contains(destination),
+              !tab.splitTree.contains(where: { $0.isDetachedForFullScreen }),
+              PaneMoveEligibility.allows(source, destination) else { return }
+
+        if let binding = source.asTerminal?.tmuxPaneBinding {
+            guard let targetBinding = destination.asTerminal?.tmuxPaneBinding,
+                  let controller = TmuxController.controller(forOwnerSurface: binding.parentSurface),
+                  let command = zone.tmuxMoveCommand(
+                    source: .init(ownerID: binding.parentUUID, windowID: binding.windowId, paneID: binding.paneId),
+                    destination: .init(ownerID: targetBinding.parentUUID, windowID: targetBinding.windowId, paneID: targetBinding.paneId)
+                  ),
+                  let requestID = tab.paneMove.begin() else { return }
+            let focusRevision = tab.paneFocusRevision
+            let selectionRevision = tabsModel.selectionRevision
+            Task { @MainActor in
+                do {
+                    _ = try await controller.sendCommandWithReply(command)
+                    tab.paneMove.finish(requestID)
+                    // tmux owns the tree; %layout-change will move the existing
+                    // surfaces. This is only the user's one-shot focus request.
+                    guard tabsModel.selectionRevision == selectionRevision,
+                          tab.paneFocusRevision == focusRevision,
+                          let currentIndex = terminals.firstIndex(where: { $0 === tab }),
+                          currentIndex == selectedTabIndex,
+                          !isAnySheetPresented, isWindowFocused,
+                          tab.splitTree.contains(source),
+                          source.asTerminal?.tmuxPaneBinding?.parentUUID == binding.parentUUID,
+                          source.asTerminal?.tmuxPaneBinding?.windowId == binding.windowId else { return }
+                    setFocusedPane(source, inTab: currentIndex)
+                } catch {
+                    tab.paneMove.finish(requestID, error: String(localized: "Couldn’t move pane: \(error.localizedDescription)"))
+                    Ghostty.logger.error("Pane move failed: \(error.localizedDescription)")
+                }
+            }
+            return
+        }
+
+        // A native tree may include terminals and nonterminal panes, but never
+        // edit a server-owned window or a mixed tree with bound tmux leaves.
+        guard !tab.isTmuxWindow, !tab.splitTree.terminalLeaves.contains(where: { $0.isTmuxPane }) else { return }
+        do {
+            tab.splitTree = try tab.splitTree.moving(view: source, to: destination, direction: zone.direction)
+            setFocusedPane(source, inTab: index)
+        } catch {
+            Ghostty.logger.error("Invalid native pane move: \(error.localizedDescription)")
+        }
+    }
+
     func handleSplitResize(tabIndex: Int, node: SplitTree<SplitPaneView>.Node, ratio: Double) {
         guard tabIndex < terminals.count else { return }
 

--- a/rootshell/UI/Shell/MainView+TerminalContent.swift
+++ b/rootshell/UI/Shell/MainView+TerminalContent.swift
@@ -1016,6 +1016,12 @@ extension MainView {
                         onResize: { node, ratio in
                             handleSplitResize(tabIndex: index, node: node, ratio: ratio)
                         },
+                        onMove: { source, destination, zone in
+                            handlePaneMove(tabID: tab.id, source: source, destination: destination, zone: zone)
+                        },
+                        allowsPaneRearrangement: !tab.paneMove.isPending && !isAnySheetPresented
+                            && appTabSwipeState == nil && !tabExpose.isActive
+                            && tabsModel.fullScreenPaneID == nil,
                         isActive: index == selectedTabIndex,
                         focusedPane: tab.focusedPane,
                         terminalEffectsEnabled: terminalEffectsEnabled,
@@ -1038,6 +1044,17 @@ extension MainView {
                     // view". Combining the stable tab UUID keeps the rebuild-on-
                     // structure-change behavior the tmux reconcile depends on.
                     .id(TabSplitTreeIdentity(tabID: tab.id, tree: tab.splitTree.structuralIdentity))
+                    .overlay(alignment: .top) {
+                        if let message = tab.paneMove.errorMessage {
+                            Text(message)
+                                .font(.callout)
+                                .padding(10)
+                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                                .padding(8)
+                                .allowsHitTesting(false)
+                                .accessibilityLabel(message)
+                        }
+                    }
                     // Visibility keys off the lagging displayedTabID (not the
                     // selection) so a freshly opened tab stays hidden, and the
                     // previous tab stays on screen, until its renderer has

--- a/rootshell/UI/Tabs/TabsModel.swift
+++ b/rootshell/UI/Tabs/TabsModel.swift
@@ -233,6 +233,9 @@ nonisolated struct TabOrderProjection: Equatable, Sendable {
 final class TabModel: Identifiable {
     /// Stable identity for `ForEach` and reorder/cleanup operations.
     let id = UUID()
+    let paneMove = PaneMoveState()
+    /// Prevent a delayed move reply from overriding a newer focus choice.
+    @ObservationIgnored private(set) var paneFocusRevision: UInt64 = 0
 
     /// The window this tab belongs to. Used for window-aware drag and per-window
     /// theme override resolution.
@@ -355,6 +358,7 @@ final class TabModel: Identifiable {
     var focusedPane: SplitPaneView? {
         didSet {
             guard oldValue !== focusedPane else { return }
+            paneFocusRevision &+= 1
             groupingRevision &+= 1
             startObserving()
             AgentAttentionCenter.shared.visibilityDidChange()
@@ -845,6 +849,7 @@ final class TabModel: Identifiable {
 @MainActor
 @Observable
 final class TabsModel {
+    @ObservationIgnored private(set) var selectionRevision: UInt64 = 0
     /// All tabs in the window, in display order.
     var tabs: [TabModel] = [] {
         didSet {
@@ -865,6 +870,7 @@ final class TabsModel {
     var selectedTabID: UUID? {
         didSet {
             guard oldValue != selectedTabID else { return }
+            selectionRevision &+= 1
             beginTabSwitchAnimationGate()
             if let tab = selectedTab { rememberSelectionScope(of: tab) }
             if isGroupedModeEnabled, !isProjectGroupingActive,

--- a/rootshell/UI/Terminal/PaneDropZone.swift
+++ b/rootshell/UI/Terminal/PaneDropZone.swift
@@ -1,0 +1,87 @@
+import UIKit
+
+/// Same normalized triangular edge regions as Ghostty's macOS split drops.
+enum PaneDropZone: CaseIterable, Equatable {
+    case left, right, top, bottom
+
+    static func calculate(at point: CGPoint, in bounds: CGRect) -> Self? {
+        guard bounds.width > 0, bounds.height > 0, bounds.contains(point) else { return nil }
+        let x = (point.x - bounds.minX) / bounds.width
+        let y = (point.y - bounds.minY) / bounds.height
+        let distance = min(x, 1 - x, y, 1 - y)
+        if distance == x { return .left }
+        if distance == 1 - x { return .right }
+        if distance == y { return .top }
+        return .bottom
+    }
+
+    var direction: SplitTree<SplitPaneView>.NewDirection {
+        switch self {
+        case .left: .left
+        case .right: .right
+        case .top: .up
+        case .bottom: .down
+        }
+    }
+
+    func previewFrame(in bounds: CGRect) -> CGRect {
+        switch self {
+        case .left: CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width / 2, height: bounds.height)
+        case .right: CGRect(x: bounds.midX, y: bounds.minY, width: bounds.width / 2, height: bounds.height)
+        case .top: CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height / 2)
+        case .bottom: CGRect(x: bounds.minX, y: bounds.midY, width: bounds.width, height: bounds.height / 2)
+        }
+    }
+
+    /// Only integer pane IDs enter the control channel; never pane titles or text.
+    func tmuxMoveCommand(source: Int, destination: Int) -> String? {
+        guard source >= 0, destination >= 0, source != destination else { return nil }
+        let flags: String
+        switch self {
+        case .left: flags = "-h -b"
+        case .right: flags = "-h"
+        case .top: flags = "-v -b"
+        case .bottom: flags = "-v"
+        }
+        return "move-pane -d \(flags) -s %\(source) -t %\(destination)"
+    }
+
+    func tmuxMoveCommand(source: TmuxPaneMoveIdentity, destination: TmuxPaneMoveIdentity) -> String? {
+        guard source.canMove(to: destination) else { return nil }
+        return tmuxMoveCommand(source: source.paneID, destination: destination.paneID)
+    }
+}
+
+struct TmuxPaneMoveIdentity {
+    let ownerID: UUID
+    let windowID: Int
+    let paneID: Int
+
+    func canMove(to destination: Self) -> Bool {
+        ownerID == destination.ownerID && windowID == destination.windowID
+            && windowID >= 0 && paneID >= 0 && destination.paneID >= 0 && paneID != destination.paneID
+    }
+}
+
+/// Shared by drag previews and the commit path. Never move a native leaf into a
+/// server-owned tree, or a tmux pane between gateways/windows via a local edit.
+@MainActor
+enum PaneMoveEligibility {
+    static func allows(_ source: SplitPaneView, _ destination: SplitPaneView) -> Bool {
+        guard source !== destination,
+              !source.isDetachedForFullScreen, !destination.isDetachedForFullScreen else { return false }
+        switch (source.asTerminal?.tmuxPaneBinding, destination.asTerminal?.tmuxPaneBinding) {
+        case (nil, nil): return true
+        case let (source?, destination?):
+            let sourceID = TmuxPaneMoveIdentity(ownerID: source.parentUUID, windowID: source.windowId, paneID: source.paneId)
+            let destinationID = TmuxPaneMoveIdentity(ownerID: destination.parentUUID, windowID: destination.windowId, paneID: destination.paneId)
+            guard sourceID.canMove(to: destinationID),
+                  source.parentSurface == destination.parentSurface,
+                  let controller = TmuxController.controller(forOwnerSurface: source.parentSurface),
+                  controller.ownerTerminalUUIDForNotifications == source.parentUUID,
+                  controller.isActive else { return false }
+            return true
+        default: return false
+        }
+    }
+}

--- a/rootshell/UI/Terminal/PaneMoveState.swift
+++ b/rootshell/UI/Terminal/PaneMoveState.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Observation
+
+/// Lives on the tab, so a tmux reconcile replacing the split host cannot lose
+/// the in-flight guard or its error message.
+@MainActor
+@Observable
+final class PaneMoveState {
+    private(set) var requestID: UUID?
+    private(set) var errorMessage: String?
+    @ObservationIgnored private var clearErrorTask: Task<Void, Never>?
+
+    var isPending: Bool { requestID != nil }
+
+    func begin() -> UUID? {
+        guard requestID == nil else { return nil }
+        clearErrorTask?.cancel()
+        errorMessage = nil
+        let id = UUID()
+        requestID = id
+        return id
+    }
+
+    func finish(_ id: UUID, error: String? = nil) {
+        guard requestID == id else { return }
+        requestID = nil
+        errorMessage = error
+        guard error != nil else { return }
+        clearErrorTask = Task { @MainActor [weak self] in
+            do { try await Task.sleep(for: .seconds(5)) } catch { return }
+            guard !Task.isCancelled else { return }
+            self?.errorMessage = nil
+        }
+    }
+
+    deinit { clearErrorTask?.cancel() }
+}

--- a/rootshell/UI/Terminal/SplitPaneRearrangementController.swift
+++ b/rootshell/UI/Terminal/SplitPaneRearrangementController.swift
@@ -1,0 +1,289 @@
+import UIKit
+
+/// A tab-local gesture, not a system drag payload: terminal text/file drops and
+/// tab transfers keep their own interactions, and a pane cannot escape its tab.
+@MainActor
+final class SplitPaneRearrangementController: NSObject, UIGestureRecognizerDelegate {
+    private weak var host: SplitTreeHostingView?
+    private var tree = SplitTree<SplitPaneView>()
+    private var handles: [UUID: PaneGrabHandleView] = [:]
+    private var frames: [UUID: CGRect] = [:]
+    private var enabled = false
+    private var touchHandlesVisible = false
+    private var hoveredPaneID: UUID?
+    private var source: SplitPaneView?
+    private var target: (pane: SplitPaneView, zone: PaneDropZone)?
+    private let preview = UIView()
+    private var hideTask: Task<Void, Never>?
+    private var backgroundObserver: NSObjectProtocol?
+    private var windowObserver: NSObjectProtocol?
+
+    var isDragging: Bool { source != nil }
+
+    init(host: SplitTreeHostingView) {
+        self.host = host
+        super.init()
+        preview.isUserInteractionEnabled = false
+        preview.layer.cornerRadius = 4
+        preview.isHidden = true
+        host.addSubview(preview)
+        let hover = UIHoverGestureRecognizer(target: self, action: #selector(hoverChanged(_:)))
+        hover.cancelsTouchesInView = false
+        hover.delegate = self
+        host.addGestureRecognizer(hover)
+        backgroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.reset() }
+        }
+        windowObserver = NotificationCenter.default.addObserver(
+            forName: UIWindow.didResignKeyNotification, object: nil, queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let self, let window = notification.object as? UIWindow,
+                      window === self.host?.window else { return }
+                self.reset()
+            }
+        }
+    }
+
+    deinit {
+        hideTask?.cancel()
+        if let backgroundObserver { NotificationCenter.default.removeObserver(backgroundObserver) }
+        if let windowObserver { NotificationCenter.default.removeObserver(windowObserver) }
+    }
+
+    /// Called before a model update as well as after layout. Any changed
+    /// topology invalidates the gesture's destination, including remote tmux edits.
+    func update(tree: SplitTree<SplitPaneView>, enabled: Bool) {
+        let canMove = enabled && tree.isSplit && tree.zoomed == nil
+            && !tree.contains(where: { $0.isDetachedForFullScreen })
+        let eligibilityChanged = self.enabled != canMove
+        if self.tree.root != tree.root || self.tree.zoomed != tree.zoomed || !canMove {
+            reset()
+        }
+        self.tree = tree
+        self.enabled = canMove
+        if eligibilityChanged { host?.setNeedsLayout() }
+        if !canMove { refreshHandles() }
+    }
+
+    func layout() {
+        guard let host else { return }
+        var nextFrames: [UUID: CGRect] = [:]
+        for pane in tree {
+            if let frame = host.slotFrame(for: pane) { nextFrames[pane.uuid] = frame }
+        }
+        if frames != nextFrames, isDragging { reset() }
+        frames = nextFrames
+
+        for id in Array(handles.keys) where nextFrames[id] == nil {
+            handles.removeValue(forKey: id)?.removeFromSuperview()
+        }
+        if enabled {
+            for pane in tree where handles[pane.uuid] == nil {
+                let handle = PaneGrabHandleView(paneID: pane.uuid)
+                handle.onPressChanged = { [weak self] pressed in
+                    guard let self, self.touchHandlesVisible else { return }
+                    if pressed { self.hideTask?.cancel() }
+                    else if !self.isDragging { self.scheduleHide() }
+                }
+                let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+                pan.maximumNumberOfTouches = 1
+                handle.addGestureRecognizer(pan)
+                host.addSubview(handle)
+                handles[pane.uuid] = handle
+            }
+        }
+        refreshHandles()
+        host.bringSubviewToFront(preview)
+    }
+
+    func revealTouchHandles() {
+        guard enabled, !isDragging else { return }
+        touchHandlesVisible = true
+        refreshHandles()
+        scheduleHide()
+    }
+
+    private func scheduleHide() {
+        hideTask?.cancel()
+        hideTask = Task { @MainActor [weak self] in
+            do { try await Task.sleep(for: .seconds(5)) } catch { return }
+            guard !Task.isCancelled, let self, !self.isDragging else { return }
+            self.touchHandlesVisible = false
+            self.refreshHandles()
+        }
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        // Observing the reveal band must not suppress terminal mouse tracking.
+        gestureRecognizer is UIHoverGestureRecognizer || otherGestureRecognizer is UIHoverGestureRecognizer
+    }
+
+    /// Returns true only when Escape belongs to an active pane drag.
+    @discardableResult
+    func cancelDrag() -> Bool {
+        guard isDragging else { return false }
+        reset()
+        // Cancel the recognizer too: its eventual finger/mouse release must
+        // never commit a gesture that Escape already cancelled.
+        for handle in handles.values {
+            for recognizer in handle.gestureRecognizers ?? [] {
+                recognizer.isEnabled = false
+                recognizer.isEnabled = true
+            }
+        }
+        return true
+    }
+
+    func reset() {
+        hideTask?.cancel()
+        hideTask = nil
+        source = nil
+        target = nil
+        touchHandlesVisible = false
+        hoveredPaneID = nil
+        preview.isHidden = true
+        refreshHandles()
+    }
+
+    func detach() {
+        reset()
+        enabled = false
+        tree = SplitTree()
+        frames.removeAll()
+        for handle in handles.values { handle.removeFromSuperview() }
+        handles.removeAll()
+        preview.removeFromSuperview()
+    }
+
+    private func refreshHandles() {
+        guard let host else { return }
+        for (id, handle) in handles {
+            let pane = tree.first(where: { $0.uuid == id })
+            let hasDestination = pane.map { source in
+                tree.contains(where: { PaneMoveEligibility.allows(source, $0) })
+            } ?? false
+            let visible = enabled && hasDestination &&
+                (touchHandlesVisible || hoveredPaneID == id || source?.uuid == id)
+            handle.isHidden = !visible
+            guard let frame = frames[id] else { continue }
+            let width = min(80, frame.width)
+            let height = min(touchHandlesVisible ? 44 : 16, frame.height)
+            handle.frame = CGRect(x: frame.midX - width / 2, y: frame.minY, width: width, height: height)
+            handle.tintColor = host.highlightColor
+            if visible { host.bringSubviewToFront(handle) }
+        }
+    }
+
+    @objc private func hoverChanged(_ recognizer: UIHoverGestureRecognizer) {
+        guard enabled, !isDragging, let host else { return }
+        hoveredPaneID = nil
+        if recognizer.state == .began || recognizer.state == .changed {
+            let point = recognizer.location(in: host)
+            for (id, frame) in frames where frame.contains(point) {
+                if point.y <= frame.minY + max(16, frame.height * 0.2) { hoveredPaneID = id }
+                break
+            }
+        }
+        refreshHandles()
+    }
+
+    @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {
+        guard let host else { return }
+        switch recognizer.state {
+        case .began:
+            guard enabled, let handle = recognizer.view as? PaneGrabHandleView,
+                  let pane = tree.first(where: { $0.uuid == handle.paneID }),
+                  tree.contains(where: { PaneMoveEligibility.allows(pane, $0) }) else { return }
+            source = pane
+            hideTask?.cancel()
+            hideTask = nil
+            refreshHandles()
+            updateTarget(at: recognizer.location(in: host))
+        case .changed:
+            guard isDragging else { return }
+            updateTarget(at: recognizer.location(in: host))
+        case .ended:
+            guard let source else { return }
+            updateTarget(at: recognizer.location(in: host))
+            let destination = target
+            reset()
+            if let destination {
+                host.onMove?(source, destination.pane, destination.zone)
+            }
+        case .cancelled, .failed:
+            reset()
+        default: break
+        }
+    }
+
+    private func updateTarget(at point: CGPoint) {
+        target = nil
+        preview.isHidden = true
+        guard let source, let host, host.bounds.contains(point) else { return }
+        for pane in tree {
+            guard PaneMoveEligibility.allows(source, pane),
+                  let frame = frames[pane.uuid],
+                  let zone = PaneDropZone.calculate(at: point, in: frame) else { continue }
+            target = (pane, zone)
+            preview.frame = zone.previewFrame(in: frame)
+            preview.backgroundColor = host.highlightColor.withAlphaComponent(0.3)
+            preview.isHidden = false
+            host.bringSubviewToFront(preview)
+            break
+        }
+    }
+}
+
+private final class PaneGrabHandleView: UIView {
+    let paneID: UUID
+    var onPressChanged: ((Bool) -> Void)?
+    private let symbol = UIImageView(image: UIImage(systemName: "ellipsis"))
+
+    init(paneID: UUID) {
+        self.paneID = paneID
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        isAccessibilityElement = true
+        accessibilityLabel = String(localized: "Move pane")
+        accessibilityHint = String(localized: "Drag to an edge of another pane in this tab.")
+        accessibilityTraits = [.button, .allowsDirectInteraction]
+        symbol.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+        symbol.isUserInteractionEnabled = false
+        symbol.contentMode = .center
+        symbol.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.85)
+        symbol.layer.cornerRadius = 5
+        symbol.clipsToBounds = true
+        addSubview(symbol)
+        #if !os(visionOS)
+        addInteraction(UIPointerInteraction(delegate: nil))
+        #endif
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        symbol.frame = CGRect(x: (bounds.width - 28) / 2, y: 1, width: 28, height: 12)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        onPressChanged?(true)
+        super.touchesBegan(touches, with: event)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        onPressChanged?(false)
+        super.touchesEnded(touches, with: event)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        onPressChanged?(false)
+        super.touchesCancelled(touches, with: event)
+    }
+}

--- a/rootshell/UI/Terminal/TerminalSplitTreeView.swift
+++ b/rootshell/UI/Terminal/TerminalSplitTreeView.swift
@@ -13,6 +13,8 @@ import os
 struct TerminalSplitTreeView: UIViewRepresentable {
     let tree: SplitTree<SplitPaneView>
     let onResize: (SplitTree<SplitPaneView>.Node, Double) -> Void
+    var onMove: ((SplitPaneView, SplitPaneView, PaneDropZone) -> Void)?
+    var allowsPaneRearrangement: Bool = true
     /// Whether this tab is the visible one. Only the active tab drives the tmux
     /// client size.
     var isActive: Bool = true
@@ -33,6 +35,8 @@ struct TerminalSplitTreeView: UIViewRepresentable {
         uiView.dividerColor = UIColor.separator
         uiView.highlightColor = uiView.tintColor ?? UIColor.systemBlue
         uiView.onResize = onResize
+        uiView.onMove = onMove
+        uiView.allowsPaneRearrangement = allowsPaneRearrangement
         uiView.isActiveTab = isActive
         uiView.terminalEffectsEnabled = terminalEffectsEnabled
         uiView.routesFocusedProgressToIntegratedEdge = routesFocusedProgressToIntegratedEdge
@@ -60,6 +64,21 @@ final class SplitTreeHostingView: UIView {
 
     var minSplitSize: CGFloat = 100
     var onResize: ((SplitTree<SplitPaneView>.Node, Double) -> Void)?
+    var onMove: ((SplitPaneView, SplitPaneView, PaneDropZone) -> Void)?
+    var allowsPaneRearrangement = true
+    private lazy var paneRearrangement = SplitPaneRearrangementController(host: self)
+
+    @discardableResult
+    func cancelPaneDrag() -> Bool { paneRearrangement.cancelDrag() }
+
+    override var keyCommands: [UIKeyCommand]? {
+        guard paneRearrangement.isDragging else { return super.keyCommands }
+        let cancel = UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(cancelPaneDragCommand))
+        cancel.wantsPriorityOverSystemBehavior = true
+        return (super.keyCommands ?? []) + [cancel]
+    }
+
+    @objc private func cancelPaneDragCommand(_ command: UIKeyCommand) { cancelPaneDrag() }
 
     /// Whether this hosting view is rendering the currently-visible tab. Only the
     /// active tab drives the tmux client size (background tabs share the same
@@ -89,6 +108,8 @@ final class SplitTreeHostingView: UIView {
     private let dividerTouchThickness: CGFloat = 24
     private var tree: SplitTree<SplitPaneView>?
     private var focusedPane: SplitPaneView?
+    private var needsFocusRestoration = false
+    private var focusRestorationGeneration: UInt64 = 0
 
     private var dividerViews: [SplitDividerHandleView] = []
     private var dividerReuseIndex: Int = 0
@@ -169,6 +190,7 @@ final class SplitTreeHostingView: UIView {
     }
 
     func update(tree: SplitTree<SplitPaneView>, focusedPane: SplitPaneView?) {
+        paneRearrangement.update(tree: tree, enabled: isActiveTab && allowsPaneRearrangement && onMove != nil)
         // SwiftUI calls this on every MainView body evaluation. Only a real
         // tree or focus change may relayout every attached pane.
         let treeChanged = self.tree?.root != tree.root || self.tree?.zoomed != tree.zoomed
@@ -176,6 +198,8 @@ final class SplitTreeHostingView: UIView {
         self.tree = tree
         self.focusedPane = focusedPane
         guard treeChanged || focusChanged else { return }
+        needsFocusRestoration = true
+        focusRestorationGeneration &+= 1
         updateTerminalEffectsEligibility()
         recomputeBorderEligibility()
         refreshProgressBarRouting()
@@ -198,6 +222,9 @@ final class SplitTreeHostingView: UIView {
     /// dismantle runs before the new host adopts them, and a pane checked out for
     /// full screen lives under the takeover container.
     func detachAllPanes() {
+        needsFocusRestoration = false
+        focusRestorationGeneration &+= 1
+        paneRearrangement.detach()
         for (_, container) in attachedContainers where container.superview === self {
             (container as? Ghostty.TerminalScrollView)?
                 .setProgressBarPresentationSuppressed(false)
@@ -268,6 +295,31 @@ final class SplitTreeHostingView: UIView {
         pushTmuxClientSizeIfNeeded()
         // Frost the dead margin (single- AND multi-pane) over `bounds − contentRect`.
         updateDeadMarginOverlay(contentRect: contentRect)
+        // Overlay chrome follows actual pane frames, including tmux's dead margin.
+        paneRearrangement.update(tree: tree, enabled: isActiveTab && allowsPaneRearrangement && onMove != nil)
+        paneRearrangement.layout()
+        restoreFocusAfterLayoutIfNeeded()
+    }
+
+    /// A structural edit replaces this hosting view. Focus acquired by the
+    /// drop handler (or didMoveToWindow during attachment) can be resigned as
+    /// UIKit finishes removing the old hierarchy. Reassert it after layout,
+    /// from the surviving host, without sending another tmux select command.
+    private func restoreFocusAfterLayoutIfNeeded() {
+        guard needsFocusRestoration else { return }
+        needsFocusRestoration = false
+        guard isActiveTab, let pane = focusedPane, pane.isLogicallyFocused else { return }
+        let generation = focusRestorationGeneration
+        DispatchQueue.main.async { [weak self, weak pane] in
+            guard let self, let pane,
+                  self.focusRestorationGeneration == generation,
+                  self.isActiveTab, self.window?.isKeyWindow == true,
+                  self.focusedPane === pane, pane.isLogicallyFocused,
+                  !pane.isDetachedForFullScreen,
+                  pane.enclosingSplitHost === self,
+                  !pane.isFirstResponder else { return }
+            _ = pane.focusDidChange(true)
+        }
     }
 
     /// Drive a MULTI-pane tmux window's size from this container's actual bounds.
@@ -636,6 +688,7 @@ final class SplitTreeHostingView: UIView {
                 return
             }
             insertSubview(container, at: 0)
+            if pane === focusedPane { needsFocusRestoration = true }
         }
 
         container.frame = frame
@@ -768,6 +821,9 @@ final class SplitTreeHostingView: UIView {
         }
         dividerView.onResizeEnd = { [weak self] node, ratio in
             self?.commitDividerToTmux(node: node, ratio: ratio)
+        }
+        dividerView.onTouchTap = { [weak self] in
+            self?.paneRearrangement.revealTouchHandles()
         }
 
         bringSubviewToFront(dividerView)
@@ -906,6 +962,7 @@ final class SplitTreeHostingView: UIView {
 // MARK: - Divider Handle
 
 private final class SplitDividerHandleView: UIView {
+    var onTouchTap: (() -> Void)?
     var onResize: ((SplitTree<SplitPaneView>.Node, Double) -> Void)?
     /// Fired once when the drag finishes (commit point), so a tmux split can push
     /// the final boundary to tmux.
@@ -935,6 +992,12 @@ private final class SplitDividerHandleView: UIView {
         addGestureRecognizer(doubleTap)
 
         pan.require(toFail: doubleTap)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTouchTap(_:)))
+        tap.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.direct.rawValue)]
+        tap.require(toFail: doubleTap)
+        tap.require(toFail: pan)
+        addGestureRecognizer(tap)
     }
 
     required init?(coder: NSCoder) {
@@ -1025,6 +1088,10 @@ private final class SplitDividerHandleView: UIView {
     @objc private func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
         guard let node else { return }
         NotificationCenter.default.post(name: .equalizeSplits, object: node.leftmostLeaf())
+    }
+
+    @objc private func handleTouchTap(_ recognizer: UITapGestureRecognizer) {
+        if recognizer.state == .ended { onTouchTap?() }
     }
 
     private func ratio(for point: CGPoint) -> Double {

--- a/rootshell/UI/Terminal/TerminalView+Gestures.swift
+++ b/rootshell/UI/Terminal/TerminalView+Gestures.swift
@@ -1200,7 +1200,9 @@ extension Ghostty.TerminalView {
         }
     }
 
-    private func loadPastedNonFileURL(
+    // NSItemProvider invokes its callbacks off the main actor. This helper and
+    // its local URL/fallback functions only process provider data, never UI.
+    private nonisolated func loadPastedNonFileURL(
         from provider: NSItemProvider,
         completion: @escaping (URL?) -> Void
     ) {

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -488,6 +488,10 @@ extension Ghostty.TerminalView {
         }
         #endif
 
+        if key.keyCode == .keyboardEscape, enclosingSplitHost?.cancelPaneDrag() == true {
+            return (true, true)
+        }
+
         // A presented overlay (tab exposé) owns navigation keys while up; it
         // must see Escape before the tmux-detach and AI-agent handlers below.
         if let overlayHandler = presentedOverlayKeyHandler, overlayHandler(OverlayKeyEvent(key)) {
@@ -1789,6 +1793,10 @@ extension Ghostty.TerminalView {
     }
 
     @objc func handleEscapeKey(_ command: UIKeyCommand) {
+        if enclosingSplitHost?.cancelPaneDrag() == true {
+            keysConsumedByOverlayAction.insert(.keyboardEscape)
+            return
+        }
         // The reserved Cmd+Period system-cancel chord can arrive as a
         // translated plain Escape. Give a cmd+period binding first refusal; a
         // twin of a chord delivery already handled on another rail is


### PR DESCRIPTION
Support native and tmux pane moves with handles and drop previews. Restore keyboard focus after moves and fix URL paste actor isolation.