### PR TITLE
Fix profiles hidden by malformed folder paths

### DIFF
--- a/rootshell/Features/Profiles/ConnectionProfile.swift
+++ b/rootshell/Features/Profiles/ConnectionProfile.swift
@@ -106,7 +106,17 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
     // MARK: - Organization
 
     /// Hierarchical folder path (e.g., "Work/Production" or "" for root)
-    var folderPath: String
+    var folderPath: String {
+        didSet {
+            folderPath = Self.normalizeFolderPath(folderPath)
+        }
+    }
+
+    /// Empty path components cannot be reached by the folder browser.
+    /// A path containing only separators represents the root folder.
+    static func normalizeFolderPath(_ path: String) -> String {
+        path.split(separator: "/").joined(separator: "/")
+    }
 
     /// Multi-tag support for flexible categorization
     var tags: Set<String>
@@ -216,7 +226,7 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
         self.notes = notes
         self.iconName = iconName
         self.colorTag = colorTag
-        self.folderPath = folderPath
+        self.folderPath = Self.normalizeFolderPath(folderPath)
         self.tags = tags
         self.vpnEnabled = vpnEnabled
         self.vpnDNSServers = vpnDNSServers
@@ -269,7 +279,7 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
         self.notes = notes
         self.iconName = iconName
         self.colorTag = colorTag
-        self.folderPath = folderPath
+        self.folderPath = Self.normalizeFolderPath(folderPath)
         self.tags = tags
         self.vpnEnabled = vpnEnabled
         self.vpnDNSServers = vpnDNSServers
@@ -305,7 +315,9 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
         iconName = try container.decodeIfPresent(String.self, forKey: .iconName)
         colorTag = try container.decodeIfPresent(ProfileColorTag.self, forKey: .colorTag)
 
-        folderPath = try container.decodeIfPresent(String.self, forKey: .folderPath) ?? ""
+        folderPath = Self.normalizeFolderPath(
+            try container.decodeIfPresent(String.self, forKey: .folderPath) ?? ""
+        )
         tags = try container.decodeIfPresent(Set<String>.self, forKey: .tags) ?? []
 
         sshConfig = try container.decode(SSHConfig.self, forKey: .sshConfig)

--- a/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
@@ -2652,6 +2652,10 @@ struct FolderPickerSheet: View {
 
     private var profileManager: ConnectionProfileManager { ConnectionProfileManager.shared }
 
+    private var normalizedNewFolderPath: String {
+        ConnectionProfile.normalizeFolderPath(newFolderName.trimmingCharacters(in: .whitespaces))
+    }
+
     var body: some View {
         NavigationStack {
             List {
@@ -2704,13 +2708,12 @@ struct FolderPickerSheet: View {
                             TextField("Folder name", text: $newFolderName)
                                 .autocapitalization(.words)
                             Button("Create") {
-                                let trimmed = newFolderName.trimmingCharacters(in: .whitespaces)
-                                if !trimmed.isEmpty {
-                                    selectedPath = trimmed
+                                if !normalizedNewFolderPath.isEmpty {
+                                    selectedPath = normalizedNewFolderPath
                                     dismiss()
                                 }
                             }
-                            .disabled(newFolderName.trimmingCharacters(in: .whitespaces).isEmpty)
+                            .disabled(normalizedNewFolderPath.isEmpty)
                         }
                         .themedRow()
                     } else {


### PR DESCRIPTION
Normalize folder paths on creation, assignment, and decoding. Reject separator-only folder names in the picker and recover existing malformed paths when profiles load.