### PR TITLE
Add coding-agent counters to the session Live Activity

### DIFF
--- a/SessionActivityWidget/AgentCountsViews.swift
+++ b/SessionActivityWidget/AgentCountsViews.swift
@@ -1,0 +1,96 @@
+//
+//  AgentCountsViews.swift
+//  SessionActivityWidget
+//
+//  Coding-agent counters for the session Live Activity: localized phrases
+//  and the summary line shared by the Dynamic Island and the watch tile.
+//
+
+import SwiftUI
+import WidgetKit
+
+/// Complete localized phrases for agent counts. Each is a whole phrase, not
+/// a number glued to a status word, so translators can reorder or inflect.
+enum AgentCountsText {
+    static func agents(_ count: Int) -> String {
+        count == 1
+            ? String(localized: "1 Agent")
+            : String(localized: "\(count) Agents")
+    }
+
+    static func needAttention(_ count: Int) -> String {
+        count == 1
+            ? String(localized: "1 needs attention")
+            : String(localized: "\(count) need attention")
+    }
+
+    static func working(_ count: Int) -> String {
+        count == 1
+            ? String(localized: "1 working")
+            : String(localized: "\(count) working")
+    }
+
+    static func idle(_ count: Int) -> String {
+        count == 1
+            ? String(localized: "1 idle")
+            : String(localized: "\(count) idle")
+    }
+
+    static var updatesPaused: String {
+        String(localized: "Updates paused")
+    }
+}
+
+/// "1 needs attention · 2 working · 1 idle", most urgent first, zero buckets
+/// omitted, with a dot colored by the worst bucket. Muted, with "Updates
+/// paused" appended, while the counts are a background snapshot.
+struct AgentSummaryLine: View {
+    let state: SessionActivityAttributes.ContentState
+    var font: Font = .caption
+    /// Muted tone for frozen text; `.secondary` washes out on tinted glass,
+    /// so the Lock Screen passes its own.
+    var mutedStyle: AnyShapeStyle = AnyShapeStyle(.secondary)
+
+    private var segments: [String] {
+        var parts: [String] = []
+        if state.agentAttentionCount > 0 {
+            parts.append(AgentCountsText.needAttention(state.agentAttentionCount))
+        }
+        if state.agentWorkingCount > 0 {
+            parts.append(AgentCountsText.working(state.agentWorkingCount))
+        }
+        if state.agentIdleCount > 0 {
+            parts.append(AgentCountsText.idle(state.agentIdleCount))
+        }
+        return parts
+    }
+
+    private var dotStyle: AnyShapeStyle {
+        if state.agentCountsFrozen { return mutedStyle }
+        if state.agentAttentionCount > 0 { return AnyShapeStyle(.orange) }
+        if state.agentWorkingCount > 0 { return AnyShapeStyle(.green) }
+        return mutedStyle
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(dotStyle)
+                .frame(width: 6, height: 6)
+            Text(segments.joined(separator: " \u{00B7} "))
+                .font(font)
+                .foregroundStyle(state.agentCountsFrozen ? mutedStyle : AnyShapeStyle(.primary))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if state.agentCountsFrozen {
+                Text("\u{00B7}")
+                    .font(font)
+                    .foregroundStyle(mutedStyle)
+                Text(AgentCountsText.updatesPaused)
+                    .font(font)
+                    .foregroundStyle(mutedStyle)
+                    .lineLimit(1)
+            }
+        }
+    }
+}

--- a/SessionActivityWidget/AgentCountsViews.swift
+++ b/SessionActivityWidget/AgentCountsViews.swift
@@ -62,6 +62,9 @@ struct AgentSummaryLine: View {
         if state.agentIdleCount > 0 {
             parts.append(AgentCountsText.idle(state.agentIdleCount))
         }
+        if state.agentCountsFrozen {
+            parts.append(AgentCountsText.updatesPaused)
+        }
         return parts
     }
 
@@ -81,16 +84,8 @@ struct AgentSummaryLine: View {
                 .font(font)
                 .foregroundStyle(state.agentCountsFrozen ? mutedStyle : AnyShapeStyle(.primary))
                 .lineLimit(1)
+                .minimumScaleFactor(0.8)
                 .truncationMode(.tail)
-            if state.agentCountsFrozen {
-                Text("\u{00B7}")
-                    .font(font)
-                    .foregroundStyle(mutedStyle)
-                Text(AgentCountsText.updatesPaused)
-                    .font(font)
-                    .foregroundStyle(mutedStyle)
-                    .lineLimit(1)
-            }
         }
     }
 }

--- a/SessionActivityWidget/SessionActivityLockScreenView.swift
+++ b/SessionActivityWidget/SessionActivityLockScreenView.swift
@@ -36,12 +36,31 @@ struct SessionActivityLockScreenView: View {
         isTinted ? AnyShapeStyle(.primary) : AnyShapeStyle(.blue)
     }
 
