### PR TITLE
Speed up cold launch by deferring non-critical startup work

### DIFF
--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -586,6 +586,13 @@ class CatalystAppDelegate: AppDelegate {
         // then falls back to false (treated as a new window), which is harmless.
         if ProtectedDataGuard.isAvailable {
             WindowStateManager.shared.ensureStateLoaded()
+
+            // Overlap helper spawn with Ghostty/UI init so the first local shell
+            // is not serialized behind MainView.onAppear. Concurrent callers share
+            // one in-flight ensure via HelperConnection.
+            Task {
+                _ = await HelperConnection.shared.ensureHelperRunning()
+            }
         }
 
         return true

--- a/rootshell/App/RootShellApp.swift
+++ b/rootshell/App/RootShellApp.swift
@@ -68,7 +68,7 @@ struct RootShellApp: App {
         guard ProtectedDataGuard.isAvailable else { return }
 
         // Initialize FontManager early to register the selected font
-        // before Ghostty surfaces try to use it (full catalog loads after first frame)
+        // before Ghostty surfaces try to use it (full catalog loads on a worker)
         _ = FontManager.shared
 
         // Initialize RemoteSessionTracker early to ensure notification observer

--- a/rootshell/App/RootShellApp.swift
+++ b/rootshell/App/RootShellApp.swift
@@ -50,6 +50,9 @@ struct RootShellApp: App {
     @MainActor private static var didRunAppStartupTasks = false
 
     init() {
+        let appInit = LaunchSignposts.begin("launch.appInit")
+        defer { LaunchSignposts.end("launch.appInit", appInit) }
+
         // AppIconManager is instantiated OUTSIDE the ProtectedDataGuard because
         // on Mac Catalyst the dock icon is a runtime-only assignment that must
         // be reapplied every launch. Its internal UserDefaults reads are
@@ -64,8 +67,8 @@ struct RootShellApp: App {
         // the real settings with zeros/nils.
         guard ProtectedDataGuard.isAvailable else { return }
 
-        // Initialize FontManager early to register bundled fonts
-        // before Ghostty surfaces try to use them
+        // Initialize FontManager early to register the selected font
+        // before Ghostty surfaces try to use it (full catalog loads after first frame)
         _ = FontManager.shared
 
         // Initialize RemoteSessionTracker early to ensure notification observer
@@ -77,22 +80,12 @@ struct RootShellApp: App {
         _ = LiveActivityManager.shared
         #endif
 
-        // Register notification categories for interactive notifications
-        NotificationManager.shared.registerNotificationCategories()
-
         // Initialize DayNightThemeManager early so it can apply the correct
         // theme on launch and begin observing system appearance changes
         _ = DayNightThemeManager.shared
 
-        // Force-instantiate LocationDiaryManager up front. We removed it from
-        // the App's @StateObject list so its per-update @Published mutations
-        // can't invalidate the App's scene list, but the singleton still needs
-        // to be alive at launch to restore persisted auto-mode tracking.
-        // macOS has no location-diary feature (no background keepalive needed),
-        // so don't spin up the singleton and its timers there.
-        #if !targetEnvironment(macCatalyst)
-        _ = LocationDiaryManager.shared
-        #endif
+        // Notification categories and LocationDiaryManager are started from the
+        // once-per-launch WindowGroup `.task` — they are not needed before first paint.
     }
 
     var body: some Scene {
@@ -114,6 +107,19 @@ struct RootShellApp: App {
                     // window open and made new windows slow.
                     guard !Self.didRunAppStartupTasks else { return }
                     Self.didRunAppStartupTasks = true
+                    LaunchSignposts.event("app.startupTask.begin")
+
+                    // Register notification categories (deferred from App.init —
+                    // not required before first paint).
+                    NotificationManager.shared.registerNotificationCategories()
+
+                    // Force-instantiate LocationDiaryManager once the first window
+                    // exists. Kept out of App.init / @StateObject so its per-update
+                    // @Published mutations can't invalidate the App scene list.
+                    // macOS has no location-diary feature.
+                    #if !targetEnvironment(macCatalyst)
+                    _ = LocationDiaryManager.shared
+                    #endif
 
                     // Re-check day/night theme now that the window exists and
                     // Ghostty.App is subscribed to themeDidChange. The initial
@@ -158,6 +164,7 @@ struct RootShellApp: App {
 
                     // Auto-start enabled background tunnels
                     await BackgroundTunnelManager.shared.startEnabledTunnels()
+                    LaunchSignposts.event("app.startupTask.end")
                 }
                 .onOpenURL { url in
                     // Handle rootshell://vpn/connect/<profileID>

--- a/rootshell/Core/Diagnostics/LaunchSignposts.swift
+++ b/rootshell/Core/Diagnostics/LaunchSignposts.swift
@@ -1,0 +1,54 @@
+import Foundation
+import os
+
+/// os_signpost intervals for cold-launch phases. Visible in Instruments under
+/// subsystem `com.rootshell`, category `Launch`. Near-zero cost when not traced.
+///
+/// Also emits `Logger` info lines with wall-clock ms since process start so a
+/// Console / lifecycle session can compare before/after without Instruments.
+nonisolated enum LaunchSignposts {
+    static let signposter = OSSignposter(subsystem: "com.rootshell", category: "Launch")
+    private static let logger = Logger(subsystem: "com.rootshell", category: "Launch")
+
+    /// Process-start reference for delta logging (CFAbsoluteTimeGetCurrent basis).
+    private static let processStart = CFAbsoluteTimeGetCurrent()
+
+    @inline(__always)
+    static func begin(_ name: StaticString) -> OSSignpostIntervalState {
+        log("begin", name)
+        return signposter.beginInterval(name)
+    }
+
+    @inline(__always)
+    static func end(_ name: StaticString, _ state: OSSignpostIntervalState) {
+        log("end", name)
+        signposter.endInterval(name, state)
+    }
+
+    /// Instantaneous event with time since process start.
+    static func event(_ name: String) {
+        let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - processStart) * 1000)
+        logger.info("event \(name, privacy: .public) +\(elapsedMs)ms")
+    }
+
+    /// First session-ready this process — primary cold-launch KPI
+    /// (process start → interactive local shell). Safe to call from any thread.
+    private static let interactiveLock = NSLock()
+    private static var didMarkInteractive = false
+
+    static func markInteractiveIfNeeded() {
+        interactiveLock.lock()
+        defer { interactiveLock.unlock() }
+        guard !didMarkInteractive else { return }
+        didMarkInteractive = true
+        event("launch.interactive")
+    }
+
+    private static func log(_ phase: String, _ name: StaticString) {
+        let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - processStart) * 1000)
+        let label = name.withUTF8Buffer { buf in
+            String(decoding: buf, as: UTF8.self)
+        }
+        logger.info("\(phase, privacy: .public) \(label, privacy: .public) +\(elapsedMs)ms")
+    }
+}

--- a/rootshell/Core/Ghostty/GhosttyApp.swift
+++ b/rootshell/Core/Ghostty/GhosttyApp.swift
@@ -317,6 +317,9 @@ extension Ghostty {
         private var lastAppliedCursorThrottle: Bool?
 
         init() {
+            let launch = LaunchSignposts.begin("launch.ghosttyApp")
+            defer { LaunchSignposts.end("launch.ghosttyApp", launch) }
+
             // Initialize ios_system environment variables (iOS/visionOS only) FIRST.
             //
             // IMPORTANT: setenv() calls must complete BEFORE Ghostty's Zig code
@@ -327,16 +330,21 @@ extension Ghostty {
             // ios_system's initializeEnvironment() was still setting XDG_CACHE_HOME /
             // XDG_CONFIG_HOME / XDG_STATE_HOME / XDG_DATA_HOME.
             #if !targetEnvironment(macCatalyst)
+            let envSP = LaunchSignposts.begin("launch.ghostty.env")
             initializeEnvironment()
+            LaunchSignposts.end("launch.ghostty.env", envSP)
             #endif
 
             // Now safe to initialize ghostty (may spawn Zig threads that read env vars).
+            let initSP = LaunchSignposts.begin("launch.ghostty.init")
             Ghostty.initialize()
+            LaunchSignposts.end("launch.ghostty.init", initSP)
 
             // Register ios_system command dictionaries and direct function entry points.
             // These mutate ios_system's commandList global, not environ — safe post-init.
             #if !targetEnvironment(macCatalyst)
 
+            let cmdsSP = LaunchSignposts.begin("launch.ghostty.commands")
             // Load command dictionaries
             if let commandDictPath = Bundle.main.path(forResource: "commandDictionary", ofType: "plist") {
                 if let error = addCommandList(commandDictPath) {
@@ -387,6 +395,7 @@ extension Ghostty {
 
             // Setup curl CA certificates for TLS/HTTPS support (only on iOS/iPadOS)
             CurlResourceManager.shared.setupResources()
+            LaunchSignposts.end("launch.ghostty.commands", cmdsSP)
             #endif
 
             // Initialize the global configuration
@@ -419,12 +428,15 @@ extension Ghostty {
             )
 
             // Create the ghostty app
+            let appSP = LaunchSignposts.begin("launch.ghostty.appNew")
             guard let app = ghostty_app_new(&runtime_cfg, config.config) else {
+                LaunchSignposts.end("launch.ghostty.appNew", appSP)
                 logger.critical("ghostty_app_new returned nil!")
                 readiness = .error
                 return
             }
             self.app = app
+            LaunchSignposts.end("launch.ghostty.appNew", appSP)
 
             // Register this instance for callback access
             // Use raw pointer address as key (not ObjectIdentifier which creates new wrapper each time)

--- a/rootshell/Core/Helper/HelperConnection.swift
+++ b/rootshell/Core/Helper/HelperConnection.swift
@@ -76,6 +76,11 @@ public class HelperConnection {
 
     private let socketConnection = SocketHelperConnection()
 
+    /// Coalesces concurrent `ensureHelperRunning()` callers (launch prewarm +
+    /// first-window onAppear) onto a single spawn/ping sequence.
+    private let ensureLock = NSLock()
+    private var inFlightEnsure: Task<Bool, Never>?
+
     /// PID of helper process if we launched it (non-sandboxed mode)
     private var helperPID: pid_t = 0 {
         didSet {
@@ -271,6 +276,29 @@ public class HelperConnection {
     /// Ensures helper is running, launching it if necessary (non-sandboxed mode only)
     /// Returns true if helper is available (either existing or newly launched)
     public func ensureHelperRunning() async -> Bool {
+        ensureLock.lock()
+        if let inFlightEnsure {
+            ensureLock.unlock()
+            return await inFlightEnsure.value
+        }
+
+        let created = Task {
+            defer {
+                self.ensureLock.lock()
+                self.inFlightEnsure = nil
+                self.ensureLock.unlock()
+            }
+            return await self.performEnsureHelperRunning()
+        }
+        inFlightEnsure = created
+        ensureLock.unlock()
+        return await created.value
+    }
+
+    private func performEnsureHelperRunning() async -> Bool {
+        let sp = LaunchSignposts.begin("launch.helper.ensure")
+        defer { LaunchSignposts.end("launch.helper.ensure", sp) }
+
         // First, check if helper is already running and healthy (reuse orphans)
         do {
             try await socketConnection.ping()

--- a/rootshell/Core/Terminal/TerminalSessionController.swift
+++ b/rootshell/Core/Terminal/TerminalSessionController.swift
@@ -102,6 +102,7 @@ final class TerminalSessionController {
         // `onReady` is invoked on the main actor by the session, so no hop.
         session.onReady = { [weak self] in
             Ghostty.logger.info("Session ready")
+            LaunchSignposts.markInteractiveIfNeeded()
             self?.host?.sessionDidBecomeReady()
         }
 

--- a/rootshell/Core/Theme/FontCatalogLoader.swift
+++ b/rootshell/Core/Theme/FontCatalogLoader.swift
@@ -1,0 +1,419 @@
+import Foundation
+import CoreText
+import UIKit
+import os
+
+/// A value snapshot of font inputs. Registration and discovery never access
+/// FontManager, UserDefaults, or published UI state on the worker thread.
+/// UIFont is immutable and Sendable; CoreText's individual functions are thread-safe.
+nonisolated struct FontCatalogLoader: Sendable {
+    typealias FontFamilyInfo = FontManager.FontFamilyInfo
+    typealias CustomFontFamily = FontManager.CustomFontFamily
+
+    let bundledFontsDirectory: URL?
+    let customFontsDirectory: URL
+    let customFontFamilies: [CustomFontFamily]
+    let hiddenUtilityFontFamilies: Set<String>
+    var replacedBundledFamilies: Set<String>
+    var availableFamilies: [FontFamilyInfo] = []
+    var systemFontFamilies: [FontFamilyInfo] = []
+    private let logger = Logger(subsystem: "com.rootshell", category: "FontManager")
+
+    init(
+        bundledFontsDirectory: URL?,
+        customFontsDirectory: URL,
+        customFontFamilies: [CustomFontFamily],
+        hiddenUtilityFontFamilies: Set<String>,
+        replacedBundledFamilies: Set<String>
+    ) {
+        self.bundledFontsDirectory = bundledFontsDirectory
+        self.customFontsDirectory = customFontsDirectory
+        self.customFontFamilies = customFontFamilies
+        self.hiddenUtilityFontFamilies = hiddenUtilityFontFamilies
+        self.replacedBundledFamilies = replacedBundledFamilies
+    }
+
+    nonisolated struct Result: Sendable {
+        let availableFamilies: [FontFamilyInfo]
+        let systemFontFamilies: [FontFamilyInfo]
+        let replacedBundledFamilies: Set<String>
+    }
+
+    mutating func load() -> Result {
+        let deferred = LaunchSignposts.begin("launch.fonts.deferred")
+        defer { LaunchSignposts.end("launch.fonts.deferred", deferred) }
+
+        registerBundledFonts()
+        let registeredCustomFamilies = registerCustomFonts()
+        let staleReplacements = replacedBundledFamilies.subtracting(registeredCustomFamilies)
+        for family in staleReplacements {
+            logger.warning("Stale bundled replacement for '\(family)' — restoring bundled font")
+            reregisterBundledFontsForFamily(family)
+        }
+        loadAvailableFamilies()
+        loadSystemFonts()
+        return Result(
+            availableFamilies: availableFamilies,
+            systemFontFamilies: systemFontFamilies,
+            replacedBundledFamilies: replacedBundledFamilies
+        )
+    }
+
+    func registerBundledFonts(matching families: Set<String>? = nil) {
+        guard let fontsURL = bundledFontsDirectory else {
+            logger.warning("Fonts directory not found in bundle")
+            return
+        }
+
+        let fileManager = FileManager.default
+        var registeredCount = 0
+
+        guard let enumerator = fileManager.enumerator(
+            at: fontsURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            logger.error("Failed to create enumerator for fonts directory")
+            return
+        }
+
+        for case let fileURL as URL in enumerator {
+            // Only process TTF and OTF font files
+            let ext = fileURL.pathExtension.lowercased()
+            guard ext == "ttf" || ext == "otf" else { continue }
+
+            let filename = fileURL.lastPathComponent
+
+            guard let (_, configName) = Self.extractFontInfo(from: fileURL) else { continue }
+
+            // Skip fonts whose family has been replaced by a custom import
+            if replacedBundledFamilies.contains(configName) {
+                logger.debug("Skipping replaced bundled font: \(filename)")
+                continue
+            }
+
+            if let families, !families.contains(configName) {
+                continue
+            }
+
+            var error: Unmanaged<CFError>?
+            if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
+                registeredCount += 1
+                logger.debug("Registered font: \(filename)")
+            } else if let cfError = error?.takeRetainedValue() {
+                // Font might already be registered - not necessarily an error
+                logger.debug("Font registration note for \(filename): \(cfError)")
+            }
+        }
+
+        logger.info("Registered \(registeredCount) bundled fonts")
+    }
+
+    func registerCustomFontFamilyFiles(_ family: CustomFontFamily) -> Bool {
+        var registeredAny = false
+        for file in family.fontFiles {
+            let fileURL = customFontsDirectory.appendingPathComponent(file.filename)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                let name = file.originalName
+                logger.warning("Custom font file missing: \(name)")
+                continue
+            }
+
+            var error: Unmanaged<CFError>?
+            if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
+                registeredAny = true
+            } else if Self.isAlreadyRegisteredError(error) {
+                registeredAny = true
+                let name = file.originalName
+                logger.debug("Custom font already registered: \(name)")
+            } else if let cfError = error?.takeRetainedValue() {
+                let name = file.originalName
+                logger.debug("Custom font registration note for \(name): \(cfError)")
+            }
+        }
+        return registeredAny
+    }
+
+    func registerCustomFonts() -> Set<String> {
+        var registeredCount = 0
+        var successfulFamilies: Set<String> = []
+
+        for family in customFontFamilies {
+            let before = successfulFamilies.count
+            if registerCustomFontFamilyFiles(family) {
+                successfulFamilies.insert(family.configName)
+                // Count files roughly for the log (one per successful family is enough signal)
+                if successfulFamilies.count > before {
+                    registeredCount += family.fontFiles.count
+                }
+            }
+        }
+
+        let count = registeredCount
+        logger.info("Registered \(count) custom font files")
+        return successfulFamilies
+    }
+
+    mutating func loadAvailableFamilies() {
+        guard let fontsURL = bundledFontsDirectory else { return }
+
+        let fileManager = FileManager.default
+        var familyMap: [String: (displayName: String, configName: String, fontURL: URL)] = [:]
+
+        guard let enumerator = fileManager.enumerator(
+            at: fontsURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for case let fileURL as URL in enumerator {
+            let ext = fileURL.pathExtension.lowercased()
+            guard ext == "ttf" || ext == "otf" else { continue }
+
+            let filename = fileURL.lastPathComponent
+
+            // Extract font family name from the font file
+            if let (familyName, configName) = Self.extractFontInfo(from: fileURL) {
+                // Skip UI-only utility fonts and families replaced by custom imports
+                guard !hiddenUtilityFontFamilies.contains(familyName) else { continue }
+                guard !replacedBundledFamilies.contains(configName) else { continue }
+
+                // Prefer Regular weight for preview
+                let isRegular = filename.contains("Regular")
+                if familyMap[familyName] == nil || isRegular {
+                    familyMap[familyName] = (familyName, configName, fileURL)
+                }
+            }
+        }
+
+        // Build FontFamilyInfo array
+        var families: [FontFamilyInfo] = []
+        for (id, info) in familyMap {
+            let sampleFont = Self.createFont(from: info.fontURL, size: 16)
+
+            families.append(FontFamilyInfo(
+                id: id,
+                displayName: info.displayName,
+                configName: info.configName,
+                sampleFont: sampleFont
+            ))
+        }
+
+        // Sort alphabetically
+        families.sort { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+
+        self.availableFamilies = families
+        logger.info("Loaded \(families.count) font families")
+    }
+
+    mutating func loadSystemFonts() {
+        let bundledConfigNames = Set(availableFamilies.map(\.configName))
+        let customConfigNames = Set(customFontFamilies.map(\.configName))
+
+        var systemFonts: [FontFamilyInfo] = []
+        var seenFamilies = Set<String>()
+
+        // Use UIFontDescriptor matching to discover all monospace fonts system-wide.
+        // This finds fonts from UIFont.familyNames AND user-installed fonts (Font Case etc.)
+        // when the com.apple.developer.user-fonts entitlement is present.
+        let monoDescriptor = UIFontDescriptor(fontAttributes: [
+            .traits: [UIFontDescriptor.TraitKey.symbolic: UIFontDescriptor.SymbolicTraits.traitMonoSpace.rawValue]
+        ])
+        let matchedDescriptors = monoDescriptor.matchingFontDescriptors(withMandatoryKeys: nil)
+        let matchCount = matchedDescriptors.count
+        logger.info("[SystemFonts] UIFontDescriptor monospace matches: \(matchCount)")
+
+        for descriptor in matchedDescriptors {
+            let font = UIFont(descriptor: descriptor, size: 16)
+            let familyName = font.familyName
+
+            guard !seenFamilies.contains(familyName),
+                  !bundledConfigNames.contains(familyName),
+                  !customConfigNames.contains(familyName),
+                  !hiddenUtilityFontFamilies.contains(familyName) else { continue }
+
+            systemFonts.append(FontFamilyInfo(
+                id: familyName,
+                displayName: familyName,
+                configName: familyName,
+                sampleFont: font
+            ))
+            seenFamilies.insert(familyName)
+        }
+
+        let traitCount = systemFonts.count
+        logger.info("[SystemFonts] From trait matching: \(traitCount) monospace families")
+
+        // Also check UIFont.familyNames with glyph-advance fallback for fonts that
+        // don't set the monospace trait but are actually monospace (e.g., Berkeley Mono)
+        for familyName in UIFont.familyNames {
+            guard !seenFamilies.contains(familyName),
+                  !bundledConfigNames.contains(familyName),
+                  !customConfigNames.contains(familyName),
+                  !hiddenUtilityFontFamilies.contains(familyName) else { continue }
+
+            guard let font = UIFont(name: familyName, size: 16) else { continue }
+            guard Self.isMonospaceByGlyphAdvance(font) else { continue }
+
+            logger.info("[SystemFonts] Glyph-advance detected mono: '\(familyName)'")
+            systemFonts.append(FontFamilyInfo(
+                id: familyName,
+                displayName: familyName,
+                configName: familyName,
+                sampleFont: font
+            ))
+            seenFamilies.insert(familyName)
+        }
+
+        // Check CoreText registered font descriptors for user-installed fonts
+        // that may not appear in UIFont.familyNames or descriptor matching
+        let descriptors = CTFontManagerCopyRegisteredFontDescriptors(.user, true) as? [CTFontDescriptor] ?? []
+        let ctCount = descriptors.count
+        logger.info("[SystemFonts] CTFontManager .user scope: \(ctCount) descriptors")
+
+        for descriptor in descriptors {
+            guard let familyName = CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String else {
+                continue
+            }
+            guard !seenFamilies.contains(familyName),
+                  !bundledConfigNames.contains(familyName),
+                  !customConfigNames.contains(familyName),
+                  !hiddenUtilityFontFamilies.contains(familyName) else { continue }
+
+            let ctFont = CTFontCreateWithFontDescriptor(descriptor, 16, nil)
+            let uiFont = ctFont as UIFont
+            let traits = uiFont.fontDescriptor.symbolicTraits
+            let isMono = traits.contains(.traitMonoSpace) || Self.isMonospaceByGlyphAdvance(uiFont)
+
+            logger.info("[SystemFonts] CT user font: '\(familyName)' mono=\(isMono)")
+            guard isMono else { continue }
+
+            systemFonts.append(FontFamilyInfo(
+                id: familyName,
+                displayName: familyName,
+                configName: familyName,
+                sampleFont: uiFont
+            ))
+            seenFamilies.insert(familyName)
+        }
+
+        systemFonts.sort {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+
+        self.systemFontFamilies = systemFonts
+        let totalCount = systemFonts.count
+        logger.info("[SystemFonts] Total: \(totalCount) system monospace font families")
+        for sf in systemFonts {
+            let name = sf.displayName
+            logger.info("[SystemFonts]   -> \(name)")
+        }
+    }
+
+    /// Include fonts that have fixed glyph advances but lack the monospace trait.
+    private static func isMonospaceByGlyphAdvance(_ font: UIFont) -> Bool {
+        let ctFont = font as CTFont
+        var characters: [UniChar] = [0x004D, 0x0069, 0x0057, 0x002E] // M, i, W, .
+        var glyphs = [CGGlyph](repeating: 0, count: characters.count)
+        guard CTFontGetGlyphsForCharacters(ctFont, &characters, &glyphs, characters.count) else { return false }
+        guard glyphs.allSatisfy({ $0 != 0 }) else { return false }
+        var advances = [CGSize](repeating: .zero, count: characters.count)
+        CTFontGetAdvancesForGlyphs(ctFont, .horizontal, glyphs, &advances, characters.count)
+        let ref = advances[0].width
+        guard ref > 0 else { return false }
+        return advances.allSatisfy { abs($0.width - ref) < 0.01 }
+    }
+
+    static func extractFontInfo(from url: URL) -> (displayName: String, configName: String)? {
+        guard let provider = CGDataProvider(url: url as CFURL),
+              let cgFont = CGFont(provider) else {
+            return nil
+        }
+
+        // Create a CTFont to get the family name
+        let ctFont = CTFontCreateWithGraphicsFont(cgFont, 12, nil, nil)
+        let familyName = CTFontCopyFamilyName(ctFont) as String
+
+        // The config name is the font family name as-is
+        return (familyName, familyName)
+    }
+
+    static func createFont(from url: URL, size: CGFloat) -> UIFont? {
+        guard let provider = CGDataProvider(url: url as CFURL),
+              let cgFont = CGFont(provider) else {
+            return nil
+        }
+
+        let ctFont = CTFontCreateWithGraphicsFont(cgFont, size, nil, nil)
+        return ctFont as UIFont
+    }
+
+    static func isAlreadyRegisteredError(_ error: Unmanaged<CFError>?) -> Bool {
+        guard let cfError = error?.takeUnretainedValue() else { return false }
+        let domain = CFErrorGetDomain(cfError) as String
+        let code = CFErrorGetCode(cfError)
+        // CTFontManagerError codes: .alreadyRegistered = 105, .duplicatedName = 106
+        guard domain == kCTFontManagerErrorDomain as String else { return false }
+        return code == 105 || code == 106
+    }
+
+    mutating func reregisterBundledFontsForFamily(_ familyName: String) {
+        guard let fontsURL = bundledFontsDirectory else { return }
+        let fileManager = FileManager.default
+
+        guard let enumerator = fileManager.enumerator(
+            at: fontsURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for case let fileURL as URL in enumerator {
+            let ext = fileURL.pathExtension.lowercased()
+            guard ext == "ttf" || ext == "otf" else { continue }
+
+            if let (_, configName) = Self.extractFontInfo(from: fileURL), configName == familyName {
+                var error: Unmanaged<CFError>?
+                if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
+                    let filename = fileURL.lastPathComponent
+                    logger.debug("Re-registered bundled font: \(filename)")
+                }
+            }
+        }
+
+        replacedBundledFamilies.remove(familyName)
+    }
+}
+
+/// One startup load, shared by asynchronous settings callers and synchronous
+/// import/delete/restore paths. The lock protects the cached result AND the full
+/// registration pass: cancellation must not allow a mutation to race a worker
+/// that is still registering fonts. Loading never hops to MainActor, so a
+/// synchronous mutation can safely wait here without a main-thread deadlock.
+nonisolated final class FontCatalogLoad: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.rootshell.fontCatalog", qos: .utility)
+    private let lock = NSLock()
+    private let input: FontCatalogLoader
+    private var result: FontCatalogLoader.Result?
+
+    init(input: FontCatalogLoader) {
+        self.input = input
+    }
+
+    func loadInBackground() async -> FontCatalogLoader.Result {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                continuation.resume(returning: self.load())
+            }
+        }
+    }
+
+    func load() -> FontCatalogLoader.Result {
+        lock.lock()
+        defer { lock.unlock() }
+        if let result { return result }
+        var loader = input
+        let loaded = loader.load()
+        result = loaded
+        return loaded
+    }
+}

--- a/rootshell/Core/Theme/FontManager.swift
+++ b/rootshell/Core/Theme/FontManager.swift
@@ -21,7 +21,7 @@ class FontManager: ObservableObject {
     static let shared = FontManager()
 
     /// Information about a bundled font family
-    struct FontFamilyInfo: Identifiable, Equatable {
+    nonisolated struct FontFamilyInfo: Identifiable, Equatable, Sendable {
         let id: String
         let displayName: String
         let configName: String  // Name to use in Ghostty config
@@ -47,14 +47,14 @@ class FontManager: ObservableObject {
     static let defaultFontKey = "__default__"
 
     /// A user-imported custom font family with one or more style variants
-    struct CustomFontFamily: Codable, Identifiable, Equatable {
+    nonisolated struct CustomFontFamily: Codable, Identifiable, Equatable, Sendable {
         let id: UUID
         var displayName: String
         let configName: String
         var fontFiles: [FontFile]
         let importDate: Date
 
-        struct FontFile: Codable, Equatable {
+        nonisolated struct FontFile: Codable, Equatable, Sendable {
             let filename: String       // UUID-prefixed filename in Documents
             let originalName: String   // Original filename for display
             let styleName: String?     // "Regular", "Bold", "Italic", etc.
@@ -138,6 +138,7 @@ class FontManager: ObservableObject {
 
     /// Background catalog build kicked off from `init`.
     private var catalogLoadTask: Task<Void, Never>?
+    private var catalogLoad: FontCatalogLoad?
 
     /// Currently selected font size
     @Published var currentFontSize: Double {
@@ -226,8 +227,8 @@ class FontManager: ObservableObject {
 
         // Critical path: register only what the first terminal needs (selected
         // family + UI utility glyphs). Full catalog discovery is expensive
-        // (every bundled file + device-wide monospace scan) and runs after
-        // the first frame — same pattern as ThemeManager's background load.
+        // (every bundled file + device-wide monospace scan) and runs on a
+        // utility queue without occupying MainActor during the first frame.
         let critical = LaunchSignposts.begin("launch.fonts.critical")
         registerCriticalPathFonts()
         LaunchSignposts.end("launch.fonts.critical", critical)
@@ -266,62 +267,51 @@ class FontManager: ObservableObject {
         }
     }
 
-    /// Finish remaining registration + build picker catalogs off the critical path.
+    /// Capture mutable manager state before crossing to the catalog worker.
+    private func makeCatalogLoader() -> FontCatalogLoader {
+        FontCatalogLoader(
+            bundledFontsDirectory: findFontsDirectory(),
+            customFontsDirectory: customFontsDirectory,
+            customFontFamilies: customFontFamilies,
+            hiddenUtilityFontFamilies: Self.hiddenUtilityFontFamilies,
+            replacedBundledFamilies: replacedBundledFamilies
+        )
+    }
+
+    /// Run the entire registration/discovery pass on a utility queue. Merely
+    /// yielding a MainActor task does not let SwiftUI reliably paint first.
     private func startBackgroundCatalogLoad() {
+        let load = FontCatalogLoad(input: makeCatalogLoader())
+        catalogLoad = load
         catalogLoadTask = Task { @MainActor [weak self] in
-            // Yield so SwiftUI can commit the first frame before we burn CPU
-            // on the remaining CTFontManager work and system font scan.
-            await Task.yield()
-            guard let self, !self.isCatalogLoaded, !Task.isCancelled else { return }
-
-            let deferred = LaunchSignposts.begin("launch.fonts.deferred")
-            defer { LaunchSignposts.end("launch.fonts.deferred", deferred) }
-
-            self.registerBundledFonts()
-            let registeredCustomFamilies = self.registerCustomFonts()
-
-            // Reconcile: prune replacement markers where the custom family failed
-            // to register any files (missing files, corruption, incompatible fonts).
-            let staleReplacements = self.replacedBundledFamilies.subtracting(registeredCustomFamilies)
-            if !staleReplacements.isEmpty {
-                for family in staleReplacements {
-                    self.logger.warning("Stale bundled replacement for '\(family)' — restoring bundled font")
-                    self.reregisterBundledFontsForFamily(family)
-                }
-                self.saveReplacedBundledFamilies()
-            }
-
-            self.loadAvailableFamilies()
-            self.loadSystemFonts()
-            self.setupFontRegistrationObserver()
-            self.isCatalogLoaded = true
-            LaunchSignposts.event("fonts.catalogReady")
+            let result = await load.loadInBackground()
+            guard let self, !self.isCatalogLoaded else { return }
+            self.applyCatalog(result)
         }
     }
 
-    /// Finish catalog work immediately when a mutation needs the full set
-    /// (import/delete/reload) before the background task lands.
-    private func completeCatalogLoadIfNeeded() {
-        guard !isCatalogLoaded else { return }
-        catalogLoadTask?.cancel()
-        catalogLoadTask = nil
-
-        registerBundledFonts()
-        let registeredCustomFamilies = registerCustomFonts()
-        let staleReplacements = replacedBundledFamilies.subtracting(registeredCustomFamilies)
-        if !staleReplacements.isEmpty {
-            for family in staleReplacements {
-                logger.warning("Stale bundled replacement for '\(family)' — restoring bundled font")
-                reregisterBundledFontsForFamily(family)
-            }
+    private func applyCatalog(_ result: FontCatalogLoader.Result) {
+        if replacedBundledFamilies != result.replacedBundledFamilies {
+            replacedBundledFamilies = result.replacedBundledFamilies
             saveReplacedBundledFamilies()
         }
-        loadAvailableFamilies()
-        loadSystemFonts()
+        availableFamilies = result.availableFamilies
+        systemFontFamilies = result.systemFontFamilies
         if fontRegistrationObserver == nil {
             setupFontRegistrationObserver()
         }
         isCatalogLoaded = true
+        catalogLoad = nil
+        catalogLoadTask = nil
+        LaunchSignposts.event("fonts.catalogReady")
+    }
+
+    /// Mutations must finish the same load, not cancel it and start another
+    /// registration pass. After this returns the worker can only deliver its
+    /// cached result, which the isCatalogLoaded guard above ignores.
+    private func completeCatalogLoadIfNeeded() {
+        guard !isCatalogLoaded, let catalogLoad else { return }
+        applyCatalog(catalogLoad.load())
     }
 
     /// Re-reads owned keys after an external batch (iCloud, restore, config file).
@@ -371,53 +361,7 @@ class FontManager: ObservableObject {
     /// - Parameter matching: When non-nil, only families in this set are registered.
     ///   Pass `nil` to register every non-replaced bundled font (deferred catalog path).
     private func registerBundledFonts(matching families: Set<String>? = nil) {
-        guard let fontsURL = findFontsDirectory() else {
-            logger.warning("Fonts directory not found in bundle")
-            return
-        }
-
-        let fileManager = FileManager.default
-        var registeredCount = 0
-
-        guard let enumerator = fileManager.enumerator(
-            at: fontsURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            logger.error("Failed to create enumerator for fonts directory")
-            return
-        }
-
-        for case let fileURL as URL in enumerator {
-            // Only process TTF and OTF font files
-            let ext = fileURL.pathExtension.lowercased()
-            guard ext == "ttf" || ext == "otf" else { continue }
-
-            let filename = fileURL.lastPathComponent
-
-            guard let (_, configName) = extractFontInfo(from: fileURL) else { continue }
-
-            // Skip fonts whose family has been replaced by a custom import
-            if replacedBundledFamilies.contains(configName) {
-                logger.debug("Skipping replaced bundled font: \(filename)")
-                continue
-            }
-
-            if let families, !families.contains(configName) {
-                continue
-            }
-
-            var error: Unmanaged<CFError>?
-            if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
-                registeredCount += 1
-                logger.debug("Registered font: \(filename)")
-            } else if let cfError = error?.takeRetainedValue() {
-                // Font might already be registered - not necessarily an error
-                logger.debug("Font registration note for \(filename): \(cfError)")
-            }
-        }
-
-        logger.info("Registered \(registeredCount) bundled fonts")
+        makeCatalogLoader().registerBundledFonts(matching: families)
     }
 
     /// Find the fonts directory in the app bundle
@@ -482,28 +426,7 @@ class FontManager: ObservableObject {
     /// Register every file belonging to one custom family.
     @discardableResult
     private func registerCustomFontFamilyFiles(_ family: CustomFontFamily) -> Bool {
-        var registeredAny = false
-        for file in family.fontFiles {
-            let fileURL = documentsPathForCustomFont(file.filename)
-            guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                let name = file.originalName
-                logger.warning("Custom font file missing: \(name)")
-                continue
-            }
-
-            var error: Unmanaged<CFError>?
-            if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
-                registeredAny = true
-            } else if isAlreadyRegisteredError(error) {
-                registeredAny = true
-                let name = file.originalName
-                logger.debug("Custom font already registered: \(name)")
-            } else if let cfError = error?.takeRetainedValue() {
-                let name = file.originalName
-                logger.debug("Custom font registration note for \(name): \(cfError)")
-            }
-        }
-        return registeredAny
+        makeCatalogLoader().registerCustomFontFamilyFiles(family)
     }
 
     /// Register all previously-imported custom fonts with CoreText.
@@ -511,23 +434,7 @@ class FontManager: ObservableObject {
     @discardableResult
     private func registerCustomFonts() -> Set<String> {
         loadCustomFontMetadata()
-        var registeredCount = 0
-        var successfulFamilies: Set<String> = []
-
-        for family in customFontFamilies {
-            let before = successfulFamilies.count
-            if registerCustomFontFamilyFiles(family) {
-                successfulFamilies.insert(family.configName)
-                // Count files roughly for the log (one per successful family is enough signal)
-                if successfulFamilies.count > before {
-                    registeredCount += family.fontFiles.count
-                }
-            }
-        }
-
-        let count = registeredCount
-        logger.info("Registered \(count) custom font files")
-        return successfulFamilies
+        return makeCatalogLoader().registerCustomFonts()
     }
 
     // MARK: - Custom Font Import
@@ -768,179 +675,20 @@ class FontManager: ObservableObject {
 
     /// Scan the fonts directory and build list of available font families
     private func loadAvailableFamilies() {
-        guard let fontsURL = findFontsDirectory() else { return }
-
-        let fileManager = FileManager.default
-        var familyMap: [String: (displayName: String, configName: String, fontURL: URL)] = [:]
-
-        guard let enumerator = fileManager.enumerator(
-            at: fontsURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        for case let fileURL as URL in enumerator {
-            let ext = fileURL.pathExtension.lowercased()
-            guard ext == "ttf" || ext == "otf" else { continue }
-
-            let filename = fileURL.lastPathComponent
-
-            // Extract font family name from the font file
-            if let (familyName, configName) = extractFontInfo(from: fileURL) {
-                // Skip UI-only utility fonts and families replaced by custom imports
-                guard !Self.hiddenUtilityFontFamilies.contains(familyName) else { continue }
-                guard !replacedBundledFamilies.contains(configName) else { continue }
-
-                // Prefer Regular weight for preview
-                let isRegular = filename.contains("Regular")
-                if familyMap[familyName] == nil || isRegular {
-                    familyMap[familyName] = (familyName, configName, fileURL)
-                }
-            }
-        }
-
-        // Build FontFamilyInfo array
-        var families: [FontFamilyInfo] = []
-        for (id, info) in familyMap {
-            let sampleFont = createFont(from: info.fontURL, size: 16)
-
-            families.append(FontFamilyInfo(
-                id: id,
-                displayName: info.displayName,
-                configName: info.configName,
-                sampleFont: sampleFont
-            ))
-        }
-
-        // Sort alphabetically
-        families.sort { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
-
-        self.availableFamilies = families
-        logger.info("Loaded \(families.count) font families")
+        var loader = makeCatalogLoader()
+        loader.availableFamilies = availableFamilies
+        loader.loadAvailableFamilies()
+        availableFamilies = loader.availableFamilies
     }
 
     // MARK: - System Font Discovery
 
     /// Discover monospace fonts installed on the device (e.g., via Font Case)
     private func loadSystemFonts() {
-        let bundledConfigNames = Set(availableFamilies.map(\.configName))
-        let customConfigNames = Set(customFontFamilies.map(\.configName))
-
-        var systemFonts: [FontFamilyInfo] = []
-        var seenFamilies = Set<String>()
-
-        // Use UIFontDescriptor matching to discover all monospace fonts system-wide.
-        // This finds fonts from UIFont.familyNames AND user-installed fonts (Font Case etc.)
-        // when the com.apple.developer.user-fonts entitlement is present.
-        let monoDescriptor = UIFontDescriptor(fontAttributes: [
-            .traits: [UIFontDescriptor.TraitKey.symbolic: UIFontDescriptor.SymbolicTraits.traitMonoSpace.rawValue]
-        ])
-        let matchedDescriptors = monoDescriptor.matchingFontDescriptors(withMandatoryKeys: nil)
-        let matchCount = matchedDescriptors.count
-        logger.info("[SystemFonts] UIFontDescriptor monospace matches: \(matchCount)")
-
-        for descriptor in matchedDescriptors {
-            let font = UIFont(descriptor: descriptor, size: 16)
-            let familyName = font.familyName
-
-            guard !seenFamilies.contains(familyName),
-                  !bundledConfigNames.contains(familyName),
-                  !customConfigNames.contains(familyName),
-                  !Self.hiddenUtilityFontFamilies.contains(familyName) else { continue }
-
-            systemFonts.append(FontFamilyInfo(
-                id: familyName,
-                displayName: familyName,
-                configName: familyName,
-                sampleFont: font
-            ))
-            seenFamilies.insert(familyName)
-        }
-
-        let traitCount = systemFonts.count
-        logger.info("[SystemFonts] From trait matching: \(traitCount) monospace families")
-
-        // Also check UIFont.familyNames with glyph-advance fallback for fonts that
-        // don't set the monospace trait but are actually monospace (e.g., Berkeley Mono)
-        for familyName in UIFont.familyNames {
-            guard !seenFamilies.contains(familyName),
-                  !bundledConfigNames.contains(familyName),
-                  !customConfigNames.contains(familyName),
-                  !Self.hiddenUtilityFontFamilies.contains(familyName) else { continue }
-
-            guard let font = UIFont(name: familyName, size: 16) else { continue }
-            guard self.isMonospaceByGlyphAdvance(font) else { continue }
-
-            logger.info("[SystemFonts] Glyph-advance detected mono: '\(familyName)'")
-            systemFonts.append(FontFamilyInfo(
-                id: familyName,
-                displayName: familyName,
-                configName: familyName,
-                sampleFont: font
-            ))
-            seenFamilies.insert(familyName)
-        }
-
-        // Check CoreText registered font descriptors for user-installed fonts
-        // that may not appear in UIFont.familyNames or descriptor matching
-        let descriptors = CTFontManagerCopyRegisteredFontDescriptors(.user, true) as? [CTFontDescriptor] ?? []
-        let ctCount = descriptors.count
-        logger.info("[SystemFonts] CTFontManager .user scope: \(ctCount) descriptors")
-
-        for descriptor in descriptors {
-            guard let familyName = CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String else {
-                continue
-            }
-            guard !seenFamilies.contains(familyName),
-                  !bundledConfigNames.contains(familyName),
-                  !customConfigNames.contains(familyName),
-                  !Self.hiddenUtilityFontFamilies.contains(familyName) else { continue }
-
-            let ctFont = CTFontCreateWithFontDescriptor(descriptor, 16, nil)
-            let uiFont = ctFont as UIFont
-            let traits = uiFont.fontDescriptor.symbolicTraits
-            let isMono = traits.contains(.traitMonoSpace) || self.isMonospaceByGlyphAdvance(uiFont)
-
-            logger.info("[SystemFonts] CT user font: '\(familyName)' mono=\(isMono)")
-            guard isMono else { continue }
-
-            systemFonts.append(FontFamilyInfo(
-                id: familyName,
-                displayName: familyName,
-                configName: familyName,
-                sampleFont: uiFont
-            ))
-            seenFamilies.insert(familyName)
-        }
-
-        systemFonts.sort {
-            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-        }
-
-        self.systemFontFamilies = systemFonts
-        let totalCount = systemFonts.count
-        logger.info("[SystemFonts] Total: \(totalCount) system monospace font families")
-        for sf in systemFonts {
-            let name = sf.displayName
-            logger.info("[SystemFonts]   -> \(name)")
-        }
-    }
-
-    /// Check if a font is monospace by comparing glyph advance widths.
-    /// Some fonts (e.g., Berkeley Mono) don't set the OS/2 isFixedPitch flag,
-    /// so UIFontDescriptor.symbolicTraits won't include .traitMonoSpace.
-    /// This fallback compares advances of characters with typically extreme width differences.
-    private func isMonospaceByGlyphAdvance(_ font: UIFont) -> Bool {
-        let ctFont = font as CTFont
-        var characters: [UniChar] = [0x004D, 0x0069, 0x0057, 0x002E] // M, i, W, .
-        var glyphs = [CGGlyph](repeating: 0, count: characters.count)
-        guard CTFontGetGlyphsForCharacters(ctFont, &characters, &glyphs, characters.count) else { return false }
-        guard glyphs.allSatisfy({ $0 != 0 }) else { return false }
-        var advances = [CGSize](repeating: .zero, count: characters.count)
-        CTFontGetAdvancesForGlyphs(ctFont, .horizontal, glyphs, &advances, characters.count)
-        let ref = advances[0].width
-        guard ref > 0 else { return false }
-        return advances.allSatisfy { abs($0.width - ref) < 0.01 }
+        var loader = makeCatalogLoader()
+        loader.availableFamilies = availableFamilies
+        loader.loadSystemFonts()
+        systemFontFamilies = loader.systemFontFamilies
     }
 
     private func setupFontRegistrationObserver() {
@@ -958,38 +706,17 @@ class FontManager: ObservableObject {
 
     /// Extract font family name and config name from a font file
     private func extractFontInfo(from url: URL) -> (displayName: String, configName: String)? {
-        guard let provider = CGDataProvider(url: url as CFURL),
-              let cgFont = CGFont(provider) else {
-            return nil
-        }
-
-        // Create a CTFont to get the family name
-        let ctFont = CTFontCreateWithGraphicsFont(cgFont, 12, nil, nil)
-        let familyName = CTFontCopyFamilyName(ctFont) as String
-
-        // The config name is the font family name as-is
-        return (familyName, familyName)
+        FontCatalogLoader.extractFontInfo(from: url)
     }
 
     /// Create a UIFont from a TTF file URL
     private func createFont(from url: URL, size: CGFloat) -> UIFont? {
-        guard let provider = CGDataProvider(url: url as CFURL),
-              let cgFont = CGFont(provider) else {
-            return nil
-        }
-
-        let ctFont = CTFontCreateWithGraphicsFont(cgFont, size, nil, nil)
-        return ctFont as UIFont
+        FontCatalogLoader.createFont(from: url, size: size)
     }
 
     /// Check if a CTFontManager registration error indicates a duplicate/already-registered font
     private func isAlreadyRegisteredError(_ error: Unmanaged<CFError>?) -> Bool {
-        guard let cfError = error?.takeUnretainedValue() else { return false }
-        let domain = CFErrorGetDomain(cfError) as String
-        let code = CFErrorGetCode(cfError)
-        // CTFontManagerError codes: .alreadyRegistered = 105, .duplicatedName = 106
-        guard domain == kCTFontManagerErrorDomain as String else { return false }
-        return code == 105 || code == 106
+        FontCatalogLoader.isAlreadyRegisteredError(error)
     }
 
     // MARK: - Bundled Font Replacement Helpers
@@ -1047,29 +774,9 @@ class FontManager: ObservableObject {
 
     /// Re-register bundled font files for a family that was previously replaced
     private func reregisterBundledFontsForFamily(_ familyName: String) {
-        guard let fontsURL = findFontsDirectory() else { return }
-        let fileManager = FileManager.default
-
-        guard let enumerator = fileManager.enumerator(
-            at: fontsURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        for case let fileURL as URL in enumerator {
-            let ext = fileURL.pathExtension.lowercased()
-            guard ext == "ttf" || ext == "otf" else { continue }
-
-            if let (_, configName) = extractFontInfo(from: fileURL), configName == familyName {
-                var error: Unmanaged<CFError>?
-                if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
-                    let filename = fileURL.lastPathComponent
-                    logger.debug("Re-registered bundled font: \(filename)")
-                }
-            }
-        }
-
-        replacedBundledFamilies.remove(familyName)
+        var loader = makeCatalogLoader()
+        loader.reregisterBundledFontsForFamily(familyName)
+        replacedBundledFamilies = loader.replacedBundledFamilies
     }
 
     private func saveReplacedBundledFamilies() {

--- a/rootshell/Core/Theme/FontManager.swift
+++ b/rootshell/Core/Theme/FontManager.swift
@@ -128,8 +128,16 @@ class FontManager: ObservableObject {
     /// System-installed monospace font families (e.g., from Font Case)
     @Published private(set) var systemFontFamilies: [FontFamilyInfo] = []
 
+    /// True once remaining bundled/custom registration and catalog discovery finish.
+    /// Font settings awaits this via `ensureFontsLoaded()`; the terminal only needs
+    /// the selected family, which is registered on the critical path.
+    @Published private(set) var isCatalogLoaded = false
+
     /// Bundled font families that have been replaced by custom imports
     private(set) var replacedBundledFamilies: Set<String> = []
+
+    /// Background catalog build kicked off from `init`.
+    private var catalogLoadTask: Task<Void, Never>?
 
     /// Currently selected font size
     @Published var currentFontSize: Double {
@@ -216,13 +224,90 @@ class FontManager: ObservableObject {
             replacedBundledFamilies = Set(saved)
         }
 
-        // Register bundled fonts with iOS, then custom fonts, then load available families
+        // Critical path: register only what the first terminal needs (selected
+        // family + UI utility glyphs). Full catalog discovery is expensive
+        // (every bundled file + device-wide monospace scan) and runs after
+        // the first frame — same pattern as ThemeManager's background load.
+        let critical = LaunchSignposts.begin("launch.fonts.critical")
+        registerCriticalPathFonts()
+        LaunchSignposts.end("launch.fonts.critical", critical)
+
+        startBackgroundCatalogLoad()
+
+        SettingsRefreshHub.shared.register(keys: Self.ownedKeys) { [weak self] keys in
+            self?.reload(keys: keys)
+        }
+    }
+
+    /// Await full font catalog registration/discovery. Font settings uses this;
+    /// terminal launch does not.
+    func ensureFontsLoaded() async {
+        if isCatalogLoaded { return }
+        await catalogLoadTask?.value
+    }
+
+    /// Register the selected family (and utility fonts) so Ghostty can resolve
+    /// the user's font before the deferred catalog finishes.
+    private func registerCriticalPathFonts() {
+        // UI glyph font used by profile icons — small, needed early.
+        registerBundledFonts(matching: Self.hiddenUtilityFontFamilies)
+
+        // Decode custom-font metadata without registering every file yet.
+        loadCustomFontMetadata()
+
+        guard let selected = currentFontFamily else { return }
+
+        if let custom = customFontFamilies.first(where: { $0.configName == selected }) {
+            registerCustomFontFamilyFiles(custom)
+        } else {
+            // Bundled or system-installed. System fonts need no registration;
+            // bundled registration is a no-op when the family isn't in the bundle.
+            registerBundledFonts(matching: Set([selected]))
+        }
+    }
+
+    /// Finish remaining registration + build picker catalogs off the critical path.
+    private func startBackgroundCatalogLoad() {
+        catalogLoadTask = Task { @MainActor [weak self] in
+            // Yield so SwiftUI can commit the first frame before we burn CPU
+            // on the remaining CTFontManager work and system font scan.
+            await Task.yield()
+            guard let self, !self.isCatalogLoaded, !Task.isCancelled else { return }
+
+            let deferred = LaunchSignposts.begin("launch.fonts.deferred")
+            defer { LaunchSignposts.end("launch.fonts.deferred", deferred) }
+
+            self.registerBundledFonts()
+            let registeredCustomFamilies = self.registerCustomFonts()
+
+            // Reconcile: prune replacement markers where the custom family failed
+            // to register any files (missing files, corruption, incompatible fonts).
+            let staleReplacements = self.replacedBundledFamilies.subtracting(registeredCustomFamilies)
+            if !staleReplacements.isEmpty {
+                for family in staleReplacements {
+                    self.logger.warning("Stale bundled replacement for '\(family)' — restoring bundled font")
+                    self.reregisterBundledFontsForFamily(family)
+                }
+                self.saveReplacedBundledFamilies()
+            }
+
+            self.loadAvailableFamilies()
+            self.loadSystemFonts()
+            self.setupFontRegistrationObserver()
+            self.isCatalogLoaded = true
+            LaunchSignposts.event("fonts.catalogReady")
+        }
+    }
+
+    /// Finish catalog work immediately when a mutation needs the full set
+    /// (import/delete/reload) before the background task lands.
+    private func completeCatalogLoadIfNeeded() {
+        guard !isCatalogLoaded else { return }
+        catalogLoadTask?.cancel()
+        catalogLoadTask = nil
+
         registerBundledFonts()
         let registeredCustomFamilies = registerCustomFonts()
-
-        // Reconcile: prune replacement markers where the custom family failed to register
-        // any files (missing files, corruption, incompatible fonts). This recovers bundled
-        // fonts that would otherwise stay permanently suppressed.
         let staleReplacements = replacedBundledFamilies.subtracting(registeredCustomFamilies)
         if !staleReplacements.isEmpty {
             for family in staleReplacements {
@@ -231,14 +316,12 @@ class FontManager: ObservableObject {
             }
             saveReplacedBundledFamilies()
         }
-
         loadAvailableFamilies()
         loadSystemFonts()
-        setupFontRegistrationObserver()
-
-        SettingsRefreshHub.shared.register(keys: Self.ownedKeys) { [weak self] keys in
-            self?.reload(keys: keys)
+        if fontRegistrationObserver == nil {
+            setupFontRegistrationObserver()
         }
+        isCatalogLoaded = true
     }
 
     /// Re-reads owned keys after an external batch (iCloud, restore, config file).
@@ -250,7 +333,17 @@ class FontManager: ObservableObject {
             let savedSize = store.get(Settings.Font.size)
             currentFontSize = savedSize > 0 ? savedSize : Settings.Font.size.defaultValue
         }
-        if keys.contains(Settings.Font.family.name) { currentFontFamily = store.get(Settings.Font.family) }
+        if keys.contains(Settings.Font.family.name) {
+            currentFontFamily = store.get(Settings.Font.family)
+            // External reload can select a family before deferred registration finishes.
+            if !isCatalogLoaded, let family = currentFontFamily {
+                if let custom = customFontFamilies.first(where: { $0.configName == family }) {
+                    registerCustomFontFamilyFiles(custom)
+                } else {
+                    registerBundledFonts(matching: Set([family]))
+                }
+            }
+        }
         if keys.contains(Settings.Font.ligatures.name) { ligaturesEnabled = store.get(Settings.Font.ligatures) }
         if keys.contains(Settings.Font.featurePrefs.name) {
             enabledFontFeatures = Self.decodeFontFeatures(store.get(Settings.Font.featurePrefs))
@@ -274,8 +367,10 @@ class FontManager: ObservableObject {
 
     // MARK: - Font Registration
 
-    /// Register all bundled TTF fonts with iOS so they can be discovered by CoreText
-    private func registerBundledFonts() {
+    /// Register bundled TTF/OTF fonts with CoreText.
+    /// - Parameter matching: When non-nil, only families in this set are registered.
+    ///   Pass `nil` to register every non-replaced bundled font (deferred catalog path).
+    private func registerBundledFonts(matching families: Set<String>? = nil) {
         guard let fontsURL = findFontsDirectory() else {
             logger.warning("Fonts directory not found in bundle")
             return
@@ -300,10 +395,15 @@ class FontManager: ObservableObject {
 
             let filename = fileURL.lastPathComponent
 
+            guard let (_, configName) = extractFontInfo(from: fileURL) else { continue }
+
             // Skip fonts whose family has been replaced by a custom import
-            if let (_, configName) = extractFontInfo(from: fileURL),
-               replacedBundledFamilies.contains(configName) {
+            if replacedBundledFamilies.contains(configName) {
                 logger.debug("Skipping replaced bundled font: \(filename)")
+                continue
+            }
+
+            if let families, !families.contains(configName) {
                 continue
             }
 
@@ -369,41 +469,58 @@ class FontManager: ObservableObject {
         customFontsDirectory.appendingPathComponent(filename)
     }
 
+    /// Decode custom-font metadata from UserDefaults without CoreText registration.
+    private func loadCustomFontMetadata() {
+        guard let data = UserDefaults.standard.data(forKey: Self.customFontFamiliesKey),
+              let families = try? JSONDecoder().decode([CustomFontFamily].self, from: data) else {
+            customFontFamilies = []
+            return
+        }
+        customFontFamilies = families
+    }
+
+    /// Register every file belonging to one custom family.
+    @discardableResult
+    private func registerCustomFontFamilyFiles(_ family: CustomFontFamily) -> Bool {
+        var registeredAny = false
+        for file in family.fontFiles {
+            let fileURL = documentsPathForCustomFont(file.filename)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                let name = file.originalName
+                logger.warning("Custom font file missing: \(name)")
+                continue
+            }
+
+            var error: Unmanaged<CFError>?
+            if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
+                registeredAny = true
+            } else if isAlreadyRegisteredError(error) {
+                registeredAny = true
+                let name = file.originalName
+                logger.debug("Custom font already registered: \(name)")
+            } else if let cfError = error?.takeRetainedValue() {
+                let name = file.originalName
+                logger.debug("Custom font registration note for \(name): \(cfError)")
+            }
+        }
+        return registeredAny
+    }
+
     /// Register all previously-imported custom fonts with CoreText.
     /// Returns the set of family configNames that successfully registered at least one file.
     @discardableResult
     private func registerCustomFonts() -> Set<String> {
-        guard let data = UserDefaults.standard.data(forKey: Self.customFontFamiliesKey),
-              let families = try? JSONDecoder().decode([CustomFontFamily].self, from: data) else {
-            return []
-        }
-
-        customFontFamilies = families
+        loadCustomFontMetadata()
         var registeredCount = 0
         var successfulFamilies: Set<String> = []
 
-        for family in families {
-            for file in family.fontFiles {
-                let fileURL = documentsPathForCustomFont(file.filename)
-                guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                    let name = file.originalName
-                    logger.warning("Custom font file missing: \(name)")
-                    continue
-                }
-
-                var error: Unmanaged<CFError>?
-                if CTFontManagerRegisterFontsForURL(fileURL as CFURL, .process, &error) {
-                    registeredCount += 1
-                    successfulFamilies.insert(family.configName)
-                } else if isAlreadyRegisteredError(error) {
-                    // Font is already registered (e.g., also installed via system/Font Case).
-                    // The font is usable — count the family as valid.
-                    successfulFamilies.insert(family.configName)
-                    let name = file.originalName
-                    logger.debug("Custom font already registered: \(name)")
-                } else if let cfError = error?.takeRetainedValue() {
-                    let name = file.originalName
-                    logger.debug("Custom font registration note for \(name): \(cfError)")
+        for family in customFontFamilies {
+            let before = successfulFamilies.count
+            if registerCustomFontFamilyFiles(family) {
+                successfulFamilies.insert(family.configName)
+                // Count files roughly for the log (one per successful family is enough signal)
+                if successfulFamilies.count > before {
+                    registeredCount += family.fontFiles.count
                 }
             }
         }
@@ -418,6 +535,8 @@ class FontManager: ObservableObject {
     /// Import font files, grouping by family name. Returns newly created or updated families.
     @discardableResult
     func importFonts(from urls: [URL]) throws -> [CustomFontFamily] {
+        completeCatalogLoadIfNeeded()
+
         struct ImportedFile {
             let familyName: String
             let styleName: String?
@@ -587,6 +706,8 @@ class FontManager: ObservableObject {
 
     /// Delete a custom font family, unregistering from CoreText and removing files
     func deleteCustomFontFamily(id: UUID) {
+        completeCatalogLoadIfNeeded()
+
         guard let index = customFontFamilies.firstIndex(where: { $0.id == id }) else { return }
 
         let family = customFontFamilies[index]
@@ -625,6 +746,7 @@ class FontManager: ObservableObject {
     /// Re-reads custom font families from UserDefaults, registers any new fonts with CoreText,
     /// and refreshes the available families list. Call after restoring fonts from a backup.
     func reloadCustomFonts() {
+        completeCatalogLoadIfNeeded()
         registerCustomFonts()
         loadAvailableFamilies()
         loadSystemFonts()
@@ -828,7 +950,8 @@ class FontManager: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.loadSystemFonts()
+                guard let self, self.isCatalogLoaded else { return }
+                self.loadSystemFonts()
             }
         }
     }

--- a/rootshell/UI/Settings/Appearance/FontSettingsView.swift
+++ b/rootshell/UI/Settings/Appearance/FontSettingsView.swift
@@ -43,6 +43,15 @@ struct FontSettingsView: View {
                 .buttonStyle(.plain)
                 .themedRow()
 
+                if !fontManager.isCatalogLoaded && fontManager.availableFamilies.isEmpty {
+                    HStack {
+                        ProgressView()
+                        Text("Loading fonts…")
+                            .foregroundColor(.secondary)
+                    }
+                    .themedRow()
+                }
+
                 // Bundled fonts
                 ForEach(fontManager.availableFamilies) { family in
                     Button(action: {
@@ -252,6 +261,9 @@ struct FontSettingsView: View {
         .navigationTitle("Font")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { SettingsScreenPinMenu(groups: [.font]) }
+        .task {
+            await fontManager.ensureFontsLoaded()
+        }
         .fileImporter(
             isPresented: $showingFileImporter,
             allowedContentTypes: [.font, UTType(filenameExtension: "ttf")!, UTType(filenameExtension: "otf")!],

--- a/rootshell/UI/Shell/MainView+EventHandlers.swift
+++ b/rootshell/UI/Shell/MainView+EventHandlers.swift
@@ -85,6 +85,7 @@ extension MainView {
     }
 
     func handleOnAppear() {
+        LaunchSignposts.event("mainView.onAppear.\(windowId)")
         updateWindowFocusState()
 
         // Restore the docked sidebar if it was pinned: `tabSidebarPinned`
@@ -227,6 +228,7 @@ extension MainView {
                 // takes its fast path when the helper is already confirmed up.
                 createLocalShellTab()
                 markPlaceholderShell()
+                LaunchSignposts.event("mainView.firstShell.sync")
             } else {
                 restorationInFlight = pendingState != nil
                 Task { @MainActor in
@@ -238,15 +240,18 @@ extension MainView {
                         Ghostty.logger.info("Restoring window state: \(savedState.tabs.count) tabs")
                         self.restoreWindowState(savedState)
                         self.restorationInFlight = false
+                        LaunchSignposts.event("mainView.firstShell.restored")
                         // A folder open that arrived during the restore was
                         // held back; it follows the restored tabs.
                         self.adoptPendingIntentRequestsAsFirstContent()
                     } else if self.adoptPendingIntentRequestsAsFirstContent() {
                         // On cold launch the URL often lands during the helper
                         // await above, after the synchronous claim missed it.
+                        LaunchSignposts.event("mainView.firstShell.intent")
                     } else {
                         // Normal fresh start - helper is already running from above
                         self.checkHelperAndCreateInitialTab()
+                        LaunchSignposts.event("mainView.firstShell.async")
                     }
                 }
             }
@@ -258,13 +263,16 @@ extension MainView {
                 RestorationHealthTracker.shared.markRestorationStarted()
                 Ghostty.logger.info("Restoring window state: \(savedState.tabs.count) tabs")
                 restoreWindowState(savedState)
+                LaunchSignposts.event("mainView.firstShell.restored")
             } else {
                 // iPad: directly open local iOS shell
                 // iPhone/visionOS: show connection sheet
                 if UIDevice.current.userInterfaceIdiom == .pad {
                     createLocalShellTabInternal()
+                    LaunchSignposts.event("mainView.firstShell.local")
                 } else {
                     addNewTab()
+                    LaunchSignposts.event("mainView.firstShell.sheet")
                 }
             }
 #endif

--- a/scripts/measure-cold-launch.sh
+++ b/scripts/measure-cold-launch.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Measure cold-launch time to first interactive session.
+#
+# Wall-clock from `open` until this process logs Ghostty "Session ready".
+#
+# Usage:
+#   ./scripts/measure-cold-launch.sh [path-to.app] [iterations]
+#
+set -euo pipefail
+
+APP="${1:-}"
+ITERATIONS="${2:-5}"
+SETTLE_SECONDS="${SETTLE_SECONDS:-3}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-90}"
+
+if [[ -z "$APP" ]]; then
+  matches=( "$HOME"/Library/Developer/Xcode/DerivedData/rootshell-*/Build/Products/DebugStandalone-maccatalyst/rootshell*.app )
+  if [[ ${#matches[@]} -eq 1 && -d "${matches[0]}" ]]; then
+    APP="${matches[0]}"
+  else
+    echo "usage: $0 /path/to/rootshell*.app [iterations]" >&2
+    echo "found ${#matches[@]} candidate app(s); pass the path explicitly." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d "$APP" ]]; then
+  echo "app not found: $APP" >&2
+  exit 1
+fi
+
+PROCESS_NAME=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist" 2>/dev/null || basename "$APP" .app)
+
+echo "App:        $APP"
+echo "Process:    $PROCESS_NAME"
+echo "Iterations: $ITERATIONS"
+echo "KPI:        wall-clock open → Session ready"
+echo
+
+kill_apps() {
+  killall "$PROCESS_NAME" rootshell-helper 2>/dev/null || true
+  if [[ "$PROCESS_NAME" != "rootshell" ]]; then
+    killall rootshell 2>/dev/null || true
+  fi
+  sleep "$SETTLE_SECONDS"
+}
+
+median() {
+  local -a sorted=()
+  local n line
+  if (($# == 0)); then
+    echo "n/a"
+    return
+  fi
+  while IFS= read -r line; do
+    sorted+=("$line")
+  done < <(printf '%s\n' "$@" | sort -n)
+  n=${#sorted[@]}
+  if ((n % 2 == 1)); then
+    echo "${sorted[$((n / 2))]}"
+  else
+    local a="${sorted[$((n / 2 - 1))]}"
+    local b="${sorted[$((n / 2))]}"
+    echo $(((a + b) / 2))
+  fi
+}
+
+samples=()
+
+for ((i = 1; i <= ITERATIONS; i++)); do
+  echo "── run $i/$ITERATIONS ──"
+  kill_apps
+
+  log_file=$(mktemp)
+  /usr/bin/log stream \
+    --level info \
+    --style compact \
+    --predicate 'subsystem == "com.kk2.rootshell" AND category == "ghostty"' \
+    >"$log_file" 2>&1 &
+  log_pid=$!
+  sleep 1
+
+  start_ns=$(python3 -c 'import time; print(time.time_ns())')
+  open -n "$APP"
+
+  # Wait for the new process, then require its PID in the ready line so we
+  # never accept a stale "Session ready" replayed from a prior launch.
+  pid=""
+  deadline=$((SECONDS + TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    pid=$(pgrep -n -x "$PROCESS_NAME" 2>/dev/null || true)
+    if [[ -n "$pid" ]]; then
+      break
+    fi
+    sleep 0.05
+  done
+
+  if [[ -z "$pid" ]]; then
+    kill "$log_pid" 2>/dev/null || true
+    wait "$log_pid" 2>/dev/null || true
+    rm -f "$log_file"
+    echo "  TIMEOUT: process $PROCESS_NAME did not start" >&2
+    continue
+  fi
+
+  ready=0
+  # Match: <process>[<pid>:...] ... Session ready
+  ready_pattern="${PROCESS_NAME}\\[${pid}:"
+  while (( SECONDS < deadline )); do
+    if grep -E "${ready_pattern}" "$log_file" 2>/dev/null | grep -F 'Session ready' >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    sleep 0.1
+  done
+  end_ns=$(python3 -c 'import time; print(time.time_ns())')
+
+  kill "$log_pid" 2>/dev/null || true
+  wait "$log_pid" 2>/dev/null || true
+  rm -f "$log_file"
+
+  if (( ready == 0 )); then
+    echo "  TIMEOUT: no Session ready for pid $pid within ${TIMEOUT_SECONDS}s" >&2
+    continue
+  fi
+
+  ms=$(( (end_ns - start_ns) / 1000000 ))
+  samples+=("$ms")
+  echo "  open → Session ready: ${ms}ms (pid $pid)"
+done
+
+kill_apps
+
+echo
+echo "══ summary ══"
+echo "open→Session ready  n=${#samples[@]}  median=$(median "${samples[@]:-}")ms  samples=${samples[*]:-none}"


### PR DESCRIPTION
## Summary

Cold launch is dominated by synchronous work before first paint (font registration/catalog, Ghostty init, Catalyst helper spawn)—not remaining app size (bundled fonts already went ~41MB → ~1.6MB). This PR optimizes the shared startup path and adds measurement tooling so we can keep iterating.

### Changes
- **FontManager critical-path split** — register only the selected family (+ utility fonts) before first paint; defer full bundled/custom registration and system-font discovery after a yield. Font settings awaits `ensureFontsLoaded()`.
- **Deferred app init** — move notification category registration and `LocationDiaryManager` out of `RootShellApp.init` into the once-per-launch `.task`.
- **Catalyst helper overlap** — pre-start `ensureHelperRunning()` from `CatalystAppDelegate`, with coalescing so concurrent callers share one ensure.
- **Launch instrumentation** — `LaunchSignposts` (`os_signpost` + Console ms-since-process-start) including `launch.interactive`.
- **`scripts/measure-cold-launch.sh`** — wall-clock `open` → Ghostty “Session ready” with PID-scoped detection.

## Findings (local MacBook Pro M1 Pro)

Fair A/B on DebugStandalone Mac Catalyst:

| Build | Median | Samples (ms) |
| --- | ---: | --- |
| **Before** (baseline without font deferral / helper prewarm / deferred init) | **6454** | 6814, 18497, 6095, 5776 *(1 timeout excluded)* |
| **After** (this PR) | **5754** | 10485, 5689, 5694, 5754, 5787 |

**Δ ≈ −700 ms (~11%)** to first interactive session. Post-warmup “after” runs are also tighter (~5.7s). First launch after a fresh build is still slow (~10–18s) on both sides (disk/cache cold start).

### How to read this
- KPI: wall-clock from `open` → Ghostty **Session ready** via `./scripts/measure-cold-launch.sh`.
- Absolute DebugStandalone times include helper spawn and debug overhead — use for commit A vs B on the same machine/setup, not as App Store absolute latency.
- Remaining time is still mostly outside the font catalog (Ghostty init, helper, themes); this is a meaningful first cut, not a 6s → 1s fix.

Reproduce:

```bash
xcodebuild -project rootshell.xcodeproj \
  -scheme rootshell-Standalone \
  -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
  build

./scripts/measure-cold-launch.sh \
  "$HOME/Library/Developer/Xcode/DerivedData/rootshell-"*/Build/Products/DebugStandalone-maccatalyst/rootshell.app \
  5
```

## Test plan
- [ ] Cold-launch DebugStandalone Mac Catalyst; local shell becomes interactive
- [ ] Font settings: catalog populates after brief loading; selected font has no flash on launch
- [ ] Quit/reopen restores windows normally
- [ ] Optional: re-run `scripts/measure-cold-launch.sh` and confirm median in the same ballpark