### PR TITLE
Unify New Tab behavior and preserve profile connection counts

### DIFF
--- a/rootshell/App/AppCommands.swift
+++ b/rootshell/App/AppCommands.swift
@@ -123,7 +123,7 @@ struct FileCommands: Commands {
 
         // Replace system "New" items with our custom file commands
         CommandGroup(replacing: .newItem) {
-            Button("New Local Shell") {
+            Button("New Tab") {
                 UIApplication.shared.sendAction(
                     #selector(Ghostty.TerminalView.menuCreateLocalShell(_:)),
                     to: nil, from: nil, for: nil
@@ -131,7 +131,7 @@ struct FileCommands: Commands {
             }
             .modifier(DynamicShortcut(action: .new_local_shell, shortcuts: shortcutState.shortcuts))
 
-            Button("New Tab") {
+            Button("Open Connections") {
                 UIApplication.shared.sendAction(
                     #selector(Ghostty.TerminalView.menuNewTab(_:)),
                     to: nil, from: nil, for: nil
@@ -147,7 +147,7 @@ struct FileCommands: Commands {
             }
             .modifier(DynamicShortcut(action: .new_window, shortcuts: shortcutState.shortcuts))
 
-            Button("Duplicate SSH Tab") {
+            Button("Duplicate Focused Tab") {
                 UIApplication.shared.sendAction(
                     #selector(Ghostty.TerminalView.menuDuplicateTabWithSSH(_:)),
                     to: nil, from: nil, for: nil

--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -1061,14 +1061,14 @@ class CatalystAppDelegate: AppDelegate {
 
     private func buildFileMenu(_ builder: UIMenuBuilder) {
         let newLocalShell = UIKeyCommand(
-            title: String(localized: "New Local Shell"),
+            title: String(localized: "New Tab"),
             action: #selector(UIApplication.ghostty_newLocalShell(_:)),
             input: "t",
             modifierFlags: [.command]
         )
 
         let newTab = UIKeyCommand(
-            title: String(localized: "New Tab"),
+            title: String(localized: "Open Connections"),
             action: #selector(UIApplication.ghostty_newTab(_:)),
             input: "s",
             modifierFlags: [.command]
@@ -1082,7 +1082,7 @@ class CatalystAppDelegate: AppDelegate {
         )
 
         let duplicateSshTab = UIKeyCommand(
-            title: String(localized: "Duplicate SSH Tab"),
+            title: String(localized: "Duplicate Focused Tab"),
             action: #selector(UIApplication.ghostty_duplicateSshTab(_:)),
             input: "R",
             modifierFlags: [.command, .shift]

--- a/rootshell/Core/Keybinds/KeybindAction.swift
+++ b/rootshell/Core/Keybinds/KeybindAction.swift
@@ -84,15 +84,15 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     case start_search = "start_search"
 
     // Tab Management
-    /// Create new local shell tab
+    /// Global New Tab command (historical serialized identifier)
     case new_local_shell = "new_local_shell"
-    /// Create new tab (browse hosts)
+    /// Open Connections (historical serialized identifier)
     case new_tab = "new_tab"
     /// Create new window
     case new_window = "new_window"
     /// Close current tab/split
     case close_tab = "close_tab"
-    /// Duplicate current SSH connection in new tab
+    /// Duplicate the focused session in a new tab
     case duplicate_ssh_tab = "duplicate_ssh_tab"
     /// Switch to previous tab
     case previous_tab = "previous_tab"
@@ -345,11 +345,11 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .reset_font_size: return String(localized: "Reset Font Size", comment: "Keybind action")
         case .start_search: return String(localized: "Find", comment: "Keybind action: open search")
 
-        case .new_local_shell: return String(localized: "New Local Shell", comment: "Keybind action")
-        case .new_tab: return String(localized: "New Tab", comment: "Keybind action")
+        case .new_local_shell: return String(localized: "New Tab", comment: "Keybind action")
+        case .new_tab: return String(localized: "Open Connections", comment: "Keybind action")
         case .new_window: return String(localized: "New Window", comment: "Keybind action")
         case .close_tab: return String(localized: "Close Tab", comment: "Keybind action")
-        case .duplicate_ssh_tab: return String(localized: "Duplicate SSH Tab", comment: "Keybind action")
+        case .duplicate_ssh_tab: return String(localized: "Duplicate Focused Tab", comment: "Keybind action")
         case .previous_tab: return String(localized: "Previous Tab", comment: "Keybind action")
         case .next_tab: return String(localized: "Next Tab", comment: "Keybind action")
         case .show_tmux_sessions: return String(localized: "tmux Sessions", comment: "Keybind action")

--- a/rootshell/Core/SettingsSync/ConfigOverlay/ConfigOverlayManager.swift
+++ b/rootshell/Core/SettingsSync/ConfigOverlay/ConfigOverlayManager.swift
@@ -215,6 +215,8 @@ final class ConfigOverlayManager {
         var values: [String: CodableValue?] = [:]
         var bound: [String: BoundEntry] = [:]
         for configKey in order {
+            // The global spelling wins regardless of file order, including reset.
+            if configKey == "tmux-new-tab-action", grouped["new-tab-action"] != nil { continue }
             guard let item = grouped[configKey] else { continue }
             guard let def = registry.definition(forConfigKey: configKey) else {
                 diags.append(ConfigOverlayDiagnostic(severity: .info, file: item.entry.sourceFile, line: item.entry.lineNumber, key: configKey,

--- a/rootshell/Core/SettingsSync/Registry/Settings+Connections.swift
+++ b/rootshell/Core/SettingsSync/Registry/Settings+Connections.swift
@@ -11,7 +11,6 @@ extension ProfileSortOrder: SettingValue {}
 extension KeyAuthRequirement: SettingValue {}
 extension KeyStorageLevel: SettingValue {}
 extension TmuxAutoMode: SettingValue {}
-extension TmuxNewTabAction: SettingValue {}
 extension TmuxTabCloseAction: SettingValue {}
 extension SessionDiscoverySortOrder: SettingValue {}
 extension MoshConfig.PredictionMode: SettingValue {}
@@ -131,9 +130,6 @@ nonisolated extension Settings {
         static let tmuxDiscoveryAttachMode = SettingKey(
             "tmuxDiscoveryAttachMode", default: TmuxAutoMode.regular, group: .multiplexer, configKey: "tmux-discovery-attach-mode",
             title: String(localized: "tmux Attach Mode", comment: "Setting title"))
-        static let tmuxNewTabAction = SettingKey(
-            "tmuxNewTabAction", default: TmuxNewTabAction.localShell, group: .multiplexer, configKey: "tmux-new-tab-action",
-            title: String(localized: "tmux New Tab Action", comment: "Setting title"))
         static let tmuxTabCloseAction = SettingKey(
             "tmuxTabCloseAction", default: TmuxTabCloseAction.closeWindow, group: .multiplexer, configKey: "tmux-tab-close-action",
             title: String(localized: "tmux Close Tab Action", comment: "Setting title"))
@@ -177,7 +173,7 @@ nonisolated extension Settings {
 
         static let all: [AnySettingDefinition] = [
             tmuxSessionName.erased, tmuxCustomCommand.erased, tmuxSessionDiscovery.erased,
-            tmuxAutoHideGatewayOnAttach.erased, tmuxDiscoveryAttachMode.erased, tmuxNewTabAction.erased,
+            tmuxAutoHideGatewayOnAttach.erased, tmuxDiscoveryAttachMode.erased,
             tmuxTabCloseAction.erased, zellijSessionDiscovery.erased, herdrSessionName.erased,
             herdrCustomCommand.erased, herdrSessionDiscovery.erased,
             zmxSessionName.erased, zmxCustomCommand.erased, zmxSessionDiscovery.erased, localSessionDiscovery.erased,

--- a/rootshell/Core/SettingsSync/Registry/Settings+Tabs.swift
+++ b/rootshell/Core/SettingsSync/Registry/Settings+Tabs.swift
@@ -25,6 +25,7 @@ enum TabHoverPreviewActivation: String, CaseIterable, Sendable {
     }
 }
 
+extension NewTabAction: SettingValue {}
 extension TabHoverPreviewActivation: SettingValue {}
 extension TopTabStyle: SettingValue {}
 extension SplitFocusBorderStyle: SettingValue {}
@@ -34,6 +35,11 @@ extension PowerManager.BatteryRefreshRate: SettingValue {}
 
 nonisolated extension Settings {
     enum Tabs {
+        // Keep the persisted identity so sync records, per-key pins, and old
+        // preferences survive the move out of Multiplexers without migration.
+        static let newTabAction = SettingKey(
+            "tmuxNewTabAction", default: NewTabAction.localShell, group: .tabs, configKey: "new-tab-action",
+            title: String(localized: "New Tab Action", comment: "Setting title"))
         static let barHidden = SettingKey(
             "tabBarHidden", default: false, group: .tabs, configKey: "tab-bar-hidden",
             title: String(localized: "Show Top Tab Bar", comment: "Setting title"))
@@ -75,7 +81,7 @@ nonisolated extension Settings {
             title: String(localized: "Tab Hover Preview Size", comment: "Setting title"))
 
         static let all: [AnySettingDefinition] = [
-            barHidden.erased, barAnimationsDisabled.erased, topTabStyle.erased, compactPillSpacing.erased,
+            newTabAction.erased, barHidden.erased, barAnimationsDisabled.erased, topTabStyle.erased, compactPillSpacing.erased,
             showScopeMenu.erased, showShortcutIndicators.erased, exposeShowsCaptions.erased, exposeZoom.erased,
             hoverPreviews.erased, hoverPreviewActivation.erased, hoverPreviewZoom.erased,
         ]

--- a/rootshell/Core/SettingsSync/Registry/SettingsRegistry.swift
+++ b/rootshell/Core/SettingsSync/Registry/SettingsRegistry.swift
@@ -60,7 +60,7 @@ nonisolated final class SettingsRegistry: Sendable {
 
     /// Lookup by text-config name (`font-size`, `tab-bar-hidden`).
     func definition(forConfigKey configKey: String) -> AnySettingDefinition? {
-        byConfigKey[configKey]
+        byConfigKey[configKey == "tmux-new-tab-action" ? "new-tab-action" : configKey]
     }
 
     /// Keys the text config overlay can carry, ordered by group then name.

--- a/rootshell/Features/Tmux/Settings/MultiplexerSettingsView.swift
+++ b/rootshell/Features/Tmux/Settings/MultiplexerSettingsView.swift
@@ -9,7 +9,6 @@ struct MultiplexerSettingsView: View {
     @Setting(Settings.Multiplexer.zmxSessionName) private var zmxSessionName
     @Setting(Settings.Multiplexer.zmxCustomCommand) private var zmxCustomCommand
     @Setting(Settings.Multiplexer.tmuxTabCloseAction) private var tabCloseAction
-    @Setting(Settings.Multiplexer.tmuxNewTabAction) private var newTabAction
 
     private var hasCustomCommand: Bool {
         !customCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -116,26 +115,18 @@ struct MultiplexerSettingsView: View {
                 }
                 .themedRow()
                 .settingContextMenu(Settings.Multiplexer.tmuxTabCloseAction)
-
-                NavigationLink {
-                    TmuxNewTabActionPickerView()
-                } label: {
-                    HStack(spacing: 12) {
-                        SettingsIcon(systemName: "plus.rectangle.on.rectangle")
-                        Text("New Tab Action")
-                        SettingPinTag(Settings.Multiplexer.tmuxNewTabAction.erased)
-                        Spacer()
-                        Text(newTabAction.displayName)
-                            .foregroundColor(.secondary)
-                            .font(.subheadline)
-                    }
-                }
-                .themedRow()
-                .settingContextMenu(Settings.Multiplexer.tmuxNewTabAction)
             } header: {
                 SettingGroupHeader("tmux Control Mode", group: .multiplexer)
             } footer: {
                 Text("These settings apply while attached with tmux -CC control mode, where each tmux window is its own tab.")
+            }
+
+            Section {
+                NewTabActionSettingsRow()
+            } header: {
+                Text("New Tabs")
+            } footer: {
+                Text("New Tab Action applies globally, including outside multiplexer sessions. The tab-bar + always opens Connections.")
             }
 
             Section {
@@ -262,16 +253,14 @@ struct TmuxTabCloseActionPickerView: View {
     }
 }
 
-/// Pushed list for choosing what ⌘T does while attached to a tmux -CC session.
-/// Same layout as the close-action picker: per-option icon + description.
-/// (id=tmux-new-tab-action)
-struct TmuxNewTabActionPickerView: View {
-    @Setting(Settings.Multiplexer.tmuxNewTabAction) private var newTabAction
+/// Global New Tab behavior, shared by Terminal and Multiplexer settings.
+struct NewTabActionPickerView: View {
+    @Setting(Settings.Tabs.newTabAction) private var newTabAction
 
     var body: some View {
         List {
             Section {
-                ForEach(TmuxNewTabAction.allCases, id: \.rawValue) { action in
+                ForEach(NewTabAction.allCases, id: \.rawValue) { action in
                     Button {
                         newTabAction = action
                     } label: {
@@ -300,12 +289,35 @@ struct TmuxNewTabActionPickerView: View {
                     .themedRow()
                 }
             } footer: {
-                Text("Controls what ⌘T does while attached to a tmux -CC session. Outside tmux it always opens a local shell.")
+                Text("Controls the New Tab command (⌘T by default, or your custom shortcut) in every session. The tab-bar + always opens Connections.")
             }
         }
         .themedList()
         .navigationTitle("New Tab Action")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar { SettingsScreenPinMenu(groups: [.multiplexer]) }
+        .toolbar { SettingsScreenPinMenu(groups: [.tabs]) }
+    }
+}
+
+/// Both settings locations edit the same registered preference.
+struct NewTabActionSettingsRow: View {
+    @Setting(Settings.Tabs.newTabAction) private var action
+
+    var body: some View {
+        NavigationLink {
+            NewTabActionPickerView()
+        } label: {
+            HStack(spacing: 12) {
+                SettingsIcon(systemName: "plus.rectangle.on.rectangle")
+                Text("New Tab Action")
+                SettingPinTag(Settings.Tabs.newTabAction.erased)
+                Spacer()
+                Text(action.displayName)
+                    .foregroundColor(.secondary)
+                    .font(.subheadline)
+            }
+        }
+        .themedRow()
+        .settingContextMenu(Settings.Tabs.newTabAction)
     }
 }

--- a/rootshell/Features/Tmux/TmuxNewTabAction.swift
+++ b/rootshell/Features/Tmux/TmuxNewTabAction.swift
@@ -1,60 +1,51 @@
-//
-//  TmuxNewTabAction.swift
-//  rootshell
-//
-//  What ⌘T (the "new local shell" command) does WHILE attached to a tmux
-//  control-mode (-CC) session. Outside tmux, ⌘T always opens a local shell;
-//  this setting only changes behavior when the selected tab is a live tmux
-//  context. Global preference, surfaced in Settings → Connections →
-//  Multiplexers. Default preserves the historical behavior (local shell).
-//  (id=tmux-new-tab-action)
-//
-
+// Global New Tab preference. The file retains its historical location to
+// preserve project source membership.
 import Foundation
 
-enum TmuxNewTabAction: String, CaseIterable, Codable, Sendable {
-    /// Always open a local shell tab, even inside a tmux session. Default —
-    /// the only behavior before this setting existed.
+nonisolated enum NewTabAction: String, CaseIterable, Codable, Sendable {
     case localShell
-
-    /// While attached to a tmux session, open a new window in that session
-    /// (the equivalent of "New tmux Tab") instead of a local shell.
-    case tmuxTab
-
-    /// While attached to a tmux session, prompt: local shell vs new tmux window.
+    // The synced key is shared with older apps, which only understand tmuxTab.
+    case duplicateFocused = "tmuxTab"
     case ask
 
-    static let storageKey = "tmuxNewTabAction"
+    // Also accept the transitional spelling written by early global-setting
+    // versions; rawValue/Codable/SettingValue always encode the legacy spelling.
+    init?(rawValue: String) {
+        switch rawValue {
+        case "localShell": self = .localShell
+        case "duplicateFocused", "tmuxTab": self = .duplicateFocused
+        case "ask": self = .ask
+        default: return nil
+        }
+    }
 
-    /// The user's current preference, defaulting to `.localShell`.
-    static var current: TmuxNewTabAction {
-        SettingsStore.shared.value(Settings.Multiplexer.tmuxNewTabAction)
+    static var current: NewTabAction {
+        SettingsStore.shared.value(Settings.Tabs.newTabAction)
     }
 
     var displayName: String {
         switch self {
-        case .localShell: return "Local Shell"
-        case .tmuxTab: return "New tmux Tab"
-        case .ask: return "Ask Each Time"
+        case .localShell: return String(localized: "Local Shell")
+        case .duplicateFocused: return String(localized: "Duplicate Focused")
+        case .ask: return String(localized: "Ask Each Time")
         }
     }
 
-    /// Longer explanation shown beneath the title in the picker list.
     var detail: String {
         switch self {
         case .localShell:
-            return "Open a local shell tab, even while attached to a tmux session."
-        case .tmuxTab:
-            return "While attached to a tmux session, open a new window in that session instead of a local shell."
+            return String(localized: "Open a new local shell tab.")
+        case .duplicateFocused:
+            return String(localized: "Open another session matching the focused pane, or a new window in its tmux control-mode session.")
         case .ask:
-            return "While attached to a tmux session, ask whether to open a local shell or a new tmux window."
+            return String(localized: "Choose a local shell, duplicate the focused session, or open Connections each time.")
         }
     }
 
     var iconName: String {
         switch self {
         case .localShell: return "terminal"
-        case .tmuxTab: return "plus.rectangle.on.rectangle"
+        case .duplicateFocused: return "plus.rectangle.on.rectangle"
         case .ask: return "questionmark.circle"
         }
     }

--- a/rootshell/UI/Settings/SettingsSections.swift
+++ b/rootshell/UI/Settings/SettingsSections.swift
@@ -441,6 +441,8 @@ struct SettingsTerminalSection: View {
                 #endif
                 #endif
 
+                NewTabActionSettingsRow()
+
                 NavigationLink {
                     KeyboardShortcutsSettingsView()
                 } label: {

--- a/rootshell/UI/Shell/EmptyStateResponder.swift
+++ b/rootshell/UI/Shell/EmptyStateResponder.swift
@@ -65,12 +65,12 @@ final class EmptyStateView: UIView {
 
     override var keyCommands: [UIKeyCommand]? {
         // Built from the user's live bindings so remaps are honored (defaults:
-        // Cmd+T new local shell, Cmd+S new tab, Cmd+N new window).
+        // Cmd+T New Tab, Cmd+S Open Connections, Cmd+N New Window).
         let manager = KeybindManager.shared
         return [
             manager.keyCommand(for: .new_local_shell, selector: #selector(handleNewLocalShell),
-                               title: "New Local Shell", wantsPriority: true),
-            manager.keyCommand(for: .new_tab, selector: #selector(handleNewTab), title: "New Tab"),
+                               title: "New Tab", wantsPriority: true),
+            manager.keyCommand(for: .new_tab, selector: #selector(handleNewTab), title: "Open Connections"),
             manager.keyCommand(for: .new_window, selector: #selector(handleNewWindow), title: "New Window"),
         ].compactMap { $0 }
     }

--- a/rootshell/UI/Shell/MainView+Body.swift
+++ b/rootshell/UI/Shell/MainView+Body.swift
@@ -158,7 +158,7 @@ extension MainView {
             TabStyleContextMenuRegion(
                 selectedStyleRawValue: topTabStyleRawValueBinding,
                 primaryAction: addNewTab,
-                accessibilityLabel: String(localized: "New Tab")
+                accessibilityLabel: String(localized: "Open Connections")
             )
         }
         .overlay(alignment: .leading) {

--- a/rootshell/UI/Shell/MainView+ChangeHandlers.swift
+++ b/rootshell/UI/Shell/MainView+ChangeHandlers.swift
@@ -86,6 +86,11 @@ extension MainView {
                 }
                 handleTerminalCountChange(oldCount: oldCount, newCount: newCount)
             }
+            // Splitting or closing a pane need not change the number of tabs.
+            // Keep profile badges current for those topology changes as well.
+            .onChange(of: WindowSessionCensus.profileCounts(in: terminals)) { _, _ in
+                notifySessionCountChanged()
+            }
             .onChange(of: selectedTabIndex) { oldValue, newValue in
                 handleSelectedTabChange(oldValue: oldValue, newValue: newValue)
             }

--- a/rootshell/UI/Shell/MainView+ConnectionSheet.swift
+++ b/rootshell/UI/Shell/MainView+ConnectionSheet.swift
@@ -110,9 +110,9 @@ extension MainView {
     private func handleSSHOrLocalConnection(config: SSHConfig?, splitOption: SSHConnectionView.SplitOption) {
         if let config = config {
             // SSH connection
-            if let tabIndex = reconnectingTabIndex {
-                // Reconnecting existing tab
-                reconnectTab(at: tabIndex, with: config)
+            if let request = authenticationRetryRequest {
+                // Resolve the failing pane, never the current selection/index.
+                reconnectTerminal(for: request, with: config)
             } else {
                 // Creating new connection - check split option
                 switch splitOption {
@@ -136,7 +136,7 @@ extension MainView {
             }
         }
         // Clear reconnection state
-        reconnectingTabIndex = nil
+        authenticationRetryRequest = nil
         reconnectConfig = nil
     }
 

--- a/rootshell/UI/Shell/MainView+EventHandlers.swift
+++ b/rootshell/UI/Shell/MainView+EventHandlers.swift
@@ -551,6 +551,10 @@ extension MainView {
         // Ghostty focus was already set when the tab was created
         if oldValue == true && newValue == false {
             pendingBrowseSelection = nil  // Clear browse selection on dismissal
+            if authenticationRetryRequest != nil {
+                authenticationRetryRequest = nil
+                reconnectConfig = nil
+            }
 
             // Safety net: if no terminals exist and the tab bar is hidden,
             // re-show the sheet immediately. Without this, the user lands on an

--- a/rootshell/UI/Shell/MainView+Notifications.swift
+++ b/rootshell/UI/Shell/MainView+Notifications.swift
@@ -378,8 +378,7 @@ extension MainView {
         observerBag.observeOnMainActor(.createLocalShell) { [self] notification in
             // Handle both UIKeyCommand (with terminal) and SwiftUI Commands (nil object)
             guard self.shouldHandleNotification(notification) else { return }
-            // Default: new local-shell tab. In a tmux -CC context the configured
-            // New Tab Action may open a tmux window or prompt. (id=tmux-new-tab-action)
+            // The legacy notification now dispatches the global New Tab action.
             self.handleNewTabCommand()
         }
 

--- a/rootshell/UI/Shell/MainView+Persistence.swift
+++ b/rootshell/UI/Shell/MainView+Persistence.swift
@@ -512,8 +512,8 @@ extension MainView {
             if connectionConfig.requiresSSHCallbacks {
                 let restoredTerminal = terminalView
                 terminalView.onAuthenticationRequired = { @MainActor @Sendable [weak restoredTerminal] config in
-                    if let index = self.terminals.firstIndex(where: { $0.splitTree.contains { $0 === restoredTerminal } }) {
-                        self.handleAuthenticationRequired(for: index, config: config)
+                    if let restoredTerminal {
+                        self.handleAuthenticationRequired(for: restoredTerminal, config: config)
                     }
                 }
                 terminalView.onHostKeyValidationRequired = { @MainActor @Sendable request, validatedTerminal in

--- a/rootshell/UI/Shell/MainView+Presentation.swift
+++ b/rootshell/UI/Shell/MainView+Presentation.swift
@@ -64,6 +64,8 @@ extension MainView {
                 (UIDevice.current.userInterfaceIdiom == .phone || clipboardManagerKeyboardMode)) ||
             connectionInfoToShow != nil ||
             tmuxDashboardRequest != nil ||
+            pendingNewTabRequest != nil ||
+            unavailableNewTabRequest != nil ||
             trzszTransferOriginRequest != nil ||
             trzszTransferIncomingOffer != nil
         #if !CHINA_BUILD
@@ -192,22 +194,54 @@ extension MainView {
             } message: {
                 Text("Choose what to do with this tmux control-mode tab.")
             }
-            // "Ask Each Time" tmux new-tab (⌘T) action sheet. (id=tmux-new-tab-action)
             .confirmationDialog(
                 "New Tab",
                 isPresented: Binding(
-                    get: { pendingTmuxNewTabTabID != nil },
-                    set: { if !$0 { pendingTmuxNewTabTabID = nil } }
+                    get: { pendingNewTabRequest != nil },
+                    set: { if !$0 { pendingNewTabRequest = nil } }
                 ),
-                titleVisibility: .visible
-            ) {
-                Button("Local Shell") { runPendingTmuxNewTab(local: true) }
-                    .keyboardShortcut(.defaultAction)
-                Button("New tmux Tab") { runPendingTmuxNewTab(local: false) }
-                Button("Cancel", role: .cancel) { pendingTmuxNewTabTabID = nil }
+                titleVisibility: .visible,
+                presenting: pendingNewTabRequest
+            ) { request in
+                Button("Local Shell") {
+                    pendingNewTabRequest = nil
+                    createLocalShellTab(for: request)
+                }
+                .keyboardShortcut(.defaultAction)
+                if let title = request.duplicateTitle {
+                    Button(title) {
+                        pendingNewTabRequest = nil
+                        runNewTabDuplicate(request)
+                    }
+                }
+                Button("Open Connections") {
+                    pendingNewTabRequest = nil
+                    addNewTab()
+                }
+                Button("Cancel", role: .cancel) { pendingNewTabRequest = nil }
                     .keyboardShortcut(.cancelAction)
-            } message: {
-                Text("Open a new local shell tab, or a new tmux window in the current session.")
+            } message: { _ in
+                Text("Choose what to open in a new tab.")
+            }
+            .alert(
+                "Session Unavailable",
+                isPresented: Binding(
+                    get: { unavailableNewTabRequest != nil },
+                    set: { if !$0 { unavailableNewTabRequest = nil } }
+                ),
+                presenting: unavailableNewTabRequest
+            ) { request in
+                Button("Local Shell") {
+                    unavailableNewTabRequest = nil
+                    createLocalShellTab(for: request)
+                }
+                Button("Open Connections") {
+                    unavailableNewTabRequest = nil
+                    addNewTab()
+                }
+                Button("Cancel", role: .cancel) { unavailableNewTabRequest = nil }
+            } message: { _ in
+                Text("The original tmux session is no longer available. Open a local shell or choose another connection.")
             }
             .sheet(item: $tmuxDashboardRequest) { request in
                 TmuxSessionDashboardView(controller: request.controller)

--- a/rootshell/UI/Shell/MainView+SSHValidation.swift
+++ b/rootshell/UI/Shell/MainView+SSHValidation.swift
@@ -19,9 +19,8 @@ extension MainView {
     func wireWindowScopedCallbacks(on terminalView: Ghostty.TerminalView) {
         let trackedTerminal = terminalView
         terminalView.onAuthenticationRequired = { @MainActor @Sendable [weak trackedTerminal] config in
-            if let trackedTerminal,
-               let index = self.terminals.firstIndex(where: { $0.splitTree.contains { $0 === trackedTerminal } }) {
-                self.handleAuthenticationRequired(for: index, config: config)
+            if let trackedTerminal {
+                self.handleAuthenticationRequired(for: trackedTerminal, config: config)
             }
         }
         terminalView.onHostKeyValidationRequired = { @MainActor @Sendable request, validatedTerminal in

--- a/rootshell/UI/Shell/MainView+Splits.swift
+++ b/rootshell/UI/Shell/MainView+Splits.swift
@@ -95,6 +95,10 @@ extension MainView {
 
     func createSplit(direction: SplitTree<SplitPaneView>.NewDirection) {
         guard terminals.indices.contains(selectedTabIndex) else { return }
+        if let vnc = terminals[selectedTabIndex].focusedPane as? VNCPaneView {
+            createVNCSplit(with: vnc.config, direction: direction, sourceProfileID: vnc.sourceProfileID)
+            return
+        }
         guard let focusedTerminal = terminals[selectedTabIndex].focusedTerminal else { return }
 
         // tmux control mode: the tmux server owns this window's topology. Ask it
@@ -121,6 +125,13 @@ extension MainView {
             connectionConfig: connectionConfig,
             windowId: windowId
         )
+        // An independent split belongs to the same originating profile.
+        // A not-yet-consumed transfer falls back to local and has no provenance.
+        if case .trzszTransfer = focusedTerminal.connectionConfig {
+            newTerminalView.sourceProfileID = nil
+        } else {
+            newTerminalView.sourceProfileID = focusedTerminal.sourceProfileID
+        }
         newTerminalView.setWindowActive(isWindowFocused)
         newTerminalView.onAgentApprovalRequired = { @MainActor @Sendable request in
             handleAgentApprovalRequest(request)
@@ -131,8 +142,8 @@ extension MainView {
         if connectionConfig.requiresSSHCallbacks {
             let sshSplitTerminal = newTerminalView
             newTerminalView.onAuthenticationRequired = { @MainActor @Sendable [weak sshSplitTerminal] config in
-                if let index = terminals.firstIndex(where: { $0.splitTree.contains { $0 === sshSplitTerminal } }) {
-                    handleAuthenticationRequired(for: index, config: config)
+                if let sshSplitTerminal {
+                    handleAuthenticationRequired(for: sshSplitTerminal, config: config)
                 }
             }
             newTerminalView.onHostKeyValidationRequired = { @MainActor @Sendable request, validatedTerminal in

--- a/rootshell/UI/Shell/MainView+TabManagement.swift
+++ b/rootshell/UI/Shell/MainView+TabManagement.swift
@@ -377,45 +377,111 @@ extension MainView {
 #endif
     }
 
-    /// ⌘T / "New Local Shell" entry point. Outside tmux this always opens a
-    /// local shell (the default). When the selected tab is a live tmux -CC
-    /// context, the user-configured New Tab Action decides: local shell, a new
-    /// tmux window, or a prompt. (id=tmux-new-tab-action)
+    /// Global New Tab command; the legacy shortcut identifier remains stable.
     @MainActor
     func handleNewTabCommand() {
-        guard terminals.indices.contains(selectedTabIndex),
-              let controller = tmuxControllerForTab(terminals[selectedTabIndex]),
-              controller.isActive else {
-            createLocalShellTab()
-            return
-        }
-        switch TmuxNewTabAction.current {
+        guard pendingNewTabRequest == nil, unavailableNewTabRequest == nil else { return }
+        let request = captureNewTabRequest()
+        switch NewTabAction.current {
         case .localShell:
-            createLocalShellTab()
-        case .tmuxTab:
-            requestTmuxNewWindow(for: terminals[selectedTabIndex])
+            createLocalShellTab(for: request)
+        case .duplicateFocused:
+            runNewTabDuplicate(request)
         case .ask:
-            pendingTmuxNewTabTabID = terminals[selectedTabIndex].id
+            pendingNewTabRequest = request
         }
     }
 
-    /// Resolve the tab captured by the "Ask Each Time" new-tab sheet and act.
-    /// Re-resolves by id (the tab array may have shifted); falls back to a local
-    /// shell if the tmux context is gone. (id=tmux-new-tab-action)
-    @MainActor
-    func runPendingTmuxNewTab(local: Bool) {
-        defer { pendingTmuxNewTabTabID = nil }
-        if local {
-            createLocalShellTab()
-            return
+    func captureNewTabRequest() -> NewTabRequest {
+        guard terminals.indices.contains(selectedTabIndex),
+              let pane = terminals[selectedTabIndex].focusedPane else {
+            return NewTabRequest(target: .local, localDirectory: nil)
         }
-        guard let id = pendingTmuxNewTabTabID,
-              let tab = terminals.first(where: { $0.id == id }),
-              let controller = tmuxControllerForTab(tab), controller.isActive else {
-            createLocalShellTab()
-            return
+        if let vnc = pane as? VNCPaneView {
+            return NewTabRequest(target: .connection(.vnc(vnc.config), vnc.sourceProfileID), localDirectory: nil)
         }
-        requestTmuxNewWindow(for: tab)
+        guard let terminal = pane.asTerminal else {
+            return NewTabRequest(target: .connections, localDirectory: nil)
+        }
+        if let controller = newTabTmuxController(for: terminal), controller.isActive {
+            return NewTabRequest(target: .tmux(terminal.uuid, controller), localDirectory: nil)
+        }
+        switch terminal.connectionConfig {
+        case .local:
+            // A stale tmux surface is not a real local shell.
+            return NewTabRequest(target: terminal.isTmuxPane ? .connections : .local,
+                                 localDirectory: terminal.isTmuxPane ? nil : terminal.pwd)
+        case .trzszTransfer:
+            return NewTabRequest(target: .connections, localDirectory: nil)
+        default:
+            return NewTabRequest(target: .connection(terminal.connectionConfig, terminal.sourceProfileID), localDirectory: nil)
+        }
+    }
+
+    private func newTabTmuxController(for terminal: Ghostty.TerminalView) -> TmuxController? {
+        if let binding = terminal.tmuxPaneBinding {
+            return TmuxController.controller(forOwnerSurface: binding.parentSurface)
+        }
+        return terminal.tmuxController
+    }
+
+    private func requestNewTmuxWindow(on terminal: Ghostty.TerminalView, ownedBy controller: TmuxController) -> Bool {
+        guard controller.isActive, newTabTmuxController(for: terminal) === controller else { return false }
+        if terminal.isTmuxPane {
+            terminal.requestTmuxNewWindow()
+            return true
+        }
+        return terminal.requestTmuxNewWindowFromGateway()
+    }
+
+    func createLocalShellTab(for request: NewTabRequest) {
+        performLocalShellAction(description: "open a local shell tab") {
+            self.openTerminalTab(config: .local(workingDirectory: request.localDirectory),
+                                 title: String(localized: "Local Shell"), suppressesTabBarAnimation: true)
+        }
+    }
+
+    func runNewTabDuplicate(_ request: NewTabRequest) {
+        switch request.target {
+        case .local:
+            createLocalShellTab(for: request)
+        case .connections:
+            addNewTab()
+        case .tmux(let terminalID, let controller):
+            guard controller.isActive else {
+                unavailableNewTabRequest = request
+                return
+            }
+            let panes = terminals.flatMap { $0.splitTree.terminalLeaves }
+            // Prefer the captured pane to preserve insertion position. If tmux
+            // removed it, the captured session can still create a new window.
+            if let original = panes.first(where: { $0.uuid == terminalID }),
+               requestNewTmuxWindow(on: original, ownedBy: controller) { return }
+            if let gateway = TmuxWindowRegistry.gatewayView(ownerTerminalUUID: controller.ownerTerminalUUIDForNotifications),
+               requestNewTmuxWindow(on: gateway, ownedBy: controller) { return }
+            for pane in panes where pane.uuid != terminalID {
+                if requestNewTmuxWindow(on: pane, ownedBy: controller) { return }
+            }
+            unavailableNewTabRequest = request
+        case .connection(let original, let profileID):
+            // Never reuse roam/cloud session IDs. Keep the effective config and
+            // profile provenance rather than re-reading an edited saved profile.
+            let config = original.forNewSplit()
+            switch config {
+            case .vnc(let vnc):
+                createVNCTab(with: vnc, sourceProfileID: profileID)
+            case .mosh(let mosh), .shellLaunchedMosh(let mosh, _):
+                createMoshTab(with: mosh, sourceProfileID: profileID)
+            case .trzsz(let trzsz), .shellLaunchedTrzsz(let trzsz, _):
+                createTrzszTab(with: trzsz, sourceProfileID: profileID)
+            case .ssh(let ssh), .shellLaunchedSSH(let ssh, _):
+                createSSHTab(with: ssh, sourceProfileID: profileID)
+            case .trzszTransfer:
+                addNewTab()
+            default:
+                openTerminalTab(config: config, title: config.displayName, sourceProfileID: profileID)
+            }
+        }
     }
 
     func createLocalShellTab() {
@@ -587,43 +653,7 @@ extension MainView {
 extension MainView {
 
     func duplicateCurrentTabWithSSH() {
-        guard terminals.indices.contains(selectedTabIndex) else { return }
-        guard let focusedTerminal = terminals[selectedTabIndex].focusedTerminal else {
-            showConnectionSidebar = true
-            return
-        }
-
-        // tmux control mode: open a new tmux window on the same gateway, matching the
-        // "New tmux Tab" menu. A window-tab pane carries a pane binding; the gateway
-        // tab (running tmux -CC) does not, so route it through its own controller.
-        if focusedTerminal.isTmuxPane {
-            focusedTerminal.requestTmuxNewWindow()
-            return
-        }
-        if focusedTerminal.requestTmuxNewWindowFromGateway() {
-            return
-        }
-
-        // Check for Mosh connection first (Mosh contains SSH config internally)
-        if let moshConfig = focusedTerminal.connectionConfig.moshConfig {
-            createMoshTab(with: moshConfig)
-            return
-        }
-
-        // Check for trzsz connection (trzsz contains SSH config internally)
-        if let trzszConfig = focusedTerminal.connectionConfig.trzszConfig {
-            createTrzszTab(with: trzszConfig)
-            return
-        }
-
-        // Then check for SSH connection
-        if let sshConfig = focusedTerminal.connectionConfig.sshConfig {
-            createSSHTab(with: sshConfig)
-            return
-        }
-
-        // Current focused terminal doesn't have SSH/Mosh config, show connection sheet
-        showConnectionSidebar = true
+        runNewTabDuplicate(captureNewTabRequest())
     }
 }
 
@@ -993,30 +1023,89 @@ extension MainView {
 
 extension MainView {
 
-    func handleAuthenticationRequired(for index: Int, config: SSHConfig) {
-        // Set reconnection state and show connection sheet
-        reconnectingTabIndex = index
+    func handleAuthenticationRequired(for terminal: Ghostty.TerminalView, config: SSHConfig) {
+        guard terminals.contains(where: { $0.splitTree.contains { $0 === terminal } }),
+              authenticationRetryRequest == nil else { return }
+        // Snapshot the failing pane before focus, topology, or profile changes.
+        // A second callback must not retarget the picker already on screen.
+        authenticationRetryRequest = SSHAuthenticationRetryRequest(
+            terminalID: terminal.uuid, sourceProfileID: terminal.sourceProfileID, config: config)
         reconnectConfig = config
         showConnectionSidebar = true
     }
 
-    func reconnectTab(at index: Int, with config: SSHConfig) {
-        guard index < terminals.count, let app = ghosttyApp.app else { return }
+    func reconnectTerminal(for request: SSHAuthenticationRetryRequest, with config: SSHConfig) {
+        guard let index = terminals.firstIndex(where: { tab in
+            tab.splitTree.terminalLeaves.contains { $0.uuid == request.terminalID }
+        }), let previous = terminals[index].splitTree.terminalLeaves.first(where: { $0.uuid == request.terminalID }),
+              let app = ghosttyApp.app else {
+            Ghostty.logger.info("Authentication retry source is no longer in this window")
+            return
+        }
 
-        let terminalView = makeConnectedTerminalView(app: app, config: .ssh(config))
-
-        // Create a new tab with updated config and window ID
-        let updatedTab = TerminalTab(terminalView: terminalView, title: config.displayName, windowId: windowId)
-        terminalView.containingTabID = updatedTab.id
-
-        // Replace the old tab
-        terminals[index] = updatedTab
-
-        // Set up title observation to sync terminal title changes to tab title
-        setupTitleObservation(at: index)
-
-        // Make sure this tab is selected
+        // Preserve captured provenance for credential edits, but not when the
+        // user chooses a different endpoint in the connection picker.
+        let sourceProfileID = request.config.host == config.host &&
+            request.config.port == config.port && request.config.username == config.username
+            ? request.sourceProfileID : nil
+        let terminalView = makeConnectedTerminalView(app: app, config: .ssh(config), sourceProfileID: sourceProfileID)
+        let tab = terminals[index]
+        terminalView.containingTabID = tab.id
+        do {
+            tab.splitTree = try tab.splitTree.replace(node: .leaf(view: previous), with: .leaf(view: terminalView))
+        } catch {
+            terminalView.prepareForClose()
+            Ghostty.logger.error("Cannot replace authentication retry pane: \(error)")
+            return
+        }
+        if previous.isFirstResponder { previous.resignFirstResponder() }
+        previous.isLogicallyFocused = false
+        withdrawKeyboardInteractive(for: previous)
+        previous.prepareForClose()
         selectedTabIndex = index
         setFocusedTerminal(terminalView, inTab: index)
+        setupTitleObservation(at: index)
+        notifySessionCountChanged()
+    }
+}
+
+/// Stable authentication retry context; tab indexes and focus are transient.
+struct SSHAuthenticationRetryRequest {
+    let terminalID: UUID
+    let sourceProfileID: UUID?
+    let config: SSHConfig
+}
+
+/// Snapshot taken before showing the chooser so a later focus change cannot
+/// silently select a different host or tmux session.
+struct NewTabRequest {
+    enum Target {
+        case local
+        case connection(ConnectionConfig, UUID?)
+        case tmux(UUID, TmuxController)
+        case connections
+    }
+
+    let target: Target
+    let localDirectory: String?
+
+    var duplicateTitle: String? {
+        switch target {
+        case .local, .connections: return nil
+        case .tmux: return String(localized: "New tmux Window")
+        case .connection(let config, _):
+            // Roaming transports decorate displayName with "roam". Use the
+            // connection's own name here without removing user-authored text.
+            let name: String
+            switch config {
+            case .mosh(let mosh), .shellLaunchedMosh(let mosh, _):
+                name = mosh.sshConfig.displayName
+            case .trzsz(let trzsz), .shellLaunchedTrzsz(let trzsz, _):
+                name = trzsz.sshConfig.displayName
+            default:
+                name = config.displayName
+            }
+            return String(localized: "Duplicate “\(name)”")
+        }
     }
 }

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -136,10 +136,9 @@ struct MainView: View {
     /// "Ask Each Time" tmux tab-close: the tab whose ⌘W/✕ is awaiting the
     /// user's choice in the close action sheet. (id=tmux-tab-close-action)
     @State var pendingTmuxCloseTabID: UUID?
-    /// "Ask Each Time" tmux new-tab (⌘T): the tmux tab whose new-tab choice is
-    /// awaiting the user (local shell vs new tmux window). (id=tmux-new-tab-action)
-    @State var pendingTmuxNewTabTabID: UUID?
-    @State var reconnectingTabIndex: Int?
+    @State var pendingNewTabRequest: NewTabRequest?
+    @State var unavailableNewTabRequest: NewTabRequest?
+    @State var authenticationRetryRequest: SSHAuthenticationRetryRequest?
     @State var reconnectConfig: SSHConfig?
     /// Source-compat shim around `tabsModel.draggingTabID`.
     var draggingTab: TerminalTab? {
@@ -510,7 +509,7 @@ struct MainView: View {
                         // Empty state - shown when all tabs are closed
                         EmptyStateResponder(
                             onNewTab: addNewTab,
-                            onNewLocalShell: createLocalShellTab
+                            onNewLocalShell: handleNewTabCommand
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else if ghosttyApp.readiness == .ready, terminals.isEmpty {

--- a/rootshell/UI/Sidebar/WindowSessionCensus.swift
+++ b/rootshell/UI/Sidebar/WindowSessionCensus.swift
@@ -55,6 +55,28 @@ enum WindowSessionCensus {
         }.count
     }
 
+    /// Independent profile-associated connections, not tmux display panes.
+    static func profileCounts(in tabs: [TabModel]) -> [UUID: Int] {
+        var profileCounts: [UUID: Int] = [:]
+
+        // Count independent pane owners, including VNC. Hidden gateways remain
+        // in tabs; their tmux display panes share the connection and add nothing.
+        var countedPaneIDs: Set<UUID> = []
+        for pane in tabs.flatMap({ Array($0.splitTree) }) where countedPaneIDs.insert(pane.uuid).inserted {
+            let profileID: UUID?
+            if let terminal = pane.asTerminal {
+                profileID = terminal.isTmuxPane ? nil : terminal.sourceProfileID
+            } else {
+                profileID = (pane as? VNCPaneView)?.sourceProfileID
+            }
+            if let profileID {
+                profileCounts[profileID, default: 0] += 1
+            }
+        }
+
+        return profileCounts
+    }
+
     /// Gather per-type counts and host names for all session types
     static func details(in tabs: [TabModel]) -> Details {
         var sshCount = 0
@@ -64,13 +86,9 @@ enum WindowSessionCensus {
         var localTaskCount = 0
         var roamCount = 0
         var roamHostNames: [String] = []
-        var profileCounts: [UUID: Int] = [:]
+        let profileCounts = Self.profileCounts(in: tabs)
 
         for terminal in tabs.flatMap({ $0.splitTree.terminalLeaves }) {
-            if let profileID = terminal.sourceProfileID {
-                profileCounts[profileID, default: 0] += 1
-            }
-
             switch terminal.connectionConfig {
             case .ssh(let config):
                 sshCount += 1


### PR DESCRIPTION
Add a global New Tab preference with Local Shell as the default, Duplicate Focused, and Ask Each Time. Share it across Terminal and Multiplexer settings while keeping the tab-bar + opening Connections.