+    /// Agent accent — `.mint` is unreadable on tinted glass.
+    private var agentAccentStyle: AnyShapeStyle {
+        isTinted ? AnyShapeStyle(.primary) : AnyShapeStyle(.mint)
+    }
+
+    /// Attention accent for agents that need the user.
+    private var attentionAccentStyle: AnyShapeStyle {
+        isTinted ? AnyShapeStyle(.primary) : AnyShapeStyle(.orange)
+    }
+
+    /// Frozen agent counts render muted; same tone as the subtitle.
+    private var mutedAgentStyle: AnyShapeStyle {
+        AnyShapeStyle(subtitleStyle)
+    }
+
     private var hasVPN: Bool {
         state.vpnStatus != nil
     }
 
     private var hasSessions: Bool {
         state.sessionCount > 0
+    }
+
+    private var hasAgents: Bool {
+        state.agentTotalCount > 0
     }
 
     private var hasWiFiInfo: Bool {
@@ -78,6 +97,10 @@ struct SessionActivityLockScreenView: View {
             )
             .font(.headline)
             .foregroundStyle(.primary)
+        } else if hasAgents {
+            Text(AgentCountsText.agents(state.agentTotalCount))
+                .font(.headline)
+                .foregroundStyle(.primary)
         } else if hasVPN {
             Text("VPN Connected")
                 .font(.headline)
@@ -117,6 +140,22 @@ struct SessionActivityLockScreenView: View {
                 Label("\(state.roamCount) Roam", systemImage: "antenna.radiowaves.left.and.right")
                     .font(.caption2)
                     .foregroundStyle(vpnAccentStyle)
+            }
+            if hasAgents {
+                Label(AgentCountsText.agents(state.agentTotalCount), systemImage: "sparkles")
+                    .font(.caption2)
+                    .foregroundStyle(state.agentCountsFrozen ? mutedAgentStyle : agentAccentStyle)
+                if state.agentAttentionCount > 0 {
+                    Label(AgentCountsText.needAttention(state.agentAttentionCount), systemImage: "exclamationmark.bubble.fill")
+                        .font(.caption2)
+                        .foregroundStyle(state.agentCountsFrozen ? mutedAgentStyle : attentionAccentStyle)
+                }
+                if state.agentCountsFrozen {
+                    Text(AgentCountsText.updatesPaused)
+                        .font(.caption2)
+                        .foregroundStyle(mutedAgentStyle)
+                        .lineLimit(1)
+                }
             }
 
             Spacer()
@@ -189,13 +228,13 @@ struct SessionActivityLockScreenView: View {
             }
 
             // Session type badges + timer
-            if hasSessions {
+            if hasSessions || hasAgents {
                 sessionBadges(spacing: 8)
             }
 
             // VPN section — full width below
             if hasVPN {
-                if hasSessions {
+                if hasSessions || hasAgents {
                     Divider()
                         .background(.primary.opacity(0.3))
                 }
@@ -227,7 +266,7 @@ struct SessionActivityLockScreenView: View {
 
             // WiFi & Network section
             if hasWiFiInfo || hasNetworkInfo {
-                if hasSessions || hasVPN {
+                if hasSessions || hasAgents || hasVPN {
                     Divider()
                         .background(.primary.opacity(0.3))
                 }
@@ -345,6 +384,14 @@ struct SessionActivityLockScreenView: View {
                         .foregroundStyle(subtitleStyle)
                         .lineLimit(1)
                 }
+
+                // One agent line, only when the tile has room for it.
+                if hasAgents {
+                    ViewThatFits(in: .vertical) {
+                        AgentSummaryLine(state: state, font: .caption2, mutedStyle: mutedAgentStyle)
+                        EmptyView()
+                    }
+                }
             }
 
             Spacer(minLength: 0)
@@ -384,13 +431,13 @@ struct SessionActivityLockScreenView: View {
             }
 
             // Session type badges + timer (tighter spacing)
-            if hasSessions {
+            if hasSessions || hasAgents {
                 sessionBadges(spacing: 6)
             }
 
             // VPN section — condensed to 2 rows (header+host merged, traffic row)
             if hasVPN {
-                if hasSessions {
+                if hasSessions || hasAgents {
                     Divider()
                         .background(.primary.opacity(0.3))
                 }
@@ -425,7 +472,7 @@ struct SessionActivityLockScreenView: View {
 
             // WiFi + Network section
             if hasWiFiInfo || hasNetworkInfo {
-                if hasSessions || hasVPN {
+                if hasSessions || hasAgents || hasVPN {
                     Divider()
                         .background(.primary.opacity(0.3))
                 }

--- a/SessionActivityWidget/SessionActivityLockScreenView.swift
+++ b/SessionActivityWidget/SessionActivityLockScreenView.swift
@@ -41,11 +41,6 @@ struct SessionActivityLockScreenView: View {
         isTinted ? AnyShapeStyle(.primary) : AnyShapeStyle(.mint)
     }
 
-    /// Attention accent for agents that need the user.
-    private var attentionAccentStyle: AnyShapeStyle {
-        isTinted ? AnyShapeStyle(.primary) : AnyShapeStyle(.orange)
-    }
-
     /// Frozen agent counts render muted; same tone as the subtitle.
     private var mutedAgentStyle: AnyShapeStyle {
         AnyShapeStyle(subtitleStyle)
@@ -145,17 +140,6 @@ struct SessionActivityLockScreenView: View {
                 Label(AgentCountsText.agents(state.agentTotalCount), systemImage: "sparkles")
                     .font(.caption2)
                     .foregroundStyle(state.agentCountsFrozen ? mutedAgentStyle : agentAccentStyle)
-                if state.agentAttentionCount > 0 {
-                    Label(AgentCountsText.needAttention(state.agentAttentionCount), systemImage: "exclamationmark.bubble.fill")
-                        .font(.caption2)
-                        .foregroundStyle(state.agentCountsFrozen ? mutedAgentStyle : attentionAccentStyle)
-                }
-                if state.agentCountsFrozen {
-                    Text(AgentCountsText.updatesPaused)
-                        .font(.caption2)
-                        .foregroundStyle(mutedAgentStyle)
-                        .lineLimit(1)
-                }
             }
 
             Spacer()
@@ -230,6 +214,14 @@ struct SessionActivityLockScreenView: View {
             // Session type badges + timer
             if hasSessions || hasAgents {
                 sessionBadges(spacing: 8)
+            }
+
+            // Agent detail gets the full width. Keeping the attention and
+            // frozen-state phrases out of the badge row prevents them from
+            // wrapping into several narrow columns beside the timer.
+            if hasAgents {
+                AgentSummaryLine(state: state, mutedStyle: mutedAgentStyle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // VPN section — full width below
@@ -433,6 +425,11 @@ struct SessionActivityLockScreenView: View {
             // Session type badges + timer (tighter spacing)
             if hasSessions || hasAgents {
                 sessionBadges(spacing: 6)
+            }
+
+            if hasAgents {
+                AgentSummaryLine(state: state, font: .caption2, mutedStyle: mutedAgentStyle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // VPN section — condensed to 2 rows (header+host merged, traffic row)

--- a/SessionActivityWidget/SessionActivityWidget.swift
+++ b/SessionActivityWidget/SessionActivityWidget.swift
@@ -52,6 +52,10 @@ struct SessionActivityWidget: Widget {
                             )
                             .font(.headline)
                             .foregroundStyle(.white)
+                        } else if context.state.agentTotalCount > 0 {
+                            Text(AgentCountsText.agents(context.state.agentTotalCount))
+                                .font(.headline)
+                                .foregroundStyle(.white)
                         }
 
                         if !context.state.hostNames.isEmpty {
@@ -59,6 +63,11 @@ struct SessionActivityWidget: Widget {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
+                        }
+
+                        // Coding agents in expanded center
+                        if context.state.agentTotalCount > 0 {
+                            AgentSummaryLine(state: context.state)
                         }
 
                         // VPN info in expanded center
@@ -144,6 +153,11 @@ struct SessionActivityWidget: Widget {
                                 .font(.caption2)
                                 .foregroundStyle(.green)
                         }
+                        if context.state.agentTotalCount > 0 {
+                            Label("\(context.state.agentTotalCount)", systemImage: "sparkles")
+                                .font(.caption2)
+                                .foregroundStyle(context.state.agentCountsFrozen ? AnyShapeStyle(.secondary) : AnyShapeStyle(.mint))
+                        }
                     }
                 }
 
@@ -191,6 +205,14 @@ struct SessionActivityWidget: Widget {
                     .clipShape(RoundedRectangle(cornerRadius: 4))
             } compactTrailing: {
                 HStack(spacing: 2) {
+                    if context.state.agentAttentionCount > 0 {
+                        Image(systemName: "exclamationmark.bubble.fill")
+                            .font(.caption2)
+                            .foregroundStyle(context.state.agentCountsFrozen ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+                        Text("\(context.state.agentAttentionCount)")
+                            .font(.caption)
+                            .foregroundStyle(context.state.agentCountsFrozen ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+                    }
                     if context.state.wifiSSID != nil {
                         Image(systemName: "wifi")
                             .font(.caption2)

--- a/SessionActivityWidget/VPNLiveActivityUpdater.swift
+++ b/SessionActivityWidget/VPNLiveActivityUpdater.swift
@@ -47,7 +47,10 @@ enum VPNLiveActivityUpdater {
             state.vpnActiveConnections = nil
             state.lastUpdated = Date()
 
+            // Agent counts ride along untouched, including `agentCountsFrozen`,
+            // which only the app may clear; they keep an agent-only activity alive.
             let hasSessionContent = state.sessionCount > 0 || state.roamCount > 0 || state.localTaskCount > 0
+                || state.agentTotalCount > 0
             let hasInfoContent =
                 state.wifiSSID != nil ||
                 state.wifiAPName != nil ||

--- a/rootshell/Core/SettingsSync/Registry/Settings+Notifications.swift
+++ b/rootshell/Core/SettingsSync/Registry/Settings+Notifications.swift
@@ -143,9 +143,13 @@ nonisolated extension Settings {
             "live_activity_wifi_info_enabled", default: false, group: .liveActivity,
             configKey: "live-activity-wifi-info-enabled",
             title: String(localized: "Live Activity WiFi Info", comment: "Setting title"))
+        static let agents = SettingKey(
+            "live_activity_agents_enabled", default: false, group: .liveActivity,
+            configKey: "live-activity-agents-enabled",
+            title: String(localized: "Live Activity Coding Agents", comment: "Setting title"))
 
         static let all: [AnySettingDefinition] = [
-            enabled.erased, sessionFilter.erased, networkInfo.erased, wifiInfo.erased,
+            enabled.erased, sessionFilter.erased, networkInfo.erased, wifiInfo.erased, agents.erased,
         ]
     }
 

--- a/rootshell/Features/AgentAttention/AgentAttentionCenter.swift
+++ b/rootshell/Features/AgentAttention/AgentAttentionCenter.swift
@@ -1332,6 +1332,29 @@ final class AgentAttentionCenter {
         return counts
     }
 
+    /// Strict coding-agent census for the Live Activity. Unlike
+    /// `globalAgentCounts`, which rolls up every attention card, this counts
+    /// only panes whose detector identified an agent (`detectedAgentRow`,
+    /// category `.agent`): task rows and OSC-only Activity rows are skipped.
+    /// The bucket comes from the composed `agentRow` status so an OSC
+    /// progress overlay counts the way the sidebar shows it. One entry per
+    /// pane; Claude fleet sub-agents ride along with their session.
+    func codingAgentCounts() -> CodingAgentCounts {
+        var counts = CodingAgentCounts()
+        for model in TmuxWindowRegistry.allTabsModels() {
+            for tab in model.tabs {
+                for pane in tab.splitTree {
+                    guard let detected = pane.presentation.detectedAgentRow,
+                          detected.category == .agent,
+                          let row = pane.presentation.agentRow
+                    else { continue }
+                    counts.add(row.status)
+                }
+            }
+        }
+        return counts
+    }
+
     /// Live agent providers and the terminal that OWNS each one's connection
     /// (a tmux -CC pane resolves to its gateway). Feeds the usage tracker;
     /// providers without usage support simply do not map.
@@ -2072,6 +2095,7 @@ final class AgentAttentionCenter {
             // Agent identities may have appeared or moved hosts; the usage
             // center debounces, so this is a cheap no-op at steady state.
             AgentUsageCenter.shared.presenceMayHaveChanged()
+            notifyAggregateConsumers()
         }
     }
 
@@ -2082,6 +2106,16 @@ final class AgentAttentionCenter {
         guard !Ghostty.isAppBackgroundedAtomic else { return }
         guard updatePresentationRollups(now: now) else { return }
         revision &+= 1
+        notifyAggregateConsumers()
+    }
+
+    /// Consumers that read the census instead of observing per-tab models.
+    /// Runs on the main actor after the presentation rollups have settled and
+    /// only reads them, so nothing here can re-enter the publish pass.
+    private func notifyAggregateConsumers() {
+        #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
+        LiveActivityManager.shared.agentCountsMayHaveChanged()
+        #endif
     }
 
     /// Compare-and-write pass shared by the full detector publisher and the

--- a/rootshell/Features/AgentAttention/AgentAttentionCenter.swift
+++ b/rootshell/Features/AgentAttention/AgentAttentionCenter.swift
@@ -307,9 +307,10 @@ final class AgentAttentionCenter {
         }
         setCoreEventsEnabled(true)
         burstScansRemaining = Tuning.initialBurstScans
-        reconcile(scheduleInitialScans: true)
+        let topologyChanged = reconcile(scheduleInitialScans: true)
         seenPass()
         publish(now: Date())
+        if topologyChanged { notifyAggregateConsumers() }
         rescheduleTimer()
     }
 
@@ -361,9 +362,13 @@ final class AgentAttentionCenter {
             publishPresentationRollups(now: Date())
             return
         }
-        reconcile(scheduleInitialScans: true)
+        let topologyChanged = reconcile(scheduleInitialScans: true)
         seenPass()
         publish(now: Date())
+        // Removing a whole tab/window drops its monitors before `publish`, so
+        // no surviving presentation row necessarily changes. Still refresh
+        // consumers whose census is derived from the live tab registry.
+        if topologyChanged { notifyAggregateConsumers() }
         rescheduleTimer()
         // Panes appearing or closing changes which hosts hold live agents,
         // even when no display state moved in the publish above.
@@ -397,7 +402,7 @@ final class AgentAttentionCenter {
         wasEnabled = true
         setCoreEventsEnabled(true)
         burstScansRemaining = Tuning.initialBurstScans
-        reconcile(scheduleInitialScans: false)
+        let topologyChanged = reconcile(scheduleInitialScans: false)
         let now = Date()
         for paneUUID in monitors.keys {
             scanDeadlines.schedule(paneUUID, at: now)
@@ -405,6 +410,7 @@ final class AgentAttentionCenter {
         refreshRelevantRepositoryFacts(now: now)
         seenPass()
         publish(now: now)
+        if topologyChanged { notifyAggregateConsumers() }
         rescheduleTimer()
     }
 
@@ -1573,9 +1579,13 @@ final class AgentAttentionCenter {
     // MARK: - Reconcile
 
     /// Monitor lifetime is a pure function of the live tab tree.
-    private func reconcile(scheduleInitialScans: Bool) {
+    /// Returns true when panes entered or left the monitored topology. That
+    /// structural change can alter aggregate censuses even if no surviving
+    /// pane's presentation state changes during the following publish pass.
+    private func reconcile(scheduleInitialScans: Bool) -> Bool {
         var live: Set<UUID> = []
         let now = Date()
+        var topologyChanged = false
         for model in TmuxWindowRegistry.allTabsModels() {
             for tab in model.tabs {
                 // tmux -CC gateway tabs render control-mode chrome,
@@ -1586,6 +1596,7 @@ final class AgentAttentionCenter {
                     if let monitor = monitors[terminal.uuid] {
                         monitor.updateOwners(tab: tab, tabsModel: model)
                     } else {
+                        topologyChanged = true
                         monitors[terminal.uuid] = AgentPaneMonitor(
                             paneUUID: terminal.uuid,
                             terminal: terminal,
@@ -1600,11 +1611,13 @@ final class AgentAttentionCenter {
             }
         }
         for uuid in monitors.keys where !live.contains(uuid) {
+            topologyChanged = true
             monitors.removeValue(forKey: uuid)
             scanDeadlines.cancel(uuid)
             livenessDeadlines.cancel(uuid)
             AgentAttentionNotificationRouter.paneRemoved(uuid)
         }
+        return topologyChanged
     }
 
     // MARK: - Heavy scan (terminal mutex, budgeted)

--- a/rootshell/Features/AgentAttention/AgentAttentionModels.swift
+++ b/rootshell/Features/AgentAttention/AgentAttentionModels.swift
@@ -55,6 +55,27 @@ nonisolated enum AgentAttentionStatus: String, Codable, Sendable, Equatable, Cas
     }
 }
 
+/// Live Activity census of detected coding agents, bucketed by what the
+/// widget can say about them. `attention` folds blocked, failed and unseen
+/// done together: each one needs the user to look. Task rows and OSC-only
+/// Activity rows are never counted.
+nonisolated struct CodingAgentCounts: Equatable, Sendable {
+    var working = 0
+    var attention = 0
+    var idle = 0
+
+    var total: Int { working + attention + idle }
+
+    mutating func add(_ status: AgentAttentionStatus) {
+        switch status {
+        case .working: working += 1
+        case .blocked, .failed, .done: attention += 1
+        case .idle, .paused: idle += 1
+        case .unknown: break
+        }
+    }
+}
+
 // MARK: - Notification event identity
 
 /// Stable identity for one semantic attention event. Repeated scans,

--- a/rootshell/Features/LiveActivity/LiveActivityManager.swift
+++ b/rootshell/Features/LiveActivity/LiveActivityManager.swift
@@ -100,6 +100,17 @@ class LiveActivityManager {
         }
     }
 
+    /// Whether to show detected coding agents (working / need attention / idle)
+    var isAgentInfoEnabled: Bool {
+        didSet {
+            guard ProtectedDataGuard.isAvailable else { return }
+            if !isReloading {
+                SettingsStore.shared.set(Settings.LiveActivity.agents, isAgentInfoEnabled)
+            }
+            handleAgentToggleChanged()
+        }
+    }
+
     @ObservationIgnored
     private var isReloading = false
 
@@ -154,6 +165,32 @@ class LiveActivityManager {
     private var lastRoamCount: Int = 0
     @ObservationIgnored
     private var lastRoamHostNames: [String] = []
+
+    // MARK: - Coding Agent Cached State
+
+    @ObservationIgnored
+    private var lastAgentWorkingCount: Int = 0
+    @ObservationIgnored
+    private var lastAgentAttentionCount: Int = 0
+    @ObservationIgnored
+    private var lastAgentIdleCount: Int = 0
+
+    /// Coalesces bursts of census changes into one publish.
+    @ObservationIgnored
+    private var agentPublishTask: Task<Void, Never>?
+
+    /// The content most recently handed to ActivityKit, so the background
+    /// edge can republish it with `agentCountsFrozen` set without rebuilding
+    /// state (see `handleAppBackgrounded`).
+    @ObservationIgnored
+    private var lastPublishedState: SessionActivityAttributes.ContentState?
+
+    /// Serializes every ActivityKit publish so an older update cannot land
+    /// after a newer one.
+    @ObservationIgnored
+    private var publishChain: Task<Void, Never>?
+
+    private static let agentPublishCoalesceDelay: Duration = .seconds(1)
 
     // MARK: - VPN Cached State
 
@@ -238,9 +275,11 @@ class LiveActivityManager {
         self.sessionFilter = store.get(Settings.LiveActivity.sessionFilter)
         self.isWiFiInfoEnabled = store.get(Settings.LiveActivity.wifiInfo)
         self.isNetworkInfoEnabled = store.get(Settings.LiveActivity.networkInfo)
+        self.isAgentInfoEnabled = store.get(Settings.LiveActivity.agents)
         SettingsRefreshHub.shared.register(keys: [
             Settings.LiveActivity.enabled.name, Settings.LiveActivity.sessionFilter.name,
             Settings.LiveActivity.wifiInfo.name, Settings.LiveActivity.networkInfo.name,
+            Settings.LiveActivity.agents.name,
         ]) { [weak self] keys in self?.reload(keys: keys) }
 
         // Reclaim any orphaned Live Activity from a previous app launch.
@@ -308,6 +347,9 @@ class LiveActivityManager {
         }
         if keys.contains(Settings.LiveActivity.networkInfo.name) {
             isNetworkInfoEnabled = store.get(Settings.LiveActivity.networkInfo)
+        }
+        if keys.contains(Settings.LiveActivity.agents.name) {
+            isAgentInfoEnabled = store.get(Settings.LiveActivity.agents)
         }
     }
 
@@ -780,6 +822,103 @@ class LiveActivityManager {
         }
     }
 
+    // MARK: - Coding Agents
+
+    /// Called by `AgentAttentionCenter` after a publish pass changed the
+    /// aggregate. Re-reads the census and, if a bucket moved, schedules one
+    /// coalesced lifecycle reconcile. Scans run sub-second on the selected
+    /// pane and a permission prompt produces several passes in a row; each
+    /// publish is an XPC to liveactivitiesd and counts against the paired
+    /// Watch's sync budget, so bursts are folded into one update.
+    func agentCountsMayHaveChanged() {
+        guard isEnabled, isAgentInfoEnabled else { return }
+        guard !Ghostty.isAppBackgroundedAtomic else { return }
+        guard refreshAgentCountsCache() else { return }
+        scheduleAgentPublish()
+    }
+
+    /// Detected coding agents shown under the current filter.
+    var displayedAgentCount: Int {
+        guard isAgentInfoEnabled, sessionFilter != .vpnOnly else { return 0 }
+        return lastAgentWorkingCount + lastAgentAttentionCount + lastAgentIdleCount
+    }
+
+    private var shownAgentWorkingCount: Int { isAgentInfoEnabled ? lastAgentWorkingCount : 0 }
+    private var shownAgentAttentionCount: Int { isAgentInfoEnabled ? lastAgentAttentionCount : 0 }
+    private var shownAgentIdleCount: Int { isAgentInfoEnabled ? lastAgentIdleCount : 0 }
+
+    /// Snapshot the census into the cache. Returns true when a bucket changed.
+    @discardableResult
+    private func refreshAgentCountsCache() -> Bool {
+        let counts = AgentAttentionCenter.shared.codingAgentCounts()
+        guard counts.working != lastAgentWorkingCount
+            || counts.attention != lastAgentAttentionCount
+            || counts.idle != lastAgentIdleCount
+        else { return false }
+        lastAgentWorkingCount = counts.working
+        lastAgentAttentionCount = counts.attention
+        lastAgentIdleCount = counts.idle
+        return true
+    }
+
+    private func clearAgentCountsCache() {
+        lastAgentWorkingCount = 0
+        lastAgentAttentionCount = 0
+        lastAgentIdleCount = 0
+    }
+
+    private func scheduleAgentPublish() {
+        guard agentPublishTask == nil else { return }
+        agentPublishTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.agentPublishCoalesceDelay)
+            guard let self, !Task.isCancelled else { return }
+            self.agentPublishTask = nil
+            self.publishAgentCountsNow()
+        }
+    }
+
+    private func cancelAgentPublish() {
+        agentPublishTask?.cancel()
+        agentPublishTask = nil
+    }
+
+    /// Fire-time half of the debounce. The entry guard in
+    /// `agentCountsMayHaveChanged` is not enough: a task scheduled in the
+    /// foreground can fire after the background edge, and
+    /// `reconcileActivityLifecycle` has no gate of its own.
+    private func publishAgentCountsNow() {
+        guard isEnabled, isAgentInfoEnabled else { return }
+        guard !shouldSkipInfoPollingForLifecycle else {
+            // The cache is current; the foreground reconcile republishes it.
+            LifecycleDebugLogger.shared.bumpSuppression("liveActivity_agents")
+            return
+        }
+        // A pending start retry publishes the newest cache when it lands;
+        // requesting again here would burn retry attempts on count churn.
+        if startRetryTask != nil, hasEligibleActivityContent { return }
+        reconcileActivityLifecycle(reason: "agent counts changed")
+    }
+
+    private func handleAgentToggleChanged() {
+        guard isEnabled else { return }
+        cancelAgentPublish()
+        if isAgentInfoEnabled {
+            // Enabling is a meaningful user action, like a filter change:
+            // clear dismiss suppression and start-retry, snapshot the census
+            // now, and reconcile so an agent-only activity can spin up
+            // without waiting for the next status change.
+            userDismissed = false
+            cancelStartRetry(resetAttempts: true)
+            refreshAgentCountsCache()
+            reconcileActivityLifecycle(reason: "agent info enabled")
+        } else {
+            clearAgentCountsCache()
+            // Ends an agent-only activity; a mixed one republishes without
+            // the agent fields.
+            reconcileActivityLifecycle(reason: "agent info disabled")
+        }
+    }
+
     // MARK: - Filter Logic
 
     /// Computed filtered session count based on current filter
@@ -848,6 +987,9 @@ class LiveActivityManager {
                 networkASName: isNetworkInfoEnabled ? lastNetworkASName : nil,
                 networkCountryFlag: isNetworkInfoEnabled ? lastNetworkCountryFlag : nil,
                 networkType: isNetworkInfoEnabled ? lastNetworkType : nil,
+                agentWorkingCount: shownAgentWorkingCount,
+                agentAttentionCount: shownAgentAttentionCount,
+                agentIdleCount: shownAgentIdleCount,
                 appIconVariant: AppIconManager.shared.selectedVariant.rawValue
             )
 
@@ -882,6 +1024,9 @@ class LiveActivityManager {
                 networkASName: isNetworkInfoEnabled ? lastNetworkASName : nil,
                 networkCountryFlag: isNetworkInfoEnabled ? lastNetworkCountryFlag : nil,
                 networkType: isNetworkInfoEnabled ? lastNetworkType : nil,
+                agentWorkingCount: shownAgentWorkingCount,
+                agentAttentionCount: shownAgentAttentionCount,
+                agentIdleCount: shownAgentIdleCount,
                 appIconVariant: AppIconManager.shared.selectedVariant.rawValue
             )
         }
@@ -908,6 +1053,9 @@ class LiveActivityManager {
     private var hasEligibleActivityContent: Bool {
         guard isEnabled else { return false }
         if filteredSessionCount > 0 || hasActiveVPN { return true }
+        // Coding agents keep the activity alive on their own (a tssh-only
+        // user has no diary sessions to do it), except in VPN Only mode.
+        if displayedAgentCount > 0 { return true }
         // Info Only: keep activity alive on WiFi/Network info alone.
         // Require at least one info source enabled to avoid an empty widget.
         if sessionFilter == .infoOnly && (isWiFiInfoEnabled || isNetworkInfoEnabled) {
@@ -985,6 +1133,7 @@ class LiveActivityManager {
         currentActivity = nil
         activityStartDate = nil
         isActivityActive = false
+        lastPublishedState = nil
     }
 
     // MARK: - Activity Lifecycle
@@ -1034,6 +1183,7 @@ class LiveActivityManager {
                 content: content,
                 pushType: nil
             )
+            lastPublishedState = state
             isActivityActive = true
             let count = filteredSessionCount
             cancelStartRetry(resetAttempts: true)
@@ -1052,13 +1202,45 @@ class LiveActivityManager {
         guard let activity = currentActivity else { return }
 
         let state = filteredContentState(at: activityStartDate ?? Date())
-        let content = ActivityContent(state: state, staleDate: nil)
+        publish(state, to: activity, reason: "update")
+    }
 
-        Task {
-            await activity.update(content)
-            let count = self.filteredSessionCount
-            Self.logger.debug("Live Activity updated: \(count) session(s)")
+    /// Hands one content state to ActivityKit behind every publish before it,
+    /// so a slow earlier update cannot overwrite a newer one; the timestamp
+    /// lets the system drop anything that still arrives out of order.
+    private func publish(
+        _ state: SessionActivityAttributes.ContentState,
+        to activity: Activity<SessionActivityAttributes>,
+        reason: String
+    ) {
+        lastPublishedState = state
+        let content = ActivityContent(state: state, staleDate: nil)
+        let stamp = Date()
+        let previous = publishChain
+        publishChain = Task {
+            await previous?.value
+            await activity.update(content, alertConfiguration: nil, timestamp: stamp)
+            Self.logger.debug(
+                "Live Activity updated (\(reason, privacy: .public)): \(state.sessionCount) session(s), \(state.agentTotalCount) agent(s)")
         }
+    }
+
+    /// Called on the background edge, after the grace task is registered.
+    /// Agent detection stops the moment the app leaves the foreground, so the
+    /// counts on the widget become a snapshot: republish the last content
+    /// with `agentCountsFrozen` set so the widget can say so. Cached state
+    /// only: no `Activity.activities` lookup and no state rebuild, both of
+    /// which can stall inside the scene transaction (see the deferral notes
+    /// in `MainView+Lifecycle`). The foreground reconcile clears the flag.
+    func handleAppBackgrounded() {
+        cancelAgentPublish()
+        guard let activity = currentActivity,
+              var state = lastPublishedState,
+              state.agentTotalCount > 0,
+              !state.agentCountsFrozen
+        else { return }
+        state.agentCountsFrozen = true
+        publish(state, to: activity, reason: "background edge")
     }
 
     private func endActivity() {
@@ -1075,6 +1257,8 @@ class LiveActivityManager {
         currentActivity = nil
         activityStartDate = nil
         isActivityActive = false
+        cancelAgentPublish()
+        lastPublishedState = nil
 
         // Stop WiFi polling and network bridge, clean up shared favicons
         stopWiFiPolling()
@@ -1140,6 +1324,8 @@ class LiveActivityManager {
                         self.isActivityActive = false
                         self.stateObserverTask = nil
                         self.userDismissed = true
+                        self.cancelAgentPublish()
+                        self.lastPublishedState = nil
 
                         // Tear down WiFi/network machinery started alongside the activity
                         self.stopWiFiPolling()

--- a/rootshell/Features/LiveActivity/LiveActivityManager.swift
+++ b/rootshell/Features/LiveActivity/LiveActivityManager.swift
@@ -62,6 +62,9 @@ class LiveActivityManager {
             if !isEnabled {
                 endActivity()
             } else {
+                if isAgentInfoEnabled {
+                    refreshAgentCountsCache()
+                }
                 reconcileActivityLifecycle(reason: "feature enabled")
             }
         }
@@ -309,6 +312,7 @@ class LiveActivityManager {
         } else if let primary = orphans.first(where: { Self.isAdoptableActivityState($0.activityState) }) {
             Self.logger.info("Adopting orphaned Live Activity \(primary.id) from previous launch")
             currentActivity = primary
+            lastPublishedState = primary.content.state
             isActivityActive = true
             // activityStartDate isn't recoverable from ActivityKit; leave it
             // nil so the next updateActivity / startActivity uses Date(). The
@@ -426,6 +430,9 @@ class LiveActivityManager {
     func reconcileAfterActivation() {
         let start = CFAbsoluteTimeGetCurrent()
         LifecycleDebugLogger.shared.checkpoint("LiveActivity.reconcile.enter")
+        if isAgentInfoEnabled {
+            refreshAgentCountsCache()
+        }
         syncVPNStateFromWidgetState(reason: "activation")
         reconcileActivityLifecycle(reason: "app activation")
         LifecycleDebugLogger.shared.checkpoint("LiveActivity.reconcile.exit",
@@ -1098,6 +1105,7 @@ class LiveActivityManager {
 
         Self.logger.info("Adopting existing Live Activity \(primary.id) during lifecycle reconciliation")
         currentActivity = primary
+        lastPublishedState = primary.content.state
         isActivityActive = true
         observeActivityState()
         startInfoPollingDeferred()
@@ -1234,6 +1242,10 @@ class LiveActivityManager {
     /// in `MainView+Lifecycle`). The foreground reconcile clears the flag.
     func handleAppBackgrounded() {
         cancelAgentPublish()
+        // A retry has no activity to freeze yet. Let foreground activation
+        // re-drive the request instead of creating an unfrozen activity after
+        // the one background-edge callback has already passed.
+        cancelStartRetry(resetAttempts: true)
         guard let activity = currentActivity,
               var state = lastPublishedState,
               state.agentTotalCount > 0,
@@ -1373,6 +1385,14 @@ class LiveActivityManager {
             await MainActor.run {
                 guard let self else { return }
                 self.startRetryTask = nil
+
+                // Cancellation can race with this MainActor hop. Re-check the
+                // lifecycle at fire time so a retry can never start from the
+                // background; activation will reconcile cached state again.
+                guard !self.shouldSkipInfoPollingForLifecycle else {
+                    LifecycleDebugLogger.shared.bumpSuppression("liveActivity_startRetry")
+                    return
+                }
 
                 guard self.currentActivity == nil,
                       self.hasEligibleActivityContent,

--- a/rootshell/Features/LiveActivity/SessionActivityAttributes.swift
+++ b/rootshell/Features/LiveActivity/SessionActivityAttributes.swift
@@ -60,6 +60,27 @@ struct SessionActivityAttributes: ActivityAttributes {
         var networkCountryFlag: String? // "US 🇺🇸"
         var networkType: String?        // "WiFi", "Cellular", etc.
 
+        // MARK: - Coding Agents (0 = disabled or none detected)
+
+        /// Detected coding-agent sessions still running.
+        var agentWorkingCount: Int = 0
+
+        /// Detected coding-agent sessions that need the user: blocked on a
+        /// prompt, failed, or finished and not yet looked at.
+        var agentAttentionCount: Int = 0
+
+        /// Detected coding-agent sessions sitting idle or paused.
+        var agentIdleCount: Int = 0
+
+        /// True once the app has left the foreground. Agent detection stops
+        /// there, so the counts above are a snapshot until the next
+        /// foreground publish clears this. Widget-side updaters copy the
+        /// state and must leave it untouched.
+        var agentCountsFrozen: Bool = false
+
+        /// Total detected coding-agent sessions.
+        var agentTotalCount: Int { agentWorkingCount + agentAttentionCount + agentIdleCount }
+
         // MARK: - App Icon
 
         /// User-selected app icon variant (raw value of `AppIconVariant`).
@@ -96,6 +117,52 @@ struct SessionActivityAttributes: ActivityAttributes {
             default:                     return "AppIconPreview"
             }
         }
+    }
+}
+
+extension SessionActivityAttributes.ContentState {
+    /// Tolerant decoding for states written by an older app version.
+    ///
+    /// The manager adopts an orphaned activity from the previous launch and
+    /// reads its `content.state` back; synthesized `Codable` would throw on a
+    /// key the previous version never wrote, even for a property declared
+    /// with a default. Every field added after the first release is decoded
+    /// with `decodeIfPresent` here. Lives in an extension so the memberwise
+    /// initializer stays available; encoding stays synthesized.
+    ///
+    /// When adding a field: give it a default in the struct AND decode it
+    /// here with `decodeIfPresent`.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sessionCount = try c.decode(Int.self, forKey: .sessionCount)
+        sshCount = try c.decode(Int.self, forKey: .sshCount)
+        k8sCount = try c.decode(Int.self, forKey: .k8sCount)
+        consoleCount = try c.decode(Int.self, forKey: .consoleCount)
+        hostNames = try c.decode([String].self, forKey: .hostNames)
+        localTaskCount = try c.decodeIfPresent(Int.self, forKey: .localTaskCount) ?? 0
+        roamCount = try c.decodeIfPresent(Int.self, forKey: .roamCount) ?? 0
+        roamHostNames = try c.decodeIfPresent([String].self, forKey: .roamHostNames) ?? []
+        lastUpdated = try c.decode(Date.self, forKey: .lastUpdated)
+        vpnProfileName = try c.decodeIfPresent(String.self, forKey: .vpnProfileName)
+        vpnHost = try c.decodeIfPresent(String.self, forKey: .vpnHost)
+        vpnBytesIn = try c.decodeIfPresent(Int64.self, forKey: .vpnBytesIn)
+        vpnBytesOut = try c.decodeIfPresent(Int64.self, forKey: .vpnBytesOut)
+        vpnActiveConnections = try c.decodeIfPresent(Int.self, forKey: .vpnActiveConnections)
+        vpnConnectedSince = try c.decodeIfPresent(Date.self, forKey: .vpnConnectedSince)
+        vpnStatus = try c.decodeIfPresent(String.self, forKey: .vpnStatus)
+        wifiSSID = try c.decodeIfPresent(String.self, forKey: .wifiSSID)
+        wifiAPName = try c.decodeIfPresent(String.self, forKey: .wifiAPName)
+        wifiAPDetail = try c.decodeIfPresent(String.self, forKey: .wifiAPDetail)
+        wifiBand = try c.decodeIfPresent(String.self, forKey: .wifiBand)
+        networkPublicIP = try c.decodeIfPresent(String.self, forKey: .networkPublicIP)
+        networkASName = try c.decodeIfPresent(String.self, forKey: .networkASName)
+        networkCountryFlag = try c.decodeIfPresent(String.self, forKey: .networkCountryFlag)
+        networkType = try c.decodeIfPresent(String.self, forKey: .networkType)
+        agentWorkingCount = try c.decodeIfPresent(Int.self, forKey: .agentWorkingCount) ?? 0
+        agentAttentionCount = try c.decodeIfPresent(Int.self, forKey: .agentAttentionCount) ?? 0
+        agentIdleCount = try c.decodeIfPresent(Int.self, forKey: .agentIdleCount) ?? 0
+        agentCountsFrozen = try c.decodeIfPresent(Bool.self, forKey: .agentCountsFrozen) ?? false
+        appIconVariant = try c.decodeIfPresent(String.self, forKey: .appIconVariant) ?? ""
     }
 }
 #endif

--- a/rootshell/UI/Settings/SettingsSearchCatalog.swift
+++ b/rootshell/UI/Settings/SettingsSearchCatalog.swift
@@ -939,6 +939,8 @@ struct SettingsSearchEntry: Identifiable, Hashable {
                 keywords: ["wifi", "ssid", "live activity"]),
             row("live-activity-network", String(localized: "Network Info"), in: .liveActivity, icon: "network",
                 keywords: ["network", "ip", "live activity"]),
+            row("live-activity-agents", String(localized: "Coding Agents"), in: .liveActivity, icon: "sparkles",
+                keywords: ["agents", "claude", "codex", "coding", "attention", "live activity"]),
 
             // MARK: Clipboard Manager
             row("clipboard-biometrics", String(localized: "Require Face ID / Touch ID to Open"), in: .clipboardManager, icon: "faceid",

--- a/rootshell/UI/Settings/System/LiveActivitySettingsView.swift
+++ b/rootshell/UI/Settings/System/LiveActivitySettingsView.swift
@@ -104,16 +104,45 @@ struct LiveActivitySettingsView: View {
                     }
                     .themedRow()
                     .settingContextMenu(Settings.LiveActivity.networkInfo)
+
+                    Toggle(isOn: Bindable(liveActivityManager).isAgentInfoEnabled) {
+                        HStack(spacing: 12) {
+                            SettingsIcon(systemName: "sparkles")
+                            VStack(alignment: .leading) {
+                                HStack(spacing: 6) {
+                                    Text("Coding Agents")
+                                    SettingPinTag(Settings.LiveActivity.agents.erased)
+                                }
+                                Text("Show detected agents and how many need you on Lock Screen")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .themedRow()
+                    .settingContextMenu(Settings.LiveActivity.agents)
+
+                    if liveActivityManager.isAgentInfoEnabled && !AgentAttentionSettings.detectionEnabled {
+                        Text("Coding Agents requires agent detection. Enable it in Settings > Agents & Commands.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                            .themedRow()
+                    }
                 } footer: {
-                    if liveActivityManager.sessionFilter == .infoOnly
-                        && !liveActivityManager.isWiFiInfoEnabled
-                        && !liveActivityManager.isNetworkInfoEnabled {
-                        Text("Info Only mode requires at least WiFi Info or Network Info to be enabled.")
-                            .foregroundColor(.orange)
-                    } else if !LocationDiaryManager.shared.isTrackingActive
-                        && (liveActivityManager.isWiFiInfoEnabled || liveActivityManager.isNetworkInfoEnabled) {
-                        Text("Background updates require Location Diary to be active. Without it, data only refreshes while the app is in the foreground.")
-                            .foregroundColor(.orange)
+                    VStack(alignment: .leading, spacing: 4) {
+                        if liveActivityManager.sessionFilter == .infoOnly
+                            && !liveActivityManager.isWiFiInfoEnabled
+                            && !liveActivityManager.isNetworkInfoEnabled {
+                            Text("Info Only mode requires at least WiFi Info or Network Info to be enabled.")
+                                .foregroundColor(.orange)
+                        } else if !LocationDiaryManager.shared.isTrackingActive
+                            && (liveActivityManager.isWiFiInfoEnabled || liveActivityManager.isNetworkInfoEnabled) {
+                            Text("Background updates require Location Diary to be active. Without it, data only refreshes while the app is in the foreground.")
+                                .foregroundColor(.orange)
+                        }
+                        if liveActivityManager.isAgentInfoEnabled {
+                            Text("Agent counts come from on-device detection and update only while rootshell is in the foreground. The Lock Screen marks them as paused while rootshell is in the background.")
+                        }
                     }
                 }
 
@@ -124,6 +153,13 @@ struct LiveActivitySettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .themedRow()
+                        let agents = liveActivityManager.displayedAgentCount
+                        if agents > 0 {
+                            Text("Showing \(agents) coding agent\(agents == 1 ? "" : "s") on Lock Screen")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .themedRow()
+                        }
                     }
                 }
             }

--- a/rootshell/UI/Shell/MainView+Lifecycle.swift
+++ b/rootshell/UI/Shell/MainView+Lifecycle.swift
@@ -617,6 +617,14 @@ extension MainView {
         )
         #endif
 
+        #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
+        // Agent detection stops with this transition, so the Live Activity's
+        // agent counts become a snapshot: mark them frozen from cached state.
+        // No ActivityKit lookup and no state rebuild here (see the deferral
+        // notes in handleAppForegrounded).
+        LiveActivityManager.shared.handleAppBackgrounded()
+        #endif
+
         // SYNCHRONOUS prelude — these atomic flags are the canonical
         // "skip MainActor work" gates consulted by output handlers, the
         // Trzsz health monitor, the Citadel heartbeat, and the action-callback


### PR DESCRIPTION
Adds an opt-in Coding Agents row to the session Live Activity: how many detected agents are running, how many need the user (blocked, failed, or finished and not looked at yet), how many sit idle. Settings > System > Live Activity > Coding Agents, off by default.

Lock Screen gets "N Agents" and "M need attention" badges next to the session badges. The expanded island gets one line like "1 needs attention, 2 working, 1 idle" and a sparkles count in the trailing region. The compact island shows the attention count only when it is above zero. With no diary sessions (tssh only) the headline becomes "N Agents" and the agents alone keep the activity alive. VPN Only hides them.

Detection stops when the app leaves the foreground, so from that moment the counts are a snapshot. On the background edge the manager republishes the last content with agentCountsFrozen set, the widget mutes the row and adds "Updates paused". The next foreground publish clears it. I used a content field for this because VPNLiveActivityUpdater copies the state and republishes it with staleDate: nil from the Control Center intents, which would drop a stale mark. The field survives that copy.

Things I decided that you may want to check.

The census is new, AgentAttentionCenter.codingAgentCounts(). globalAgentCounts() rolls up task rows and OSC-only Activity rows too, so it did not fit. Only panes with a detectedAgentRow of category .agent are counted, by the composed agentRow status so OSC progress overlays match the sidebar. done goes into "need attention", per the ladder comment in AgentAttentionModels.

Both revision bump sites in AgentAttentionCenter call LiveActivityManager.agentCountsMayHaveChanged() under the ActivityKit guard. The manager compares with a cache and folds bursts into one publish after about a second. The fire-time path rechecks the setting and the lifecycle gates and leaves a pending start retry alone, otherwise count churn would burn the retry attempts.

Publishes go through one serial chain with update(_:alertConfiguration:timestamp:), so a slow earlier update cannot land after a newer one. The background-edge publish reuses the last published state only, no Activity.activities lookup and no state rebuild inside the scene transaction.

ContentState gets a tolerant init(from:) in an extension. The manager adopts an orphaned activity from the previous launch, and synthesized decoding throws on keys the previous build never wrote. Every field added after the first release now decodes with decodeIfPresent.

The new setting is mirrored into the manager like the other Live Activity keys (init, SettingsRefreshHub, reload). Turning it on clears the dismiss suppression and reconciles right away. Turning it off zeroes the cache and reconciles so an agent-only activity ends.

Not in this PR: fresh counts while backgrounded (that needs ActivityKit push from the hook side and a token transport that does not exist yet), translations for the new strings, and the guard in MainView+Lifecycle that treats an active Live Activity as a stronger background mode when deciding on the 30 s grace task. A Live Activity gives no background runtime, so that guard shortens background life for TCP SSH users who run the activity without the location diary. I can send that one separately.

Builds for iOS (rootshell-AppStore, DebugAppStore). Not verified on a device yet: the status transitions, the frozen mark on the background edge and its reset on foreground, tssh-only eligibility, the Control Center VPN toggle while backgrounded, swipe-dismiss suppression, upgrade over a running activity from the previous build.

One toolchain note. On Xcode 26.2 the app target fails to type-check an unrelated expression at SSHConnectionView.swift:470, on main as well. README asks for 26.4, so I suspect it is my machine. I verified the build with a temporary split of that expression, which is not part of this PR.
