### PR TITLE
Improve rf empty-directory and home-boundary guidance

### DIFF
--- a/rootshell/Features/FileBrowser/RFCommand.swift
+++ b/rootshell/Features/FileBrowser/RFCommand.swift
@@ -1889,6 +1889,7 @@ final class RFCommand {
             return
 
         case .parentColumn:
+            guard !activeTab.isAtRestrictedHome else { return }
             if button == .left {
                 let relRow = display.layout.parentRegion.relativeRow(row)
                 let entryIdx = (activeTab.parentDir?.scrollOffset ?? 0) + relRow
@@ -1966,6 +1967,7 @@ final class RFCommand {
 
         switch hit {
         case .parentColumn:
+            guard !activeTab.isAtRestrictedHome else { return }
             activeTab.parentDir?.scroll(delta: delta, visibleCount: vc)
             renderParentColumn()
 
@@ -2781,6 +2783,10 @@ final class RFCommand {
 
     private func renderParentColumnInner() {
         let tab = activeTab
+        if tab.isAtRestrictedHome {
+            display.drawCenteredMessages(["Home", "Navigation starts here"], region: display.layout.parentRegion)
+            return
+        }
         if let parent = tab.parentDir {
             if tab.isParentLoading && parent.visibleEntries.isEmpty {
                 display.drawCenteredMessage("Loading...", region: display.layout.parentRegion)
@@ -2807,6 +2813,18 @@ final class RFCommand {
     private func renderCurrentColumnInner() {
         let tab = activeTab
         let dir = activeDir
+        if dir.visibleEntries.isEmpty {
+            let messages: [String]
+            if tab.searchResults != nil || !(dir.filterText ?? "").isEmpty {
+                messages = ["No matches"]
+            } else if !dir.showHidden && dir.allEntries.contains(where: { $0.isHidden }) {
+                messages = ["No visible files", "Press . to show hidden files", "a: New file", "A: New folder"]
+            } else {
+                messages = ["No files", "a: New file", "A: New folder"]
+            }
+            display.drawCenteredMessages(messages, region: display.layout.currentRegion)
+            return
+        }
         let yankInfo: (paths: Set<String>, isCut: Bool)? = yankClipboard.map {
             (paths: Set($0.paths), isCut: $0.isCut)
         }

--- a/rootshell/Features/FileBrowser/RFDisplay.swift
+++ b/rootshell/Features/FileBrowser/RFDisplay.swift
@@ -556,6 +556,48 @@ final class RFDisplay {
         }
     }
 
+    /// Draw messages in priority order, wrapping within the column's cell width.
+    /// Short regions retain the headline and first hint before secondary actions.
+    func drawCenteredMessages(_ messages: [String], region: TUIRegion) {
+        guard region.width > 0, region.height > 0 else { return }
+        buffer.fill(row: region.row, col: region.col, width: region.width, height: region.height)
+        var lines: [String] = []
+        for message in messages {
+            var line = ""
+            for word in message.split(whereSeparator: { $0.isWhitespace }) {
+                let candidate = line.isEmpty ? String(word) : line + " " + word
+                if RFWidth.width(of: candidate) <= region.width {
+                    line = candidate
+                    continue
+                }
+                if !line.isEmpty {
+                    lines.append(line)
+                    line = ""
+                }
+                // Also handle a word wider than the region without splitting a glyph.
+                for character in word {
+                    if RFWidth.width(of: line) + RFWidth.width(of: character) > region.width {
+                        if !line.isEmpty { lines.append(line) }
+                        line = ""
+                    }
+                    if RFWidth.width(of: character) <= region.width {
+                        line.append(character)
+                    }
+                }
+            }
+            if !line.isEmpty { lines.append(line) }
+        }
+
+        let visibleLines = lines.prefix(region.height)
+        let startRow = region.row + (region.height - visibleLines.count) / 2
+        let style = TUIStyle(fg: theme.dimmed)
+        for (offset, line) in visibleLines.enumerated() {
+            let col = region.col + max(0, (region.width - RFWidth.width(of: line)) / 2)
+            buffer.writeTruncated(row: startRow + offset, col: col, line, style: style,
+                                  maxWidth: region.width)
+        }
+    }
+
     /// Draw a centered message in a region (for empty/binary/loading states).
     func drawCenteredMessage(_ message: String, region: TUIRegion) {
         buffer.fill(row: region.row, col: region.col, width: region.width, height: region.height)

--- a/rootshell/Features/FileBrowser/RFTab.swift
+++ b/rootshell/Features/FileBrowser/RFTab.swift
@@ -88,6 +88,13 @@ final class RFTab {
     /// Defaults to ~/Documents. Set to nil to allow unrestricted navigation.
     var rootPath: String?
 
+    /// The parent column has no navigable entries at the local home boundary.
+    var isAtRestrictedHome: Bool {
+        guard !dataSource.isRemote, let rootPath else { return false }
+        return (currentDir.path as NSString).standardizingPath
+            == (rootPath as NSString).standardizingPath
+    }
+
     /// Per-tab bookmarks (character key → absolute path).
     var bookmarks: [Character: String] = [:]
 


### PR DESCRIPTION
Show contextual empty states with hidden-file and creation hints. Clarify the restricted home boundary and keep guidance within columns.