### PR TITLE
Add local shell profiles and per-profile theme overrides

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6106,6 +6106,9 @@
         }
       }
     },
+    "%@ (Unavailable)" : {
+
+    },
     "%@ / %@" : {
       "localizations" : {
         "ar" : {
@@ -53965,6 +53968,9 @@
         }
       }
     },
+    "All Devices" : {
+
+    },
     "All Exposed Keys" : {
       "comment" : "Local SSH agent client rule all keys toggle",
       "localizations" : {
@@ -57982,7 +57988,7 @@
       }
     },
     "Always" : {
-      "comment" : "Always On Display duration: never auto-lock\nCert validity: no start bound\nHole-punch mode: always perform\nLocation Diary authorization status\nPrediction mode: always show predictions\nShader animation: always\nTab hover preview activation",
+      "comment" : "Cert validity: no start bound\nHole-punch mode: always perform\nLocation Diary authorization status\nPrediction mode: always show predictions\nShader animation: always\nTab hover preview activation",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -65393,6 +65399,9 @@
           }
         }
       }
+    },
+    "Applied to the entire tab when this profile opens, including split panes." : {
+
     },
     "Applies to sessions opened from now on. Existing tabs keep the shell they started with." : {
       "localizations" : {
@@ -141106,7 +141115,7 @@
       }
     },
     "Copied" : {
-      "comment" : "Clipboard entry source: explicit copy\nCopy button state: copied",
+      "comment" : "Clipboard entry source: explicit copy\nCopy button state: copied\nLocal SSH agent export copied button",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -172313,7 +172322,7 @@
       }
     },
     "Denied" : {
-      "comment" : "Location Diary authorization status",
+      "comment" : "Local SSH agent audit outcome\nLocation Diary authorization status",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -265506,7 +265515,7 @@
       }
     },
     "Identity" : {
-      "comment" : "OpenPubkey field: signed-in account",
+      "comment" : "Local SSH agent client rule identity key label\nOpenPubkey field: signed-in account",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -319735,7 +319744,7 @@
       }
     },
     "Local SSH Agent" : {
-      "comment" : "Setting title",
+      "comment" : "Local SSH agent settings title\nSetting title\nSettings row: local SSH agent",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -367893,7 +367902,7 @@
       }
     },
     "None" : {
-      "comment" : "Auth method: no authentication\nBackground effect: no effect active\nBell sound: completely silent\nBookmarked locations: none saved\nCursor effect: no effect\nKey auth requirement: none\nKubernetes auth method: no authentication\nNotification sound: silent\nProfile folder: no folder selected\nQuick setup pair: disable both swipes\nSplit border style: no border\nVNC jump selection\nVNC security preference\nVPN excluded routes: none configured",
+      "comment" : "Auth method: no authentication\nBackground effect: no effect active\nBell sound: completely silent\nCursor effect: no effect\nKey auth requirement: none\nKubernetes auth method: no authentication\nNotification sound: silent\nProfile folder: no folder selected\nQuick setup pair: disable both swipes\nSettings status: none configured\nSplit border style: no border\nVNC jump selection\nVNC security preference\nVPN excluded routes: none configured",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -376709,7 +376718,7 @@
       }
     },
     "Off" : {
-      "comment" : "Agent notification policy: never notify\nAlways On Display duration: disabled\nMod-tap: no active rules\nScreen Sharing clipboard sync default\nSetting value display\nTask notification policy: never notify\nToggle state: disabled\nTwo-finger long press: gesture disabled\nVNC keyboard toolbar preference",
+      "comment" : "Agent notification policy: never notify\nMod-tap: no active rules\nScreen Sharing clipboard sync default\nSetting value display\nSettings status: disabled\nTask notification policy: never notify\nToggle state: disabled\nTwo-finger long press: gesture disabled\nVNC keyboard toolbar preference",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -377173,7 +377182,7 @@
       }
     },
     "On" : {
-      "comment" : "Setting value display\nToggle state: enabled\nVNC keyboard toolbar preference",
+      "comment" : "Setting value display\nSettings status: enabled\nToggle state: enabled\nVNC keyboard toolbar preference",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -384890,7 +384899,11 @@
         }
       }
     },
+    "Opens a saved local shell or remote connection profile." : {
+
+    },
     "Opens an SSH connection to a saved profile." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -404661,6 +404674,12 @@
         }
       }
     },
+    "Platform" : {
+
+    },
+    "Platform Filter" : {
+
+    },
     "Play Remote Audio" : {
       "localizations" : {
         "ar" : {
@@ -415314,6 +415333,9 @@
           }
         }
       }
+    },
+    "Profile Unavailable" : {
+
     },
     "Profiles" : {
       "localizations" : {
@@ -467379,6 +467401,12 @@
         }
       }
     },
+    "Saving replaces this profile's Local Shell settings (directory, startup command, platform) with Screen Sharing settings." : {
+
+    },
+    "Saving replaces this profile's Local Shell settings (directory, startup command, platform) with SSH settings." : {
+
+    },
     "Saving replaces this profile's Screen Sharing settings (quality, display, audio) with SSH settings. The hostname is carried over." : {
       "comment" : "Profile editor footer shown when converting a Screen Sharing profile to SSH",
       "localizations" : {
@@ -467533,6 +467561,12 @@
           }
         }
       }
+    },
+    "Saving replaces this profile's Screen Sharing settings with Local Shell settings." : {
+
+    },
+    "Saving replaces this profile's SSH settings (keys, port forwards, agent forwarding, terminal options) with Local Shell settings." : {
+
     },
     "Saving replaces this profile's SSH settings (keys, port forwards, agent forwarding, terminal options) with Screen Sharing settings. The hostname is carried over." : {
       "comment" : "Profile editor footer shown when converting an SSH profile to Screen Sharing",
@@ -469695,6 +469729,7 @@
       }
     },
     "Screen Sharing profiles can't run commands." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -497966,6 +498001,9 @@
         }
       }
     },
+    "Shell on this device" : {
+
+    },
     "Shell Utilities:" : {
       "comment" : "Help: shell utilities section header",
       "localizations" : {
@@ -498894,6 +498932,9 @@
           }
         }
       }
+    },
+    "Show All Platforms" : {
+
     },
     "Show All Tabs" : {
       "comment" : "Tab hover preview: exposé hint tooltip",
@@ -520383,7 +520424,7 @@
       }
     },
     "SSH Agent" : {
-      "comment" : "Setting group title",
+      "comment" : "Agent key section header\nSetting group title",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -529030,6 +529071,12 @@
           }
         }
       }
+    },
+    "Starting Directory (Optional)" : {
+
+    },
+    "Startup Command (Optional)" : {
+
     },
     "Statistics" : {
       "localizations" : {
@@ -568708,6 +568755,9 @@
         }
       }
     },
+    "This action requires an SSH, mosh, or tssh profile." : {
+
+    },
     "This certificate belongs to '%@', not '%@'. Open that key's details to attach it there." : {
       "comment" : "Cert import error: belongs to another key",
       "localizations" : {
@@ -573034,6 +573084,9 @@
         }
       }
     },
+    "This local profile is unavailable on this device. Enable Show All Platforms in Profiles to edit its platform or repair its settings." : {
+
+    },
     "This looks like a private key. Paste the certificate (-cert.pub), not the key itself." : {
       "comment" : "Cert import error: private key pasted",
       "localizations" : {
@@ -573650,6 +573703,9 @@
           }
         }
       }
+    },
+    "This profile is unavailable on this device. Edit its platform using Show All Platforms in Profiles." : {
+
     },
     "This profile normally inherits the remote terminal type from Settings. Override it only for hosts that require a different terminfo name." : {
       "localizations" : {
@@ -601613,6 +601669,9 @@
         }
       }
     },
+    "Unavailable on this device · Tap to edit" : {
+
+    },
     "Unbalanced quote." : {
       "comment" : "Local shell warning: quote is never closed",
       "extractionState" : "stale",
@@ -614139,6 +614198,9 @@
         }
       }
     },
+    "Use Default" : {
+
+    },
     "Use Device Location" : {
       "localizations" : {
         "ar" : {
@@ -621247,6 +621309,9 @@
           }
         }
       }
