### PR TITLE
Fix profiles vanishing because sync JSON is UF_HIDDEN

### DIFF
--- a/rootshell/Core/Sync/SyncableFileStore.swift
+++ b/rootshell/Core/Sync/SyncableFileStore.swift
@@ -240,10 +240,16 @@ struct SyncableFileStore<T: SyncableRecord> {
         let storeName = self.storeName
         let fileURLs: [URL]
         do {
+            // Do not use `.skipsHiddenFiles`. The store lives under
+            // `Documents/.ghostty/...`, and on macOS files in a dot-directory
+            // are UF_HIDDEN — skipping them makes every profile (and other
+            // sync records) disappear from the UI while remaining on disk.
+            // Atomic temp files use a `.*.tmp` name and are already excluded
+            // by the `.json` path-extension filter below.
             fileURLs = try FileManager.default.contentsOfDirectory(
                 at: directoryURL,
                 includingPropertiesForKeys: [.contentModificationDateKey],
-                options: [.skipsHiddenFiles]
+                options: []
             )
             lastLoadFailed = false
         } catch {


### PR DESCRIPTION
## Summary
- Fixes [#412](https://github.com/kitknox/rootshell/issues/412): connection profiles (and other `SyncableFileStore` records) could disappear from the UI while their JSON files remained on disk.
- Root cause: stores live under `Documents/.ghostty/...`. On macOS, files in a dot-directory are `UF_HIDDEN`, and `contentsOfDirectory` was called with `.skipsHiddenFiles`, so every record was skipped on load.
- Stop using `.skipsHiddenFiles`. Atomic write temps (`.*.tmp`) are already excluded by the existing `.json` extension filter.

## Test plan
- [ ] On macOS Standalone, confirm profile JSON under `~/Documents/.ghostty/sync/connection_profiles/` has the Finder/UF_HIDDEN flag (or lives under `.ghostty`)
- [ ] Launch a build **without** this fix (or temporarily restore `.skipsHiddenFiles`): Profiles shows empty / “No profiles yet” while files remain on disk
- [ ] Launch a build **with** this fix: all active profiles appear again after quit/relaunch
- [ ] Create, edit, and soft-delete a profile; confirm reload still works and no `.tmp` leftovers are loaded
- [ ] Spot-check known hosts / SSH history sync stores still load after relaunch


Made with [Cursor](https://cursor.com)