+    },
+    "Uses this device's shell. An empty directory inherits the current local shell's directory. The startup command runs once when you open the profile." : {
+
     },
     "Uses your ChatGPT Plus/Pro subscription instead of a metered API key." : {
       "localizations" : {
@@ -639021,7 +639086,7 @@
       }
     },
     "Weekly" : {
-      "comment" : "Agent usage window title: weekly quota",
+      "comment" : "Agent usage window title: weekly quota\nUpdate interval: weekly",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/rootshell/Core/CloudKit/CloudKitSyncManager.swift
+++ b/rootshell/Core/CloudKit/CloudKitSyncManager.swift
@@ -236,7 +236,7 @@ final class CloudKitSyncManager {
             // An existing change token has already consumed past AppSetting
             // records, so fetch the zone from scratch.
             let changes = try await fetchZoneChanges(resetToken: true)
-            await processChangedRecords(changes.records)
+            try await processChangedRecords(changes.records)
             await processDeletedRecords(changes.deletedRecords)
             let cloud = changes.records.compactMap { $0.recordType == AppSettingRecord.recordType ? AppSettingRecord.from($0) : nil }
             let preview = coordinator.mergePreview(cloud: cloud)
@@ -434,7 +434,7 @@ final class CloudKitSyncManager {
                 // Fetch remote changes first
                 syncState = .fetchingChanges
                 let changes = try await fetchZoneChanges()
-                await processChangedRecords(changes.records)
+                try await processChangedRecords(changes.records)
                 await processDeletedRecords(changes.deletedRecords)
 
                 // Push all local records for the new types
@@ -525,7 +525,7 @@ final class CloudKitSyncManager {
             syncState = .fetchingChanges
             let shouldPushAll = try await ensureCustomZoneReady()
             let changes = try await fetchZoneChanges(resetToken: true)
-            await processChangedRecords(changes.records)
+            try await processChangedRecords(changes.records)
             await processDeletedRecords(changes.deletedRecords)
 
             if shouldPushAll {
@@ -843,7 +843,7 @@ final class CloudKitSyncManager {
 
             // Fetch remote changes from the custom zone
             let changes = try await fetchZoneChanges()
-            await processChangedRecords(changes.records)
+            try await processChangedRecords(changes.records)
             await processDeletedRecords(changes.deletedRecords)
 
             // Push local changes
@@ -885,7 +885,7 @@ final class CloudKitSyncManager {
 
         // Fetch all existing records from the custom zone
         let changes = try await fetchZoneChanges(resetToken: true)
-        await processChangedRecords(changes.records)
+        try await processChangedRecords(changes.records)
         await processDeletedRecords(changes.deletedRecords)
 
         // Push all local records to seed the zone
@@ -945,7 +945,7 @@ final class CloudKitSyncManager {
 
         // Apply to local store
         let records = allRecords.compactMap { T.from($0) }
-        await applyRemoteRecords(records, type: type)
+        try await applyRemoteRecords(records, type: type)
         return true
     }
 
@@ -1132,7 +1132,16 @@ final class CloudKitSyncManager {
     }
 
     /// Process changed records from CloudKit
-    private func processChangedRecords(_ records: [CKRecord]) async {
+    private func processChangedRecords(_ records: [CKRecord]) async throws {
+        // Fetch currently advances the zone token before applying records. If
+        // a companion cannot reach disk, refetch rather than losing that change.
+        var appliedAll = false
+        defer {
+            if !appliedAll {
+                zoneChangeToken = nil
+                saveChangeToken()
+            }
+        }
         // Settings are merged as one batch so managers reload and the terminal
         // config rewrites once, not once per key.
         var settingRecords: [AppSettingRecord] = []
@@ -1147,25 +1156,28 @@ final class CloudKitSyncManager {
             case SSHConnectionHistoryEntry.recordType:
                 guard isHistorySyncEnabled else { continue }
                 if let entry = SSHConnectionHistoryEntry.from(record) {
-                    await applyRemoteRecords([entry], type: SSHConnectionHistoryEntry.self)
+                    try await applyRemoteRecords([entry], type: SSHConnectionHistoryEntry.self)
                 }
             case KnownHost.recordType:
                 guard isKnownHostsSyncEnabled else { continue }
                 if let host = KnownHost.from(record) {
-                    await applyRemoteRecords([host], type: KnownHost.self)
+                    try await applyRemoteRecords([host], type: KnownHost.self)
                 }
             case ConnectionProfile.recordType:
                 guard isProfilesSyncEnabled else { continue }
-                if let profile = ConnectionProfile.from(record) {
-                    await applyRemoteRecords([profile], type: ConnectionProfile.self)
+                if let theme = ProfileThemeRecord.from(record) {
+                    try ConnectionProfileManager.shared.applyRemoteTheme(theme)
+                } else if let profile = ConnectionProfile.from(record) {
+                    try await applyRemoteRecords([profile], type: ConnectionProfile.self)
                 }
             default:
                 Self.logger.warning("Unknown record type: \(record.recordType)")
             }
         }
         if !settingRecords.isEmpty {
-            await applyRemoteRecords(settingRecords, type: AppSettingRecord.self)
+            try await applyRemoteRecords(settingRecords, type: AppSettingRecord.self)
         }
+        appliedAll = true
     }
 
     /// Process deleted records from CloudKit
@@ -1219,7 +1231,7 @@ final class CloudKitSyncManager {
     }
 
     /// Apply remote records to local stores
-    private func applyRemoteRecords<T: CloudKitSyncable>(_ records: [T], type: T.Type) async {
+    private func applyRemoteRecords<T: CloudKitSyncable>(_ records: [T], type: T.Type) async throws {
         syncState = .applyingChanges
 
         switch T.recordType {
@@ -1233,7 +1245,10 @@ final class CloudKitSyncManager {
             }
         case ConnectionProfile.recordType:
             if let profiles = records as? [ConnectionProfile] {
-                ConnectionProfileManager.shared.applyRemoteChanges(profiles)
+                let result = ConnectionProfileManager.shared.applyRemoteChangesWithFailures(profiles)
+                if let failure = result.failures.first { throw failure.error }
+            } else if let themes = records as? [ProfileThemeRecord] {
+                for theme in themes { try ConnectionProfileManager.shared.applyRemoteTheme(theme) }
             }
         case AppSettingRecord.recordType:
             if let settings = records as? [AppSettingRecord] {
@@ -1273,13 +1288,19 @@ final class CloudKitSyncManager {
 
     /// Save a record with conflict resolution
     private func saveRecord<T: CloudKitSyncable>(_ record: T) async throws {
+        // Write the companion first. Failure queues the original profile, so
+        // retries and initial pushes always include both records.
+        if let profile = record as? ConnectionProfile,
+           let theme = ProfileThemeRecord(profile: profile) {
+            try await saveRecord(theme)
+        }
         let ckRecord = record.toCKRecord()
 
         do {
             let (saveResults, _) = try await database.modifyRecords(
                 saving: [ckRecord],
                 deleting: [],
-                savePolicy: .allKeys
+                savePolicy: record is ProfileThemeRecord ? .ifServerRecordUnchanged : .allKeys
             )
             for (_, result) in saveResults {
                 if case .failure(let error) = result {
@@ -1288,6 +1309,9 @@ final class CloudKitSyncManager {
             }
         } catch let ckError as CKError where ckError.code == .serverRecordChanged {
             try await resolveServerRecordConflict(ckError, localRecord: record)
+        }
+        if let theme = record as? ProfileThemeRecord {
+            try ConnectionProfileManager.shared.markThemeSynced(theme)
         }
     }
 
@@ -1307,7 +1331,7 @@ final class CloudKitSyncManager {
             let (saveResults, _) = try await database.modifyRecords(
                 saving: [serverRecord],
                 deleting: [],
-                savePolicy: .allKeys
+                savePolicy: localRecord is ProfileThemeRecord ? .ifServerRecordUnchanged : .allKeys
             )
             for (_, result) in saveResults {
                 if case .failure(let error) = result {
@@ -1316,12 +1340,24 @@ final class CloudKitSyncManager {
             }
         } else {
             // Server is newer - accept server record and update local store
-            await applyRemoteRecords([serverModel], type: T.self)
+            try await applyRemoteRecords([serverModel], type: T.self)
         }
     }
 
     /// Push all pending changes from offline queue
     private func pushPendingChanges() async throws {
+        // Includes themes recovered from local profiles or legacy envelopes,
+        // even when there has been no profile edit and the offline queue is empty.
+        if isProfilesSyncEnabled {
+            for theme in ConnectionProfileManager.shared.pendingThemesForSync {
+                do {
+                    try await saveRecord(theme)
+                } catch let error as CKError where error.code == .requestRateLimited {
+                    scheduleRateLimitedRetry(after: error.retryAfterSeconds ?? 30)
+                    return
+                }
+            }
+        }
         let batch = offlineQueue.nextBatch(limit: 100)
         guard !batch.isEmpty else { return }
 

--- a/rootshell/Core/CloudKit/CloudKitSyncable.swift
+++ b/rootshell/Core/CloudKit/CloudKitSyncable.swift
@@ -412,20 +412,25 @@ extension ConnectionProfile: CloudKitSyncable {
         record["schemaVersion"] = Int64(Self.schemaVersion)
         record["deviceID"] = CloudKitSyncSettings.deviceID
 
-        // SSH config as JSON data. VNC records deliberately OMIT the blob:
+        // SSH config as JSON data. VNC and local records deliberately OMIT the blob:
         // old builds decode unknown protocols as `?? .ssh`, and a placeholder
         // sshConfig would materialize there as a corrupt SSH profile. The
         // missing blob instead trips their existing guard and the record is
         // skipped - skip, not break.
-        if connectionProtocol == .vnc {
+        if !isSSHBased {
             record["sshConfig"] = nil as Data?
         } else if let sshData = try? JSONEncoder().encode(sshConfig) {
             record["sshConfig"] = sshData
         }
 
-        // Extension envelope for VNC configuration and future profile fields.
-        if let extensionPayload, !extensionPayload.isEmpty,
-           let envelopeData = try? JSONEncoder().encode(extensionPayload) {
+        // Keep appearance out of the legacy envelope: old clients reconstruct
+        // that envelope and erase unknown fields. Theme revisions ride a
+        // separate ProfileThemeRecord using the same existing CloudKit schema.
+        var connectionPayload = extensionPayload
+        connectionPayload?.themeName = nil
+        connectionPayload?.themeModifiedAt = nil
+        if let connectionPayload, !connectionPayload.isEmpty,
+           let envelopeData = try? JSONEncoder().encode(connectionPayload) {
             record["extensionData"] = envelopeData
         } else {
             record["extensionData"] = nil as Data?
@@ -485,13 +490,15 @@ extension ConnectionProfile: CloudKitSyncable {
                     logger.debug("Raw sshConfig JSON: \(jsonString)")
                 }
             }
-        } else if connectionProtocol != .vnc {
+        } else if connectionProtocol != .vnc && connectionProtocol != .local {
             logger.warning("ConnectionProfile '\(name)' missing sshConfig data")
         }
 
         let validSSHConfig: SSHConfig
         if let sshConfig {
             validSSHConfig = sshConfig
+        } else if connectionProtocol == .local {
+            validSSHConfig = ConnectionProfile.localPlaceholderSSHConfig()
         } else if connectionProtocol == .vnc {
             // VNC records omit sshConfig; synthesize the placeholder from the
             // envelope (or empty when the envelope is missing/undecodable -
@@ -561,5 +568,41 @@ extension ConnectionProfile: CloudKitSyncable {
             useCount: useCount,
             extensionPayload: extensionPayload
         )
+    }
+}
+
+// MARK: - ProfileThemeRecord + CloudKitSyncable
+
+extension ProfileThemeRecord: CloudKitSyncable {
+    // Reuse the deployed record type and fields; no CloudKit schema additions.
+    static var recordType: String { ConnectionProfile.recordType }
+    static var schemaVersion: Int { 1 }
+
+    static func recordName(for record: ProfileThemeRecord) -> String {
+        CloudKitRecordName.make(recordType: "ConnectionProfileTheme", identity: record.id.uuidString)
+    }
+
+    func apply(to record: CKRecord) {
+        // Missing profileID is intentional: every older profile decoder rejects
+        // this record before reading the envelope. Its ID is in the opaque data.
+        record["profileID"] = nil as String?
+        record["name"] = nil as String?
+        var wireRecord = self
+        wireRecord.syncedRevision = nil
+        record["extensionData"] = try? JSONEncoder().encode(wireRecord)
+        record["modifiedAt"] = modifiedAt
+        record["schemaVersion"] = Int64(Self.schemaVersion)
+        record["isDeleted"] = isDeleted ? 1 : 0
+    }
+
+    static func from(_ record: CKRecord) -> ProfileThemeRecord? {
+        guard record.recordType == recordType,
+              let data = record["extensionData"] as? Data,
+              var theme = try? JSONDecoder().decode(Self.self, from: data),
+              record.recordID.recordName == recordName(for: theme) else { return nil }
+        theme.syncedRevision = theme.modifiedAt
+        // Use the theme revision, not server modificationDate: an unrelated
+        // profile edit or an offline retry must never become a new theme edit.
+        return theme
     }
 }

--- a/rootshell/Core/Terminal/TerminalSessionController.swift
+++ b/rootshell/Core/Terminal/TerminalSessionController.swift
@@ -1042,6 +1042,13 @@ final class TerminalSessionController {
                 } else {
                     try await session.start()
                 }
+                if case .local = connectionConfig {
+                    let command = host.terminalPendingStartupCommand
+                    host.terminalPendingStartupCommand = nil
+                    if let command, !command.isEmpty {
+                        session.sendInput(Data((command + "\n").utf8))
+                    }
+                }
                 Ghostty.logger.info("Session started successfully")
 
                 if case .mosh = connectionConfig {

--- a/rootshell/Features/AppIntents/ConnectionProfileEntity.swift
+++ b/rootshell/Features/AppIntents/ConnectionProfileEntity.swift
@@ -70,7 +70,7 @@ extension ConnectionProfile {
         ConnectionProfileEntity(
             id: id,
             name: name,
-            host: sshConfig.host,
+            host: connectionProtocol == .local ? displayString : sshConfig.host,
             username: sshConfig.username,
             folderPath: folderPath,
             connectionProtocol: connectionProtocol.displayName,

--- a/rootshell/Features/AppIntents/ConnectionProfileEntityQuery.swift
+++ b/rootshell/Features/AppIntents/ConnectionProfileEntityQuery.swift
@@ -14,14 +14,16 @@ struct ConnectionProfileEntityQuery: EntityQuery, EntityStringQuery, EnumerableE
 
     func allEntities() async -> [ConnectionProfileEntity] {
         await MainActor.run {
-            ConnectionProfileManager.shared.profiles.map { $0.toEntity() }
+            ConnectionProfileManager.shared.availableProfiles.map { $0.toEntity() }
         }
     }
 
     func entities(for identifiers: [UUID]) async -> [ConnectionProfileEntity] {
         await MainActor.run {
             identifiers.compactMap { id in
-                ConnectionProfileManager.shared.profile(for: id)?.toEntity()
+                guard let profile = ConnectionProfileManager.shared.profile(for: id),
+                      !profile.isDeleted else { return nil }
+                return profile.toEntity()
             }
         }
     }
@@ -29,6 +31,7 @@ struct ConnectionProfileEntityQuery: EntityQuery, EntityStringQuery, EnumerableE
     func entities(matching string: String) async -> [ConnectionProfileEntity] {
         await MainActor.run {
             ConnectionProfileManager.shared.profiles(matching: string)
+                .filter { $0.isAvailableOnCurrentPlatform }
                 .map { $0.toEntity() }
         }
     }
@@ -36,6 +39,36 @@ struct ConnectionProfileEntityQuery: EntityQuery, EntityStringQuery, EnumerableE
     func suggestedEntities() async -> [ConnectionProfileEntity] {
         await MainActor.run {
             ConnectionProfileManager.shared.getSuggestions(matching: "", limit: 20)
+                .map { $0.toEntity() }
+        }
+    }
+}
+
+/// The SSH command action retains ConnectionProfileEntity IDs for existing
+/// shortcuts, but restricts every picker and lookup path to SSH transports.
+struct SSHConnectionProfileEntityQuery: EntityQuery, EntityStringQuery {
+    func entities(for identifiers: [UUID]) async -> [ConnectionProfileEntity] {
+        await MainActor.run {
+            identifiers.compactMap { id in
+                guard let profile = ConnectionProfileManager.shared.profile(for: id),
+                      !profile.isDeleted, profile.isSSHBased else { return nil }
+                return profile.toEntity()
+            }
+        }
+    }
+
+    func entities(matching string: String) async -> [ConnectionProfileEntity] {
+        await MainActor.run {
+            ConnectionProfileManager.shared.profiles(matching: string)
+                .filter { $0.isSSHBased }
+                .map { $0.toEntity() }
+        }
+    }
+
+    func suggestedEntities() async -> [ConnectionProfileEntity] {
+        await MainActor.run {
+            ConnectionProfileManager.shared.profiles
+                .filter { $0.isSSHBased }
                 .map { $0.toEntity() }
         }
     }

--- a/rootshell/Features/AppIntents/ConnectionProtocolAppEnum.swift
+++ b/rootshell/Features/AppIntents/ConnectionProtocolAppEnum.swift
@@ -9,6 +9,7 @@ import AppIntents
 
 /// Shortcuts-visible mirror of ConnectionProtocol for filtering profiles.
 enum ConnectionProtocolAppEnum: String, AppEnum {
+    case local
     case ssh
     case mosh
     case trzsz
@@ -24,6 +25,7 @@ enum ConnectionProtocolAppEnum: String, AppEnum {
     /// existing `Localizable.xcstrings` translations apply to both call sites.
     nonisolated static var caseDisplayRepresentations: [ConnectionProtocolAppEnum: DisplayRepresentation] {
         [
+            .local: "Local Shell",
             .ssh:   "SSH",
             .mosh:  "Roam - mosh compatible",
             .trzsz: "Roam - tssh",
@@ -33,6 +35,7 @@ enum ConnectionProtocolAppEnum: String, AppEnum {
 
     var connectionProtocol: ConnectionProtocol {
         switch self {
+        case .local: return .local
         case .ssh: return .ssh
         case .mosh: return .mosh
         case .trzsz: return .trzsz

--- a/rootshell/Features/AppIntents/GetConnectionProfilesIntent.swift
+++ b/rootshell/Features/AppIntents/GetConnectionProfilesIntent.swift
@@ -30,7 +30,7 @@ struct GetConnectionProfilesIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[ConnectionProfileEntity]> {
-        var results = ConnectionProfileManager.shared.profiles
+        var results = ConnectionProfileManager.shared.availableProfiles
 
         if let folder, !folder.isEmpty {
             results = results.filter { $0.folderPath == folder }
@@ -55,7 +55,9 @@ struct GetConnectionProfilesIntent: AppIntent {
     struct FolderOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
             await MainActor.run {
-                ConnectionProfileManager.shared.allFolders.map { $0.path }
+                Set(ConnectionProfileManager.shared.availableProfiles.map { $0.folderPath })
+                    .filter { !$0.isEmpty }
+                    .sorted()
             }
         }
     }
@@ -63,7 +65,8 @@ struct GetConnectionProfilesIntent: AppIntent {
     struct TagOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
             await MainActor.run {
-                ConnectionProfileManager.shared.allTags.map { $0.name }
+                Set(ConnectionProfileManager.shared.availableProfiles.flatMap { $0.tags })
+                    .sorted()
             }
         }
     }

--- a/rootshell/Features/AppIntents/OpenConnectionProfileIntent.swift
+++ b/rootshell/Features/AppIntents/OpenConnectionProfileIntent.swift
@@ -10,7 +10,7 @@ import AppIntents
 /// Shortcuts action: open a saved connection profile, optionally with a directory and command.
 struct OpenConnectionProfileIntent: AppIntent {
     static var title: LocalizedStringResource = "Open Connection Profile"
-    static var description: IntentDescription = "Opens an SSH connection to a saved profile."
+    static var description: IntentDescription = "Opens a saved local shell or remote connection profile."
     static var openAppWhenRun = true
 
     @Parameter(title: "Profile")
@@ -27,8 +27,13 @@ struct OpenConnectionProfileIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        guard ConnectionProfileManager.shared.profile(for: profile.id) != nil else {
+        guard let saved = ConnectionProfileManager.shared.profile(for: profile.id),
+              !saved.isDeleted else {
             throw IntentError.profileNotFound
+        }
+
+        guard saved.isAvailableOnCurrentPlatform else {
+            throw IntentError.profileUnavailable
         }
 
         let launchCommand = Self.composeLaunchCommand(
@@ -76,9 +81,12 @@ struct OpenConnectionProfileIntent: AppIntent {
 
     enum IntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
         case profileNotFound
+        case profileUnavailable
 
         var localizedStringResource: LocalizedStringResource {
             switch self {
+            case .profileUnavailable:
+                return "This profile is unavailable on this device. Edit its platform using Show All Platforms in Profiles."
             case .profileNotFound:
                 return "Connection profile not found."
             }

--- a/rootshell/Features/AppIntents/RunSSHCommandIntent.swift
+++ b/rootshell/Features/AppIntents/RunSSHCommandIntent.swift
@@ -23,7 +23,7 @@ struct RunSSHCommandIntent: AppIntent, ForegroundContinuableIntent {
     /// bloating the Shortcuts run.
     private static let maxOutputCharacters = 100_000
 
-    @Parameter(title: "Profile")
+    @Parameter(title: "Profile", query: SSHConnectionProfileEntityQuery())
     var profile: ConnectionProfileEntity
 
     @Parameter(title: "Command")
@@ -34,10 +34,11 @@ struct RunSSHCommandIntent: AppIntent, ForegroundContinuableIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        guard let savedProfile = ConnectionProfileManager.shared.profile(for: profile.id) else {
+        guard let savedProfile = ConnectionProfileManager.shared.profile(for: profile.id),
+              !savedProfile.isDeleted else {
             throw IntentError.profileNotFound
         }
-        guard savedProfile.connectionProtocol != .vnc else {
+        guard savedProfile.isSSHBased else {
             throw IntentError.notATerminalProfile
         }
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -162,7 +163,7 @@ struct RunSSHCommandIntent: AppIntent, ForegroundContinuableIntent {
             case .profileNotFound:
                 return "Connection profile not found."
             case .notATerminalProfile:
-                return "Screen Sharing profiles can't run commands."
+                return "This action requires an SSH, mosh, or tssh profile."
             case .emptyCommand:
                 return "A command is required."
             case .keyUnavailable(let profileName):

--- a/rootshell/Features/LocalShell/LocalShellSession+Completion.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+Completion.swift
@@ -21,7 +21,8 @@ extension LocalShellSession {
         if state.suggestions.isEmpty {
             state.suggestions = QuickConnectSuggestionProvider.shared.getSuggestions(
                 matching: extraction.completableText,
-                mode: state.matchingMode
+                mode: state.matchingMode,
+                context: .sshDestination
             )
             state.suggestionIndex = 0
         }
@@ -48,7 +49,8 @@ extension LocalShellSession {
 
         let suggestions = QuickConnectSuggestionProvider.shared.getSuggestions(
             matching: extraction.completableText,
-            mode: .prefix
+            mode: .prefix,
+            context: .sshDestination
         )
 
         guard let firstSuggestion = suggestions.first else {
@@ -250,7 +252,7 @@ extension LocalShellSession {
                 || bufferPrefix.lowercased().contains(" -p\t")
 
             let rawHostSuggestions = QuickConnectSuggestionProvider.shared
-                .getSuggestions(matching: prefix, mode: scpCompletion.matchingMode)
+                .getSuggestions(matching: prefix, mode: scpCompletion.matchingMode, context: .sshDestination)
 
             // ProfileSuggestion.matches() always uses substring across name/host/username/folder/tags/notes,
             // ignoring `mode`. In .prefix mode that lets a profile whose tag/notes contains "ni" surface its

--- a/rootshell/Features/Profiles/ConnectionProfile.swift
+++ b/rootshell/Features/Profiles/ConnectionProfile.swift
@@ -21,6 +21,8 @@ enum ProfileColorTag: String, Codable, CaseIterable, Sendable {
 
 /// Connection protocol options for profiles
 enum ConnectionProtocol: String, Codable, CaseIterable, Sendable {
+    /// Shell on the current device
+    case local
     /// Standard SSH connection
     case ssh
     /// Mosh (mobile shell) connection - survives network changes and high latency
@@ -32,6 +34,7 @@ enum ConnectionProtocol: String, Codable, CaseIterable, Sendable {
 
     var displayName: String {
         switch self {
+        case .local: return String(localized: "Local Shell")
         case .ssh: return String(localized: "SSH", comment: "Connection protocol: SSH")
         case .mosh: return String(localized: "Roam - mosh compatible", comment: "Connection protocol: mosh")
         case .trzsz: return String(localized: "Roam - tssh", comment: "Connection protocol: trzsz")
@@ -41,6 +44,7 @@ enum ConnectionProtocol: String, Codable, CaseIterable, Sendable {
 
     var description: String {
         switch self {
+        case .local: return String(localized: "Shell on this device")
         case .ssh: return String(localized: "Standard secure shell connection", comment: "Connection protocol description: SSH")
         case .mosh: return String(localized: "Mobile shell - better for unreliable networks", comment: "Connection protocol description: mosh")
         case .trzsz: return String(localized: "QUIC-based mobile shell - modern roaming protocol", comment: "Connection protocol description: trzsz")
@@ -50,6 +54,7 @@ enum ConnectionProtocol: String, Codable, CaseIterable, Sendable {
 
     var iconName: String {
         switch self {
+        case .local: return "terminal"
         case .ssh: return "terminal"
         case .mosh: return "antenna.radiowaves.left.and.right"
         case .trzsz: return "antenna.radiowaves.left.and.right"
@@ -123,7 +128,7 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
 
     // MARK: - Connection Configuration
 
-    /// Connection protocol (SSH or Mosh)
+    /// Local shell or remote connection protocol
     var connectionProtocol: ConnectionProtocol
 
     /// Transport mode for TSSH connections (default inherits from Settings > Roam)
@@ -144,7 +149,8 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
 
     /// SSH connection configuration.
     ///
-    /// Non-optional for backward compatibility, so VNC profiles carry a
+    /// Non-optional for backward compatibility. Local profiles carry an empty
+    /// placeholder with auth `.none`; VNC profiles carry a
     /// PLACEHOLDER SSHConfig (host/port/username mirrored from `vncConfig`,
     /// auth `.none`). It must never be used to open an SSH connection; the
     /// real VNC settings live in `extensionPayload.vncConfig`. Note the
@@ -153,9 +159,8 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
     /// profile.
     var sshConfig: SSHConfig
 
-    /// Versioned envelope for extension fields (VNC config now, future
-    /// additions later). nil / empty envelopes are omitted from JSON so SSH
-    /// profile files are byte-identical to before this field existed.
+    /// Versioned envelope for VNC/local settings and the profile theme.
+    /// Empty envelopes are omitted so existing SSH profile JSON stays unchanged.
     var extensionPayload: ProfileExtensionPayload?
 
     // MARK: - VPN Configuration
@@ -390,6 +395,40 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
 
     // MARK: - Computed Properties
 
+    var isSSHBased: Bool {
+        connectionProtocol == .ssh || connectionProtocol == .mosh || connectionProtocol == .trzsz
+    }
+
+    var isAvailableOnCurrentPlatform: Bool {
+        connectionProtocol != .local || localConfig?.platform.isAvailable == true
+    }
+
+    var localConfig: LocalProfileConfig? {
+        get { extensionPayload?.localConfig }
+        set {
+            var payload = extensionPayload ?? ProfileExtensionPayload()
+            payload.localConfig = newValue
+            extensionPayload = payload.isEmpty ? nil : payload
+        }
+    }
+
+    var themeName: String? {
+        get { extensionPayload?.themeName }
+        set {
+            guard themeName != newValue else { return }
+            var payload = extensionPayload ?? ProfileExtensionPayload()
+            payload.themeName = newValue
+            payload.themeModifiedAt = Date()
+            extensionPayload = payload
+        }
+    }
+
+    static func localPlaceholderSSHConfig() -> SSHConfig {
+        var config = SSHConfig(host: "", port: 22, username: "", password: "")
+        config.authMethod = .none
+        return config
+    }
+
     /// Convenience accessor for the VNC config in the extension envelope.
     /// Setting a value creates the envelope; clearing the last field drops it
     /// so SSH profiles never carry an empty envelope.
@@ -444,6 +483,9 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
 
     /// Display string for autocomplete/suggestions (shows host info)
     var displayString: String {
+        if connectionProtocol == .local {
+            return String(localized: "Local Shell")
+        }
         if connectionProtocol == .vnc, let vncConfig {
             return vncConfig.displayName
         }
@@ -459,6 +501,8 @@ struct ConnectionProfile: Codable, Identifiable, Hashable, SyncableRecord {
     /// Display string with protocol prefix (e.g., "mosh user@host")
     var displayStringWithProtocol: String {
         switch connectionProtocol {
+        case .local:
+            return displayString
         case .ssh:
             return displayString
         case .mosh:

--- a/rootshell/Features/Profiles/ConnectionProfileManager.swift
+++ b/rootshell/Features/Profiles/ConnectionProfileManager.swift
@@ -18,13 +18,14 @@ final class ConnectionProfileManager {
 
     /// File store for sync-ready per-record storage
     private var store: SyncableFileStore<ConnectionProfile>
+    private var themeStore: SyncableFileStore<ProfileThemeRecord>
 
     /// Sorted profiles (by name), excluding deleted
     private(set) var profiles: [ConnectionProfile] = []
 
     /// All records including tombstones (for CloudKit sync)
     var allRecordsForSync: [ConnectionProfile] {
-        store.allRecords
+        store.allRecords.map(profileWithTheme)
     }
 
     /// Whether the last disk load failed to list the store directory
@@ -34,7 +35,9 @@ final class ConnectionProfileManager {
 
     /// Reload all profiles from disk (recovery path when the initial load failed)
     func reloadFromDisk() {
+        themeStore.reload()
         store.reload()
+        restoreProfileThemesFromDisk()
         updateProfilesFromStore()
     }
 
@@ -47,7 +50,9 @@ final class ConnectionProfileManager {
 
     private init() {
         self.store = SyncableFileStore<ConnectionProfile>(storeName: "connection_profiles")
+        self.themeStore = SyncableFileStore<ProfileThemeRecord>(storeName: "profile_themes")
         sanitizePersistedProfiles()
+        restoreProfileThemesFromDisk()
         updateProfilesFromStore()
     }
 
@@ -88,11 +93,17 @@ final class ConnectionProfileManager {
         return folders.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
     }
 
-    /// All unique tags with usage counts
+    /// All unique tags with usage counts (including other platforms for editors).
     var allTags: [ProfileTag] {
+        tags(showAllPlatforms: true)
+    }
+
+    /// Browse filters and counts must use the same platform scope as results.
+    func tags(showAllPlatforms: Bool) -> [ProfileTag] {
+        let visibleProfiles = showAllPlatforms ? profiles : availableProfiles
         var tagCounts: [String: Int] = [:]
 
-        for profile in profiles {
+        for profile in visibleProfiles {
             for tag in profile.tags {
                 tagCounts[tag, default: 0] += 1
             }
@@ -469,9 +480,31 @@ final class ConnectionProfileManager {
 
     // MARK: - Query Operations
 
+    var availableProfiles: [ConnectionProfile] {
+        profiles.filter { $0.isAvailableOnCurrentPlatform }
+    }
+
+    var hasUnavailableProfiles: Bool {
+        profiles.contains { !$0.isAvailableOnCurrentPlatform }
+    }
+
+    /// Folder counts must reflect the same platform filter as their rows.
+    func subfolders(of parentPath: String, showAllPlatforms: Bool) -> [ProfileFolder] {
+        let visible = showAllPlatforms ? profiles : availableProfiles
+        return subfolders(of: parentPath).compactMap { folder in
+            let descendants = visible.filter {
+                $0.folderPath == folder.path || $0.folderPath.hasPrefix(folder.path + "/")
+            }
+            guard !descendants.isEmpty else { return nil }
+            return ProfileFolder(path: folder.path,
+                                 profileCount: descendants.filter { $0.folderPath == folder.path }.count,
+                                 totalProfileCount: descendants.count)
+        }
+    }
+
     /// Get a profile by ID
     func profile(for id: UUID) -> ConnectionProfile? {
-        store.record(for: id)
+        store.record(for: id).map(profileWithTheme)
     }
 
     /// Get profiles in a specific folder (direct children only)
@@ -512,6 +545,7 @@ final class ConnectionProfileManager {
         }
 
         return filtered
+            .filter { $0.isAvailableOnCurrentPlatform }
             .sorted { p1, p2 in
                 // Sort by last used (most recent first), then by use count
                 if let d1 = p1.lastUsedAt, let d2 = p2.lastUsedAt {
@@ -526,6 +560,40 @@ final class ConnectionProfileManager {
     }
 
     // MARK: - Sync Support
+
+    var pendingThemesForSync: [ProfileThemeRecord] {
+        themeStore.allRecords.filter { $0.needsUpload }
+    }
+
+    /// A delayed upload must not acknowledge a newer local edit.
+    func markThemeSynced(_ theme: ProfileThemeRecord) throws {
+        guard var current = themeStore.record(for: theme.id),
+              current.modifiedAt == theme.modifiedAt,
+              current.themeName == theme.themeName,
+              current.isDeleted == theme.isDeleted,
+              current.needsUpload else { return }
+        current.syncedRevision = theme.modifiedAt
+        try themeStore.save(current, updateTimestamp: false, notifySync: false)
+    }
+
+    /// A theme may arrive before its profile or after an old client's edit.
+    /// Persist it independently, then join it to whichever profile is present.
+    func applyRemoteTheme(_ theme: ProfileThemeRecord) throws {
+        let newest: ProfileThemeRecord
+        if let existing = themeStore.record(for: theme.id), existing.modifiedAt >= theme.modifiedAt {
+            if !theme.needsUpload {
+                try markThemeSynced(theme)
+            }
+            newest = themeStore.record(for: theme.id) ?? existing
+        } else {
+            try themeStore.save(theme, updateTimestamp: false, notifySync: false)
+            newest = theme
+        }
+        if let profile = store.record(for: theme.id) {
+            try store.save(newest.applying(to: profile), updateTimestamp: false, notifySync: false)
+            updateProfilesFromStore()
+        }
+    }
 
     /// Apply changes from remote sync
     @discardableResult
@@ -543,6 +611,14 @@ final class ConnectionProfileManager {
         var failures: [(id: UUID, error: Error)] = []
 
         for remote in remoteProfiles {
+            if let theme = ProfileThemeRecord(profile: remote) {
+                do {
+                    try applyRemoteTheme(theme)
+                } catch {
+                    failures.append((id: remote.id, error: error))
+                    continue
+                }
+            }
             let needsPersist: Bool
             if let existing = store.record(for: remote.id) {
                 needsPersist = remote.modifiedAt > existing.modifiedAt
@@ -602,7 +678,9 @@ final class ConnectionProfileManager {
 
     /// Reload all records from disk
     func reload() {
+        themeStore.reload()
         store.reload()
+        restoreProfileThemesFromDisk()
         updateProfilesFromStore()
     }
 
@@ -680,9 +758,29 @@ final class ConnectionProfileManager {
 
     // MARK: - Private Helpers
 
+    private func profileWithTheme(_ profile: ConnectionProfile) -> ConnectionProfile {
+        guard let theme = themeStore.record(for: profile.id) else { return profile }
+        return theme.applying(to: profile)
+    }
+
+    /// Seed the companion cache from local JSON/backups made before companion
+    /// records existed. This also repairs a partial write after a disk failure.
+    private func restoreProfileThemesFromDisk() {
+        for profile in store.allRecords {
+            guard let theme = ProfileThemeRecord(profile: profile),
+                  themeStore.record(for: profile.id).map({ $0.modifiedAt < theme.modifiedAt }) ?? true else { continue }
+            do {
+                try themeStore.save(theme, updateTimestamp: false, notifySync: false)
+            } catch {
+                Self.logger.error("Failed to restore profile theme: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Update the profiles array from the store
     private func updateProfilesFromStore() {
         profiles = store.activeRecords
+            .map(profileWithTheme)
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         syncVPNSharedProfiles()
     }
@@ -692,7 +790,27 @@ final class ConnectionProfileManager {
         updateTimestamp: Bool = true,
         notifySync: Bool = true
     ) throws {
-        let sanitized = sanitizeProfileForPersistence(profile)
+        var sanitized = sanitizeProfileForPersistence(profile)
+        if notifySync {
+            let existing = store.record(for: profile.id).map(profileWithTheme)
+            if sanitized.themeName != existing?.themeName {
+                var payload = sanitized.extensionPayload ?? ProfileExtensionPayload()
+                payload.themeModifiedAt = Date()
+                sanitized.extensionPayload = payload
+            } else if let previousRevision = existing?.extensionPayload?.themeModifiedAt {
+                // Editing connection settings must not advance the theme revision.
+                var payload = sanitized.extensionPayload ?? ProfileExtensionPayload()
+                payload.themeModifiedAt = previousRevision
+                sanitized.extensionPayload = payload
+            }
+        }
+        if let incomingTheme = ProfileThemeRecord(profile: sanitized),
+           themeStore.record(for: sanitized.id).map({ $0.modifiedAt < incomingTheme.modifiedAt }) ?? true {
+            try themeStore.save(incomingTheme, updateTimestamp: false, notifySync: false)
+        }
+        if let theme = themeStore.record(for: sanitized.id) {
+            sanitized = theme.applying(to: sanitized)
+        }
         try store.save(sanitized, updateTimestamp: updateTimestamp, notifySync: notifySync)
     }
 

--- a/rootshell/Features/Profiles/ProfileExtensionPayload.swift
+++ b/rootshell/Features/Profiles/ProfileExtensionPayload.swift
@@ -2,8 +2,8 @@
 //  ProfileExtensionPayload.swift
 //  rootshell
 //
-//  Versioned envelope for profile fields that ride the single opaque
-//  CloudKit `extensionData` blob instead of per-field schema additions.
+//  Versioned local/backup envelope. Connection fields use CloudKit
+//  `extensionData`; themes sync separately to protect against old writers.
 //
 
 import Foundation
@@ -22,23 +22,34 @@ struct ProfileExtensionPayload: Codable, Hashable, Sendable {
 
     /// Screen Sharing / VNC configuration, when this profile is a VNC profile.
     var vncConfig: VNCConnectionConfig?
+    var localConfig: LocalProfileConfig?
+    var themeName: String?
+    /// Independent revision for theme changes, including clearing an override.
+    /// Kept in local JSON/backups; CloudKit sends it in a separate record.
+    var themeModifiedAt: Date?
 
     init(
         version: Int = ProfileExtensionPayload.currentVersion,
-        vncConfig: VNCConnectionConfig? = nil
+        vncConfig: VNCConnectionConfig? = nil,
+        localConfig: LocalProfileConfig? = nil,
+        themeName: String? = nil,
+        themeModifiedAt: Date? = nil
     ) {
         self.version = version
         self.vncConfig = vncConfig
+        self.localConfig = localConfig
+        self.themeName = themeName
+        self.themeModifiedAt = themeModifiedAt
     }
 
     /// True when nothing meaningful is stored. Empty envelopes are omitted
     /// from profile JSON and never written to CKRecords.
     var isEmpty: Bool {
-        vncConfig == nil
+        vncConfig == nil && localConfig == nil && themeName == nil && themeModifiedAt == nil
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, vncConfig
+        case version, vncConfig, localConfig, themeName, themeModifiedAt
     }
 
     init(from decoder: Decoder) throws {
@@ -46,6 +57,9 @@ struct ProfileExtensionPayload: Codable, Hashable, Sendable {
         version = ((try? container.decodeIfPresent(Int.self, forKey: .version)) ?? nil) ?? Self.currentVersion
         // Field-level tolerance: a bad vncConfig must not sink the envelope.
         vncConfig = (try? container.decodeIfPresent(VNCConnectionConfig.self, forKey: .vncConfig)) ?? nil
+        localConfig = try? container.decodeIfPresent(LocalProfileConfig.self, forKey: .localConfig)
+        themeName = try? container.decodeIfPresent(String.self, forKey: .themeName)
+        themeModifiedAt = try? container.decodeIfPresent(Date.self, forKey: .themeModifiedAt)
         // Early development builds stored the VNC object directly before the
         // versioned envelope was introduced. Preserve those profiles too.
         if vncConfig == nil,
@@ -59,5 +73,83 @@ struct ProfileExtensionPayload: Codable, Hashable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(version, forKey: .version)
         try container.encodeIfPresent(vncConfig, forKey: .vncConfig)
+        try container.encodeIfPresent(localConfig, forKey: .localConfig)
+        try container.encodeIfPresent(themeName, forKey: .themeName)
+        try container.encodeIfPresent(themeModifiedAt, forKey: .themeModifiedAt)
+    }
+}
+
+/// Local profiles sync everywhere; availability controls where they can launch.
+struct LocalProfileConfig: Codable, Hashable, Sendable {
+    enum Platform: String, Codable, CaseIterable, Sendable {
+        case all, macOS, iOS
+
+        var displayName: String {
+            switch self {
+            case .all: return String(localized: "All Devices")
+            case .macOS: return "macOS"
+            case .iOS: return "iOS/iPadOS"
+            }
+        }
+
+        var isAvailable: Bool {
+            #if targetEnvironment(macCatalyst) || os(macOS)
+            return self == .all || self == .macOS
+            #else
+            return self == .all || self == .iOS
+            #endif
+        }
+    }
+
+    var workingDirectory: String?
+    var startupCommand: String?
+    var platform: Platform
+
+    init(workingDirectory: String? = nil, startupCommand: String? = nil, platform: Platform = .all) {
+        self.workingDirectory = workingDirectory
+        self.startupCommand = startupCommand
+        self.platform = platform
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case workingDirectory, startupCommand, platform
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+        startupCommand = try container.decodeIfPresent(String.self, forKey: .startupCommand)
+        platform = try container.decodeIfPresent(Platform.self, forKey: .platform) ?? .all
+    }
+}
+
+/// Independently versioned appearance data. Older clients never materialize its
+/// CloudKit record, so an old writer cannot clear it while editing the profile.
+struct ProfileThemeRecord: SyncableRecord, Sendable {
+    let id: UUID
+    var themeName: String?
+    var modifiedAt: Date
+    var isDeleted: Bool = false
+    /// Local-only acknowledgement. Missing in pre-migration cache files means
+    /// this revision still needs a companion upload.
+    var syncedRevision: Date?
+
+    var needsUpload: Bool { syncedRevision != modifiedAt }
+
+    init?(profile: ConnectionProfile) {
+        guard let revision = profile.extensionPayload?.themeModifiedAt
+                ?? (profile.themeName == nil ? nil : profile.modifiedAt) else { return nil }
+        id = profile.id
+        themeName = profile.themeName
+        modifiedAt = revision
+    }
+
+    func applying(to profile: ConnectionProfile) -> ConnectionProfile {
+        var result = profile
+        var payload = result.extensionPayload ?? ProfileExtensionPayload()
+        payload.themeName = isDeleted ? nil : themeName
+        payload.themeModifiedAt = modifiedAt
+        result.extensionPayload = payload
+        return result
     }
 }

--- a/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
@@ -27,6 +27,8 @@ struct ProfileEditorSheet: View {
     @FocusState private var isTagFieldFocused: Bool
 
     // Connection protocol state
+    @State private var localConfig = LocalProfileConfig()
+    @State private var profileThemeName: String = ""
     @State private var connectionProtocol: ConnectionProtocol = .ssh
 
     // Keeps the host/username/jump fields when the picker flips between the
@@ -228,7 +230,11 @@ struct ProfileEditorSheet: View {
             // Organization Section
             organizationSection
 
-            if connectionProtocol == .vnc {
+            appearanceSection
+
+            if connectionProtocol == .local {
+                localConnectionSection
+            } else if connectionProtocol == .vnc {
                 // Screen Sharing: protocol picker plus the shared VNC form
                 // sections; the SSH-specific sections don't apply.
                 vncConnectionSection
@@ -303,6 +309,7 @@ struct ProfileEditorSheet: View {
         .onAppear {
             loadExistingProfile()
         }
+        .task { await ThemeManager.shared.ensureThemesLoaded() }
         .onChange(of: connectionProtocol) { oldValue, newValue in
             carryEndpointAcrossProtocolChange(from: oldValue, to: newValue)
         }
@@ -512,6 +519,60 @@ struct ProfileEditorSheet: View {
 
     // MARK: - Connection Section
 
+    private var appearanceSection: some View {
+        Section("Appearance") {
+            Picker("Theme", selection: $profileThemeName) {
+                Text("Use Default").tag("")
+                if !profileThemeName.isEmpty,
+                   !ThemeManager.shared.availableThemes.contains(where: { $0.name == profileThemeName }) {
+                    Text("\(profileThemeName) (Unavailable)").tag(profileThemeName)
+                }
+                ForEach(ThemeManager.shared.availableThemes, id: \.name) { theme in
+                    Text(theme.name).tag(theme.name)
+                }
+            }
+            .themedRow()
+            Text("Applied to the entire tab when this profile opens, including split panes.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .themedRow()
+        }
+    }
+
+    private var localConnectionSection: some View {
+        Section {
+            protocolPickerRow
+            Picker("Platform", selection: $localConfig.platform) {
+                ForEach(LocalProfileConfig.Platform.allCases, id: \.self) { platform in
+                    Text(platform.displayName).tag(platform)
+                }
+            }
+            .themedRow()
+            TextField("Starting Directory (Optional)", text: Binding(
+                get: { localConfig.workingDirectory ?? "" },
+                set: { localConfig.workingDirectory = $0.isEmpty ? nil : $0 }
+            ))
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .themedRow()
+            TextField("Startup Command (Optional)", text: Binding(
+                get: { localConfig.startupCommand ?? "" },
+                set: { localConfig.startupCommand = $0.isEmpty ? nil : $0 }
+            ), axis: .vertical)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .themedRow()
+            Text("Uses this device's shell. An empty directory inherits the current local shell's directory. The startup command runs once when you open the profile.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .themedRow()
+        } header: {
+            Text("Local Shell")
+        } footer: {
+            if let protocolConversionNotice { Text(protocolConversionNotice) }
+        }
+    }
+
     /// Protocol picker row shared by the SSH connection section and the
     /// Screen Sharing section (which replaces the SSH fields entirely).
     private var protocolPickerRow: some View {
@@ -538,13 +599,24 @@ struct ProfileEditorSheet: View {
         }
     }
 
-    /// Saving after a switch across the Screen Sharing boundary replaces the
-    /// stored configuration wholesale, so say so before the user commits.
+    /// Crossing the SSH, Screen Sharing, or Local Shell boundary replaces
+    /// the stored configuration, so describe the loss before saving.
     private var protocolConversionNotice: String? {
         guard let existing = existingProfile,
-              (existing.connectionProtocol == .vnc) != (connectionProtocol == .vnc) else {
-            return nil
+              existing.connectionProtocol != connectionProtocol else { return nil }
+        if connectionProtocol == .local {
+            if existing.connectionProtocol == .vnc {
+                return String(localized: "Saving replaces this profile's Screen Sharing settings with Local Shell settings.")
+            }
+            return String(localized: "Saving replaces this profile's SSH settings (keys, port forwards, agent forwarding, terminal options) with Local Shell settings.")
         }
+        if existing.connectionProtocol == .local {
+            if connectionProtocol == .vnc {
+                return String(localized: "Saving replaces this profile's Local Shell settings (directory, startup command, platform) with Screen Sharing settings.")
+            }
+            return String(localized: "Saving replaces this profile's Local Shell settings (directory, startup command, platform) with SSH settings.")
+        }
+        guard (existing.connectionProtocol == .vnc) != (connectionProtocol == .vnc) else { return nil }
         if connectionProtocol == .vnc {
             return String(
                 localized: "Saving replaces this profile's SSH settings (keys, port forwards, agent forwarding, terminal options) with Screen Sharing settings. The hostname is carried over.",
@@ -1551,6 +1623,7 @@ struct ProfileEditorSheet: View {
     // MARK: - Validation
 
     private var isFormValid: Bool {
+        if connectionProtocol == .local { return nameValidationMessage == nil }
         if connectionProtocol == .vnc {
             return nameValidationMessage == nil && vncForm.isValid
         }
@@ -1666,7 +1739,8 @@ struct ProfileEditorSheet: View {
         to newValue: ConnectionProtocol
     ) {
         // SSH / Roam / tssh all share one field set, so nothing to carry.
-        guard (oldValue == .vnc) != (newValue == .vnc) else { return }
+        guard oldValue != .local, newValue != .local,
+              (oldValue == .vnc) != (newValue == .vnc) else { return }
 
         if newValue == .vnc {
             var destination = vncForm.endpoint
@@ -1754,6 +1828,9 @@ struct ProfileEditorSheet: View {
 
             // Load connection protocol and transport mode
             connectionProtocol = profile.connectionProtocol
+            profileThemeName = profile.themeName ?? ""
+            localConfig = profile.localConfig ?? LocalProfileConfig()
+            if profile.connectionProtocol == .local { return }
             trzszTransportMode = profile.trzszTransportMode
 
             // Screen Sharing profiles: populate the VNC form and skip the
@@ -2004,6 +2081,10 @@ struct ProfileEditorSheet: View {
 
     private func saveProfile() {
         errorMessage = nil
+        if connectionProtocol == .local {
+            saveLocalProfile()
+            return
+        }
 
         if connectionProtocol == .vnc {
             saveVNCProfile()
@@ -2213,6 +2294,8 @@ struct ProfileEditorSheet: View {
                 // Switching a Screen Sharing profile to an SSH-family
                 // protocol drops the stale VNC config from the envelope.
                 updated.vncConfig = nil
+                updated.localConfig = nil
+                updated.themeName = profileThemeName.isEmpty ? nil : profileThemeName
                 try profileManager.updateProfile(updated)
             } else {
                 // Create new profile
@@ -2236,7 +2319,47 @@ struct ProfileEditorSheet: View {
                     vpnEnabled: vpnEnabled,
                     vpnDNSServers: vpnDNSServers,
                     vpnExcludedRoutes: vpnExcludedRoutes,
-                    vpnBlockQUIC: vpnBlockQUIC
+                    vpnBlockQUIC: vpnBlockQUIC,
+                    extensionPayload: ProfileExtensionPayload(themeName: profileThemeName.isEmpty ? nil : profileThemeName)
+                )
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func saveLocalProfile() {
+        guard isFormValid else { return }
+        var config = localConfig
+        let directory = config.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        config.workingDirectory = directory?.isEmpty == false ? directory : nil
+        let command = config.startupCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+        config.startupCommand = command?.isEmpty == false ? command : nil
+        let payload = ProfileExtensionPayload(
+            localConfig: config,
+            themeName: profileThemeName.isEmpty ? nil : profileThemeName
+        )
+        do {
+            if let existing = existingProfile {
+                // Construct a clean local profile, retaining identity and usage metadata.
+                let updated = ConnectionProfile(
+                    id: existing.id, name: trimmedName,
+                    sshConfig: ConnectionProfile.localPlaceholderSSHConfig(),
+                    connectionProtocol: .local,
+                    notes: notes.isEmpty ? nil : notes, iconName: iconName,
+                    colorTag: colorTag, folderPath: folderPath, tags: tags,
+                    createdAt: existing.createdAt, lastUsedAt: existing.lastUsedAt,
+                    useCount: existing.useCount, extensionPayload: payload
+                )
+                try profileManager.updateProfile(updated)
+            } else {
+                try profileManager.createProfile(
+                    name: trimmedName, sshConfig: ConnectionProfile.localPlaceholderSSHConfig(),
+                    connectionProtocol: .local,
+                    notes: notes.isEmpty ? nil : notes, iconName: iconName,
+                    colorTag: colorTag, folderPath: folderPath, tags: tags,
+                    extensionPayload: payload
                 )
             }
             dismiss()
@@ -2283,6 +2406,8 @@ struct ProfileEditorSheet: View {
                 updated.tags = tags
                 updated.connectionProtocol = .vnc
                 updated.vncConfig = config
+                updated.localConfig = nil
+                updated.themeName = profileThemeName.isEmpty ? nil : profileThemeName
                 updated.sshConfig = ConnectionProfile.vncPlaceholderSSHConfig(for: config)
                 try profileManager.updateProfile(updated)
             } else {
@@ -2295,7 +2420,7 @@ struct ProfileEditorSheet: View {
                     colorTag: colorTag,
                     folderPath: folderPath,
                     tags: tags,
-                    extensionPayload: ProfileExtensionPayload(vncConfig: config)
+                    extensionPayload: ProfileExtensionPayload(vncConfig: config, themeName: profileThemeName.isEmpty ? nil : profileThemeName)
                 )
             }
             dismiss()

--- a/rootshell/Features/Profiles/Views/ProfileKeyAvailabilityBadge.swift
+++ b/rootshell/Features/Profiles/Views/ProfileKeyAvailabilityBadge.swift
@@ -14,7 +14,7 @@ struct ProfileKeyAvailabilityBadge: View {
     let profile: ConnectionProfile
 
     var body: some View {
-        if !ConnectionKeyResolver.isResolvable(config: profile.sshConfig, profileID: profile.id) {
+        if profile.isSSHBased && !ConnectionKeyResolver.isResolvable(config: profile.sshConfig, profileID: profile.id) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .symbolEffect(.wiggle, options: .repeat(2).speed(0.8))
                 .font(.caption2)

--- a/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
@@ -32,10 +32,14 @@ struct ProfilesBrowseSheet: View {
 
     // Manager
     private var profileManager: ConnectionProfileManager { ConnectionProfileManager.shared }
+    private var availableTags: [ProfileTag] {
+        profileManager.tags(showAllPlatforms: showAllPlatforms)
+    }
 
     // State
     @State private var searchQuery: String = ""
     @State private var selectedTags: Set<String> = []
+    @State private var showAllPlatforms = false
     @State private var showTagFilter: Bool = false
     @Setting(Settings.Connections.profilesSortOrder) private var sortOrder
     @State private var showingNewProfileSheet: Bool = false
@@ -142,6 +146,17 @@ struct ProfilesBrowseSheet: View {
             highlightedIndex = 0
             triggerDNSPrefetch()
         }
+        .onChange(of: Set(availableTags.map(\.name))) { _, names in
+            selectedTags.formIntersection(names)
+            if names.isEmpty { showTagFilter = false }
+        }
+        .onChange(of: profileManager.hasUnavailableProfiles) { _, hasUnavailable in
+            if !hasUnavailable { showAllPlatforms = false }
+        }
+        .onChange(of: showAllPlatforms) { _, _ in
+            highlightedIndex = 0
+            triggerDNSPrefetch()
+        }
         .onChange(of: sortOrder) { _, _ in
             highlightedIndex = 0
         }
@@ -219,6 +234,16 @@ struct ProfilesBrowseSheet: View {
                 Button("Cancel") { dismiss() }
             }
 
+            if profileManager.hasUnavailableProfiles {
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Toggle("Show All Platforms", isOn: $showAllPlatforms)
+                    } label: {
+                        Image(systemName: "line.3.horizontal.decrease.circle")
+                    }
+                    .accessibilityLabel("Platform Filter")
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     presentNewProfileSheet(in: folder)
@@ -312,7 +337,7 @@ struct ProfilesBrowseSheet: View {
             onSubmit: { activateHighlightedItem() }
         ) {
             // Tag filter button (only show if tags exist)
-            if !profileManager.allTags.isEmpty {
+            if !availableTags.isEmpty {
                 Button(action: { showTagFilter = true }) {
                     ZStack(alignment: .topTrailing) {
                         Image(systemName: "tag")
@@ -327,7 +352,7 @@ struct ProfilesBrowseSheet: View {
                 }
                 .popover(isPresented: $showTagFilter, arrowEdge: .top) {
                     TagFilterPopover(
-                        tags: profileManager.allTags,
+                        tags: availableTags,
                         selectedTags: $selectedTags
                     )
                     .themedSubSheet(sheetThemeColors)
@@ -505,7 +530,7 @@ struct ProfilesBrowseSheet: View {
     // MARK: - Filtering
 
     private func filteredFolders(in parentPath: String) -> [ProfileFolder] {
-        profileManager.subfolders(of: parentPath)
+        profileManager.subfolders(of: parentPath, showAllPlatforms: showAllPlatforms)
     }
 
     private func filteredProfiles(in folder: String) -> [ConnectionProfile] {
@@ -524,7 +549,8 @@ struct ProfilesBrowseSheet: View {
             profiles = profileManager.profiles(inFolder: folder)
         }
 
-        return profiles.sorted(by: sortOrder.compare)
+        return profiles.filter { showAllPlatforms || $0.isAvailableOnCurrentPlatform }
+            .sorted(by: sortOrder.compare)
     }
 
     // MARK: - Actions
@@ -543,7 +569,10 @@ struct ProfilesBrowseSheet: View {
     }
 
     private func selectProfile(_ profile: ConnectionProfile) {
-        profileManager.recordUsage(id: profile.id)
+        guard profile.isAvailableOnCurrentPlatform else {
+            editingProfile = profile
+            return
+        }
         onProfileSelected?(ProfileSelection(profile: profile, splitOption: splitOption))
         dismiss()
     }
@@ -630,7 +659,7 @@ struct ProfilesBrowseSheet: View {
 
             var hosts: [String] = []
             for item in items[lower...upper] {
-                if case .profile(let profile) = item {
+                if case .profile(let profile) = item, profile.connectionProtocol != .local {
                     let host = profile.sshConfig.host
                     if !host.isEmpty { hosts.append(host) }
                 }
@@ -702,6 +731,16 @@ struct ProfileRow: View {
                 Text(profile.name)
                     .foregroundColor(.primary)
 
+                if profile.connectionProtocol == .local {
+                    Text(profile.localConfig?.platform.displayName ?? String(localized: "Unavailable"))
+                        .font(.caption)
+                        .foregroundStyle(profile.isAvailableOnCurrentPlatform ? Color.secondary : Color.orange)
+                    if !profile.isAvailableOnCurrentPlatform {
+                        Text("Unavailable on this device · Tap to edit")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 Text(profile.displayString)
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/rootshell/Features/QuickConnect/ProfileSuggestion.swift
+++ b/rootshell/Features/QuickConnect/ProfileSuggestion.swift
@@ -19,6 +19,7 @@ struct ProfileSuggestion: QuickConnectSuggestion {
 
     /// Complete with the connection string (vnc:// URL for Screen Sharing)
     var completionString: String {
+        if profile.connectionProtocol == .local { return profile.name }
         if profile.connectionProtocol == .vnc {
             let config = profile.vncConfig
             let host = config?.host ?? profile.sshConfig.host
@@ -35,6 +36,10 @@ struct ProfileSuggestion: QuickConnectSuggestion {
 
     var detailText: String? {
         var parts: [String] = []
+
+        if profile.connectionProtocol == .local {
+            parts.append(profile.displayString)
+        }
 
         // Show protocol if Mosh or Screen Sharing
         if profile.connectionProtocol == .mosh {

--- a/rootshell/Features/QuickConnect/QuickConnectSuggestionProvider.swift
+++ b/rootshell/Features/QuickConnect/QuickConnectSuggestionProvider.swift
@@ -65,16 +65,22 @@ class QuickConnectSuggestionProvider: ObservableObject {
 
     // MARK: - Public API
 
+    enum Context {
+        case connectionLauncher
+        case sshDestination
+    }
+
     /// Get unified suggestions matching search text
     func getSuggestions(
         matching searchText: String,
-        mode: MatchingMode = .prefix
+        mode: MatchingMode = .prefix,
+        context: Context = .connectionLauncher
     ) -> [AnyQuickConnectSuggestion] {
         var all: [AnyQuickConnectSuggestion] = []
 
         // Profile suggestions (highest priority)
-        let profiles = profileManager.profiles
-            .filter { !$0.isDeleted }
+        let profiles = profileManager.availableProfiles
+            .filter { !$0.isDeleted && (context == .connectionLauncher || $0.isSSHBased) }
             .map { ProfileSuggestion(profile: $0) }
             .filter { searchText.isEmpty || $0.matches(searchText, mode: mode) }
             .map { AnyQuickConnectSuggestion($0) }
@@ -82,6 +88,7 @@ class QuickConnectSuggestionProvider: ObservableObject {
 
         // History suggestions
         let history = historyManager.entries
+            .filter { context == .connectionLauncher || ($0.connectionProtocol != .vnc && $0.connectionProtocol != .local) }
             .map { HistorySuggestion(entry: $0) }
             .filter { searchText.isEmpty || $0.matches(searchText, mode: mode) }
             .map { AnyQuickConnectSuggestion($0) }
@@ -89,6 +96,7 @@ class QuickConnectSuggestionProvider: ObservableObject {
 
         // Local network (mDNS) suggestions
         let localNetwork = makeLocalNetworkSuggestions()
+            .filter { context == .connectionLauncher || $0.host.kind == .ssh }
             .filter { searchText.isEmpty || $0.matches(searchText, mode: mode) }
             .map { AnyQuickConnectSuggestion($0) }
         all.append(contentsOf: localNetwork)

--- a/rootshell/Features/SSH/Views/SSHConnectionView+VNC.swift
+++ b/rootshell/Features/SSH/Views/SSHConnectionView+VNC.swift
@@ -60,6 +60,7 @@ extension SSHConnectionView {
     func applyVNCProfile(_ profile: ConnectionProfile) {
         guard let config = profile.vncConfig else { return }
 
+        quickConnectProfile = profile
         connectionType = .vnc
         vncForm = VNCFormState(config: config)
 
@@ -68,11 +69,11 @@ extension SSHConnectionView {
             vncForm.password = saved
         }
 
-        ConnectionProfileManager.shared.recordUsage(id: profile.id)
     }
 
     /// Populate the VNC form from a discovered host or vnc:// quick connect.
     func applyVNCTarget(hostname: String, port: Int?) {
+        quickConnectProfile = nil
         connectionType = .vnc
         var form = VNCFormState()
         form.hostname = hostname
@@ -146,7 +147,15 @@ extension SSHConnectionView {
             }
         }
 
-        onVNCConnect?(config, splitOption)
+        if var profile = quickConnectProfile,
+           profile.connectionProtocol == .vnc,
+           profile.vncConfig?.host == config.host,
+           let onProfileConnect {
+            profile.vncConfig = config
+            onProfileConnect(profile, splitOption)
+        } else {
+            onVNCConnect?(config, splitOption)
+        }
         close()
     }
 }

--- a/rootshell/Features/SSH/Views/SSHConnectionView.swift
+++ b/rootshell/Features/SSH/Views/SSHConnectionView.swift
@@ -22,6 +22,7 @@ struct SSHConnectionView: View {
     
     // Split option for how to open the connection
     // (internal: shared with the Screen Sharing form extension)
+    @State var quickConnectProfile: ConnectionProfile?
     @State var splitOption: SplitOption = .newTab
     
     // Kubernetes-specific state
@@ -688,7 +689,7 @@ struct SSHConnectionView: View {
                 // Screen Sharing has its own connection tab; the terminal
                 // protocols are the only valid choices here.
                 Picker("Protocol", selection: $connectionProtocol) {
-                    ForEach(ConnectionProtocol.allCases.filter { $0 != .vnc }, id: \.self) { proto in
+                    ForEach(ConnectionProtocol.allCases.filter { $0 != .vnc && $0 != .local }, id: \.self) { proto in
                         Label(proto.displayName, systemImage: proto.iconName).tag(proto)
                     }
                 }
@@ -2149,6 +2150,18 @@ struct SSHConnectionView: View {
             )
         }
         
+        // Preserve the profile's theme and provenance when its populated form opens.
+        if var profile = quickConnectProfile,
+           profile.sshConfig.host == config.host,
+           profile.sshConfig.username == config.username,
+           profile.connectionProtocol == connectionProtocol,
+           let onProfileConnect {
+            profile.sshConfig = config
+            onProfileConnect(profile, splitOption)
+            close()
+            return
+        }
+
         // Call the appropriate connection callback based on connection type
         if connectionProtocol == .mosh, let moshCallback = onMoshConnect {
             // Create MoshConfig from SSHConfig
@@ -2597,6 +2610,7 @@ struct SSHConnectionView: View {
     }
     
     private func handleProfileAccepted(_ profile: ConnectionProfile) {
+        quickConnectProfile = profile
         let config = profile.sshConfig
         
         // Set protocol from profile
@@ -2727,12 +2741,11 @@ struct SSHConnectionView: View {
                                 username: config.username,
                                 port: config.port)
 
-        // Record usage
-        ConnectionProfileManager.shared.recordUsage(id: profile.id)
     }
     
     /// Handle unified suggestion acceptance (history or cloud instance)
     private func handleUnifiedSuggestionAccepted(_ suggestion: AnyQuickConnectSuggestion) {
+        quickConnectProfile = nil
         // Defer setting suggestion detail and cloud label until after SwiftUI's update cycle
         // processes the text change. This prevents updateFieldsFromQuickConnect (triggered by
         // .onChange) from immediately clearing these values after we set them.
@@ -2820,7 +2833,11 @@ struct SSHConnectionView: View {
                 // Find the profile and apply its config (VNC profiles switch
                 // to the Screen Sharing form instead of the SSH fields)
                 if let profile = ConnectionProfileManager.shared.profiles.first(where: { $0.id == suggestion.id }) {
-                    if profile.connectionProtocol == .vnc {
+                    if profile.connectionProtocol == .local {
+                        guard profile.isAvailableOnCurrentPlatform else { return }
+                        onProfileConnect?(profile, splitOption)
+                        close()
+                    } else if profile.connectionProtocol == .vnc {
                         applyVNCProfile(profile)
                     } else {
                         handleProfileAccepted(profile)
@@ -2832,6 +2849,7 @@ struct SSHConnectionView: View {
     
     /// Apply selection from the host browse sheet
     private func applyBrowseSelection(_ selection: BrowseHostSelection) {
+        quickConnectProfile = nil
         // Discovered Screen Sharing hosts go straight to the VNC form; the
         // SSH auth/username restoration below doesn't apply to them.
         if selection.serviceKind == .vnc {
@@ -3710,6 +3728,9 @@ extension SSHConnectionView {
         
         // Manager
         private var profileManager: ConnectionProfileManager { ConnectionProfileManager.shared }
+        private var availableTags: [ProfileTag] {
+            profileManager.tags(showAllPlatforms: showAllPlatforms)
+        }
         
         // Split option binding from parent
         @Binding var splitOption: SSHConnectionView.SplitOption
@@ -3717,6 +3738,7 @@ extension SSHConnectionView {
         // State
         @State private var searchQuery: String = ""
         @State private var selectedTags: Set<String> = []
+        @State private var showAllPlatforms = false
         @State private var showTagFilter: Bool = false
         @State private var showingNewProfileSheet: Bool = false
         @State private var editingProfile: ConnectionProfile?
@@ -3805,6 +3827,16 @@ extension SSHConnectionView {
                 .onChange(of: selectedTags) { _, _ in
                     highlightedIndex = 0
                 }
+                .onChange(of: Set(availableTags.map(\.name))) { _, names in
+                    selectedTags.formIntersection(names)
+                    if names.isEmpty { showTagFilter = false }
+                }
+                .onChange(of: profileManager.hasUnavailableProfiles) { _, hasUnavailable in
+                    if !hasUnavailable { showAllPlatforms = false }
+                }
+                .onChange(of: showAllPlatforms) { _, _ in
+                    highlightedIndex = 0
+                }
                 .onChange(of: sortOrder) { _, _ in
                     highlightedIndex = 0
                 }
@@ -3815,6 +3847,16 @@ extension SSHConnectionView {
                     ProfileEditorSheet(profile: profile, embedded: true)
                 }
                 .toolbar {
+                    if profileManager.hasUnavailableProfiles {
+                        ToolbarItem(placement: .primaryAction) {
+                            Menu {
+                                Toggle("Show All Platforms", isOn: $showAllPlatforms)
+                            } label: {
+                                Image(systemName: "line.3.horizontal.decrease.circle")
+                            }
+                            .accessibilityLabel("Platform Filter")
+                        }
+                    }
                     ToolbarItem(placement: .primaryAction) {
                         Button {
                             presentNewProfileSheet(in: currentFolder)
@@ -3958,7 +4000,7 @@ extension SSHConnectionView {
                 onSubmit: { activateHighlightedItem() }
             ) {
                 // Tag filter button (only show if tags exist)
-                if !profileManager.allTags.isEmpty {
+                if !availableTags.isEmpty {
                     Button(action: { showTagFilter = true }) {
                         ZStack(alignment: .topTrailing) {
                             Image(systemName: "tag")
@@ -3973,7 +4015,7 @@ extension SSHConnectionView {
                     }
                     .popover(isPresented: $showTagFilter, arrowEdge: .top) {
                         TagFilterPopover(
-                            tags: profileManager.allTags,
+                            tags: availableTags,
                             selectedTags: $selectedTags
                         )
                         .themedSubSheet(sheetThemeColors)
@@ -4174,7 +4216,7 @@ extension SSHConnectionView {
         // MARK: - Filtering
         
         private func filteredFolders(in parentPath: String) -> [ProfileFolder] {
-            profileManager.subfolders(of: parentPath)
+            profileManager.subfolders(of: parentPath, showAllPlatforms: showAllPlatforms)
         }
         
         private func filteredProfiles(in folder: String) -> [ConnectionProfile] {
@@ -4193,7 +4235,8 @@ extension SSHConnectionView {
                 profiles = profileManager.profiles(inFolder: folder)
             }
             
-            return profiles.sorted(by: sortOrder.compare)
+            return profiles.filter { showAllPlatforms || $0.isAvailableOnCurrentPlatform }
+                .sorted(by: sortOrder.compare)
         }
         
         // MARK: - Actions
@@ -4212,7 +4255,10 @@ extension SSHConnectionView {
         }
         
         private func selectProfile(_ profile: ConnectionProfile) {
-            profileManager.recordUsage(id: profile.id)
+            guard profile.isAvailableOnCurrentPlatform else {
+                editingProfile = profile
+                return
+            }
             onProfileSelected(profile, splitOption)
         }
         

--- a/rootshell/Features/Tunnel/BackgroundTunnel.swift
+++ b/rootshell/Features/Tunnel/BackgroundTunnel.swift
@@ -191,9 +191,9 @@ final class BackgroundTunnel {
                 try await connect(using: resolvedConfig)
                 await startPortForwards()
                 startHealthMonitoring()
-            case .vnc:
+            case .vnc, .local:
                 // VNC profiles are never VPN-capable (isVPNCapable excludes them)
-                throw TunnelError.connectionFailed("Screen Sharing profiles cannot run tunnels")
+                throw TunnelError.connectionFailed("This profile type cannot run tunnels")
             }
             transition(to: .connected)
             reconnectionManager?.handleConnected()
@@ -689,9 +689,9 @@ final class BackgroundTunnel {
                 try await self.connect(using: resolvedConfig)
                 await self.startPortForwards()
                 self.startHealthMonitoring()
-            case .vnc:
+            case .vnc, .local:
                 // VNC profiles are never VPN-capable (isVPNCapable excludes them)
-                throw TunnelError.connectionFailed("Screen Sharing profiles cannot run tunnels")
+                throw TunnelError.connectionFailed("This profile type cannot run tunnels")
             }
 
             // stop() may have run while the connect was awaiting (cooperative

--- a/rootshell/Features/VNC/Views/MainAlertController.swift
+++ b/rootshell/Features/VNC/Views/MainAlertController.swift
@@ -34,6 +34,7 @@ import UserNotifications
         case newHost
         case keyChanged
         case helperMissing
+        case profileUnavailable
         case vncProfileInvalid
         case vncHighPerformanceTransport
         case vncCertificate
@@ -59,6 +60,7 @@ import UserNotifications
     var validationData: MainView.ValidationData?
 
     var showHelperMissingAlert = false
+    var showProfileUnavailableAlert = false
 
     /// A shared file failed to import (see FileOpenCoordinator).
     var fileOpenErrorMessage: String?
@@ -186,6 +188,8 @@ import UserNotifications
             return showKeyChangedAlert
         case .helperMissing:
             return showHelperMissingAlert
+        case .profileUnavailable:
+            return showProfileUnavailableAlert
         case .vncProfileInvalid:
             return showVNCProfileInvalidAlert
         case .vncHighPerformanceTransport:
@@ -269,6 +273,8 @@ import UserNotifications
             showKeyChangedAlert = false
         case .helperMissing:
             showHelperMissingAlert = false
+        case .profileUnavailable:
+            showProfileUnavailableAlert = false
         case .vncProfileInvalid:
             showVNCProfileInvalidAlert = false
         case .vncHighPerformanceTransport:

--- a/rootshell/Features/VNC/Views/PaneFullScreenController.swift
+++ b/rootshell/Features/VNC/Views/PaneFullScreenController.swift
@@ -272,7 +272,7 @@ final class PaneFullScreenController {
             return
         }
 
-        let overlay = VNCPaneThemedSurface(windowId: pane.windowId) {
+        let overlay = VNCPaneThemedSurface(pane: pane) {
             VNCConnectionFailureCard(
                 subtitle: pane.config.displayName,
                 message: message,

--- a/rootshell/Features/VNC/Views/VNCPaneView.swift
+++ b/rootshell/Features/VNC/Views/VNCPaneView.swift
@@ -197,8 +197,14 @@ final class VNCPaneView: SplitPaneView, ObservableObject {
     /// user chose not to save it. Consumed by the first connect attempt.
     var pendingPassword: String?
 
-    /// Window this pane currently belongs to (bookkeeping only in v1).
-    private(set) var windowId: String
+    /// Window this pane currently belongs to, including its theme context.
+    private(set) var windowId: String {
+        didSet { objectWillChange.send() }
+    }
+
+    override var containingTabID: UUID? {
+        didSet { objectWillChange.send() }
+    }
 
     /// Set by PaneFullScreenController while this pane is checked out for
     /// the in-window full-screen takeover, so close/retarget flows can reach
@@ -1256,7 +1262,7 @@ struct VNCPaneRootView: View {
         // glass tint and scheme, and hostOwnsRecoveryChrome suppresses the
         // package's reconnect/failure cards that would otherwise show
         // through rootshell's clear-glass cards as duplicates.
-        VNCPaneThemedSurface(windowId: pane.windowId) {
+        VNCPaneThemedSurface(pane: pane) {
             ZStack {
                 RemoteDesktopView(
                     session: pane.session,
@@ -1301,23 +1307,22 @@ struct VNCPaneRootView: View {
 
 // MARK: - Pane Theme
 
-/// Window-scoped mirror of MainView's sheet-theme resolution for surfaces
+/// Pane-context mirror of MainView's sheet-theme resolution for surfaces
 /// hosted inside the pane's own UIHostingController, where the sheet theme
-/// environment is never installed. Tab-level theme overrides don't apply
-/// (VNC panes aren't terminal tabs); window overrides and per-theme UI
-/// overrides do.
+/// environment is never installed. Resolve the containing tab so profile,
+/// tab, window, and per-theme UI overrides also reach the pane chrome.
 struct VNCPaneTheme {
     let accent: Color?
     let background: Color?
     let colorScheme: ColorScheme?
 
-    static func resolve(windowId: String, themedUIEnabled: Bool) -> VNCPaneTheme {
+    static func resolve(tabId: UUID?, windowId: String, themedUIEnabled: Bool) -> VNCPaneTheme {
         guard themedUIEnabled else {
             return VNCPaneTheme(accent: nil, background: nil, colorScheme: nil)
         }
         let themeManager = ThemeManager.shared
         let (themeName, _) = ThemeOverrideManager.shared.resolveTheme(
-            tabId: nil,
+            tabId: tabId,
             windowId: windowId
         )
         let colors = themeName == themeManager.currentTheme
@@ -1365,7 +1370,7 @@ extension EnvironmentValues {
 /// belongs on rootshell's dialog cards (VNCOverlayCard applies it), not on
 /// the package's HUD menu, where theme tinting proved a bad fit.
 struct VNCPaneThemedSurface<Content: View>: View {
-    let windowId: String
+    @ObservedObject var pane: VNCPaneView
     @ViewBuilder let content: () -> Content
 
     @Setting(Settings.Theme.themedUI) private var themedUIEnabled
@@ -1373,7 +1378,8 @@ struct VNCPaneThemedSurface<Content: View>: View {
 
     var body: some View {
         let theme = VNCPaneTheme.resolve(
-            windowId: windowId,
+            tabId: pane.containingTabID,
+            windowId: pane.windowId,
             themedUIEnabled: themedUIEnabled
         )
         content()

--- a/rootshell/UI/Shell/MainView+Alerts.swift
+++ b/rootshell/UI/Shell/MainView+Alerts.swift
@@ -36,6 +36,8 @@ extension MainView {
             return alerts.validationData?.alertTitle ?? "⚠️ WARNING: Host Key Changed"
         case .helperMissing:
             return String(localized: "Rootshell Helper Required", comment: "Standalone helper alert title")
+        case .profileUnavailable:
+            return String(localized: "Profile Unavailable")
         case .vncProfileInvalid:
             return String(localized: "Screen Sharing Unavailable", comment: "Alert title for a VNC profile without a usable configuration")
         case .vncHighPerformanceTransport:
@@ -151,7 +153,7 @@ extension MainView {
                     Button("OK", role: .cancel) {
                         alerts.dismissActive()
                     }
-                case .vncProfileInvalid:
+                case .profileUnavailable, .vncProfileInvalid:
                     Button("OK", role: .cancel) {
                         alerts.dismissActive()
                     }
@@ -243,6 +245,8 @@ extension MainView {
                     }
                 case .helperMissing:
                     Text("Local shells on Mac require the separate Rootshell Helper app. Launch the helper and try again.")
+                case .profileUnavailable:
+                    Text("This local profile is unavailable on this device. Enable Show All Platforms in Profiles to edit its platform or repair its settings.")
                 case .vncProfileInvalid:
                     Text("This profile has no usable Screen Sharing configuration. It may have been created by a newer version of the app - edit the profile or update the app.")
                 case .vncHighPerformanceTransport:

--- a/rootshell/UI/Shell/MainView+ConnectionSheet.swift
+++ b/rootshell/UI/Shell/MainView+ConnectionSheet.swift
@@ -248,6 +248,16 @@ extension MainView {
     }
 
     func connectToProfile(_ profile: ConnectionProfile, splitOption: SSHConnectionView.SplitOption) {
+        guard !profile.isDeleted, profile.isAvailableOnCurrentPlatform else {
+            alerts.showProfileUnavailableAlert = true
+            alerts.enqueue(.profileUnavailable)
+            return
+        }
+        if profile.connectionProtocol == .local {
+            ConnectionProfileManager.shared.recordUsage(id: profile.id)
+            createLocalProfile(profile, splitOption: splitOption)
+            return
+        }
         // Record usage
         ConnectionProfileManager.shared.recordUsage(id: profile.id)
 
@@ -356,7 +366,9 @@ extension MainView {
             return
         }
 
-        if vncConfig.security == .none || VNCPasswordManager.shared.hasPassword(for: vncConfig) {
+        if let password = VNCPasswordManager.shared.takeEphemeralPassword(for: vncConfig.passwordKey) {
+            handleVNCConnection(config: vncConfig, splitOption: splitOption, sourceProfileID: profile.id, password: password)
+        } else if vncConfig.security == .none || VNCPasswordManager.shared.hasPassword(for: vncConfig) {
             handleVNCConnection(config: vncConfig, splitOption: splitOption, sourceProfileID: profile.id)
         } else {
             passwordPromptProfile = profile
@@ -375,7 +387,11 @@ extension MainView {
         }
 
         if let override = request.launchCommandOverride {
-            profile.sshConfig.launchCommand = override
+            if profile.connectionProtocol == .local {
+                profile.localConfig?.startupCommand = override
+            } else {
+                profile.sshConfig.launchCommand = override
+            }
         }
 
         connectToProfile(profile, splitOption: .newTab)
@@ -413,7 +429,7 @@ extension MainView {
             case .unresolved(let partialConfig, let unresolvedKeys):
                 keyResolutionConfig = partialConfig
                 keyResolutionUnresolvedKeys = unresolvedKeys
-                keyResolutionProfileID = nil
+                keyResolutionProfileID = sourceProfileID
                 keyResolutionConnectionIdentity = nil
                 keyResolutionProtocol = connectionProtocol
                 keyResolutionTransportMode = trzszTransportMode
@@ -428,6 +444,11 @@ extension MainView {
         }
 
         switch connectionProtocol {
+        case .local:
+            if let sourceProfileID,
+               let profile = ConnectionProfileManager.shared.profile(for: sourceProfileID) {
+                connectToProfile(profile, splitOption: splitOption)
+            }
         case .mosh:
             // Create Mosh connection
             let moshConfig = MoshConfig(sshConfig: config)

--- a/rootshell/UI/Shell/MainView+TabManagement.swift
+++ b/rootshell/UI/Shell/MainView+TabManagement.swift
@@ -162,7 +162,8 @@ extension MainView {
         insertPaneAsTab(
             terminalView,
             title: title,
-            suppressesTabBarAnimation: suppressesTabBarAnimation
+            suppressesTabBarAnimation: suppressesTabBarAnimation,
+            profileThemeSourceID: sourceProfileID
         )
     }
 
@@ -175,10 +176,12 @@ extension MainView {
     func insertPaneAsTab(
         _ pane: SplitPaneView,
         title: String,
-        suppressesTabBarAnimation: Bool = false
+        suppressesTabBarAnimation: Bool = false,
+        profileThemeSourceID: UUID? = nil
     ) {
         let newTab = TerminalTab(paneView: pane, title: title, windowId: windowId)
         pane.containingTabID = newTab.id
+        applyProfileTheme(profileID: profileThemeSourceID, tabID: newTab.id)
 
         // Insert tab after current tab (not at end)
         let insertionIndex = min(selectedTabIndex + 1, terminals.count)
@@ -233,8 +236,9 @@ extension MainView {
         direction: SplitTree<SplitPaneView>.NewDirection,
         logLabel: String,
         sourceProfileID: UUID? = nil,
-        configFor: (SplitPaneView) -> ConnectionConfig,
-        fallbackToTab: () -> Void
+        startupCommand: String? = nil,
+        configFor: @MainActor (SplitPaneView) -> ConnectionConfig,
+        fallbackToTab: @MainActor () -> Void
     ) {
         guard terminals.indices.contains(selectedTabIndex) else {
             // No tab exists, create a new tab instead
@@ -265,12 +269,15 @@ extension MainView {
             sourceProfileID: sourceProfileID
         )
 
+        newTerminalView.pendingStartupCommand = startupCommand
+
         insertPaneAsSplit(
             newTerminalView,
             at: targetPane,
             inTab: selectedTabIndex,
             direction: direction,
-            logLabel: logLabel
+            logLabel: logLabel,
+            profileThemeSourceID: sourceProfileID
         )
     }
 
@@ -283,7 +290,8 @@ extension MainView {
         at targetPane: SplitPaneView,
         inTab tabIndex: Int,
         direction: SplitTree<SplitPaneView>.NewDirection,
-        logLabel: String
+        logLabel: String,
+        profileThemeSourceID: UUID? = nil
     ) {
         pane.containingTabID = terminals[tabIndex].id
 
@@ -295,11 +303,22 @@ extension MainView {
                 direction: direction
             )
 
+            applyProfileTheme(profileID: profileThemeSourceID, tabID: terminals[tabIndex].id)
+
             // Set focus immediately - Ghostty focus is independent of UIKit focus
             setFocusedPane(pane, inTab: tabIndex)
         } catch {
             Ghostty.logger.error("Failed to create \(logLabel) split: \(error)")
         }
+    }
+
+    /// Only explicit launches pass a profile ID here. Restore and pane moves
+    /// retain their saved/user-selected tab override instead of reapplying it.
+    private func applyProfileTheme(profileID: UUID?, tabID: UUID) {
+        guard let profileID,
+              let name = ConnectionProfileManager.shared.profile(for: profileID)?.themeName,
+              ThemeManager.shared.themeInfo(for: name) != nil else { return }
+        themeOverrideManager.setTabTheme(tabId: tabID, themeName: name)
     }
 
     // MARK: - Per-Protocol Creators
@@ -338,7 +357,7 @@ extension MainView {
 
     /// Ensures ghostty-helper is available before running a local shell action on Catalyst
     /// Will auto-launch helper if running in non-sandboxed mode
-    func performLocalShellAction(description: String, action: @escaping () -> Void) {
+    func performLocalShellAction(description: String, action: @escaping @MainActor () -> Void) {
 #if targetEnvironment(macCatalyst)
         // Fast path: when the helper has already been confirmed running, run
         // the action synchronously instead of awaiting ensureHelperRunning()
@@ -409,8 +428,16 @@ extension MainView {
         switch terminal.connectionConfig {
         case .local:
             // A stale tmux surface is not a real local shell.
-            return NewTabRequest(target: terminal.isTmuxPane ? .connections : .local,
-                                 localDirectory: terminal.isTmuxPane ? nil : terminal.pwd)
+            guard !terminal.isTmuxPane else {
+                return NewTabRequest(target: .connections, localDirectory: nil)
+            }
+            if let profileID = terminal.sourceProfileID {
+                return NewTabRequest(
+                    target: .connection(.local(workingDirectory: terminal.pwd), profileID),
+                    localDirectory: terminal.pwd
+                )
+            }
+            return NewTabRequest(target: .local, localDirectory: terminal.pwd)
         case .trzszTransfer:
             return NewTabRequest(target: .connections, localDirectory: nil)
         default:
@@ -468,6 +495,11 @@ extension MainView {
             // profile provenance rather than re-reading an edited saved profile.
             let config = original.forNewSplit()
             switch config {
+            case .local:
+                performLocalShellAction(description: "duplicate a local shell") {
+                    self.openTerminalTab(config: config, title: config.displayName,
+                                         sourceProfileID: profileID, suppressesTabBarAnimation: true)
+                }
             case .vnc(let vnc):
                 createVNCTab(with: vnc, sourceProfileID: profileID)
             case .mosh(let mosh), .shellLaunchedMosh(let mosh, _):
@@ -480,6 +512,53 @@ extension MainView {
                 addNewTab()
             default:
                 openTerminalTab(config: config, title: config.displayName, sourceProfileID: profileID)
+            }
+        }
+    }
+
+    func createLocalProfile(_ profile: ConnectionProfile, splitOption: SSHConnectionView.SplitOption) {
+        guard profile.isAvailableOnCurrentPlatform, let local = profile.localConfig else { return }
+        performLocalShellAction(description: "open a local shell profile") {
+            let configuredDirectory = local.workingDirectory.flatMap { raw -> String? in
+                guard let path = Self.resolveIntentDirectory(raw) else { return nil }
+                #if targetEnvironment(macCatalyst)
+                // The helper exits if chdir fails; use HOME for a missing
+                // directory (common when a profile syncs to another Mac).
+                var isDirectory: ObjCBool = false
+                if !FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+                    || !isDirectory.boolValue {
+                    return Self.resolveIntentDirectory("~")
+                }
+                #endif
+                return path
+            }
+            @MainActor func inheritedDirectory(from pane: SplitPaneView?) -> String? {
+                guard let terminal = pane?.asTerminal,
+                      case .local = terminal.connectionConfig else { return nil }
+                return terminal.pwd
+            }
+            let openTab: @MainActor () -> Void = {
+                let focused = self.terminals.indices.contains(self.selectedTabIndex)
+                    ? self.terminals[self.selectedTabIndex].focusedPane : nil
+                self.openTerminalTab(
+                    config: .local(workingDirectory: configuredDirectory ?? inheritedDirectory(from: focused)),
+                    title: profile.name, sourceProfileID: profile.id,
+                    suppressesTabBarAnimation: true, startupCommand: local.startupCommand
+                )
+            }
+            switch splitOption {
+            case .newTab:
+                openTab()
+            case .splitRight, .splitDown:
+                self.openTerminalSplit(
+                    direction: splitOption == .splitRight ? .right : .down,
+                    logLabel: "local profile", sourceProfileID: profile.id,
+                    startupCommand: local.startupCommand,
+                    configFor: { pane in
+                        .local(workingDirectory: configuredDirectory ?? inheritedDirectory(from: pane))
+                    },
+                    fallbackToTab: openTab
+                )
             }
         }
     }

--- a/rootshell/UI/Shell/MainView+VNC.swift
+++ b/rootshell/UI/Shell/MainView+VNC.swift
@@ -64,7 +64,7 @@ extension MainView {
     /// handoff from a profile password prompt (not saved to the Keychain).
     func createVNCTab(with config: VNCConnectionConfig, sourceProfileID: UUID? = nil, password: String? = nil) {
         let pane = makeVNCPane(config: config, sourceProfileID: sourceProfileID, password: password)
-        insertPaneAsTab(pane, title: config.displayName)
+        insertPaneAsTab(pane, title: config.displayName, profileThemeSourceID: sourceProfileID)
     }
 
     /// Open a Screen Sharing session as a split of the focused pane in the
@@ -98,7 +98,8 @@ extension MainView {
             at: targetPane,
             inTab: selectedTabIndex,
             direction: direction,
-            logLabel: "VNC"
+            logLabel: "VNC",
+            profileThemeSourceID: sourceProfileID
         )
     }
 }


### PR DESCRIPTION
Support platform-aware profiles, local launch settings, and profile themes. Preserve synced themes without CloudKit schema changes. Update profile browsing, completions, Shortcuts, and tab duplication.