### PR TITLE
Add keyboard-driven Quick Settings overlay

### DIFF
--- a/rootshell/App/AppCommands.swift
+++ b/rootshell/App/AppCommands.swift
@@ -556,6 +556,14 @@ struct ShellCommands: Commands {
                 )
             }
             .modifier(DynamicShortcut(action: .open_settings, shortcuts: shortcutState.shortcuts))
+
+            Button("Quick Settings…") {
+                UIApplication.shared.sendAction(
+                    #selector(UIApplication.menuToggleQuickSettings(_:)),
+                    to: nil, from: nil, for: nil
+                )
+            }
+            .modifier(DynamicShortcut(action: .toggle_quick_settings, shortcuts: shortcutState.shortcuts))
         }
     }
 }

--- a/rootshell/App/CatalystAppDelegate.swift
+++ b/rootshell/App/CatalystAppDelegate.swift
@@ -1410,17 +1410,31 @@ class CatalystAppDelegate: AppDelegate {
             modifierFlags: [.command]
         )
 
+        let quickSettings: UICommand
+        if let sequence = KeybindManager.shared.sequence(for: .toggle_quick_settings),
+           !sequence.isSequence, let trigger = sequence.first {
+            quickSettings = UIKeyCommand(
+                title: String(localized: "Quick Settings…"),
+                action: #selector(UIApplication.menuToggleQuickSettings(_:)),
+                input: trigger.uiKeyInput,
+                modifierFlags: trigger.uiModifierFlags
+            )
+        } else {
+            quickSettings = UICommand(title: String(localized: "Quick Settings…"),
+                                      action: #selector(UIApplication.menuToggleQuickSettings(_:)))
+        }
+
         #if !CHINA_BUILD
         let shellMenu = UIMenu(
             title: String(localized: "Shell"),
             identifier: UIMenu.Identifier("com.rootshell.shell"),
-            children: [browseHosts, browseProfiles, aiAgent, voiceAgent, settings]
+            children: [browseHosts, browseProfiles, aiAgent, voiceAgent, settings, quickSettings]
         )
         #else
         let shellMenu = UIMenu(
             title: String(localized: "Shell"),
             identifier: UIMenu.Identifier("com.rootshell.shell"),
-            children: [browseHosts, browseProfiles, settings]
+            children: [browseHosts, browseProfiles, settings, quickSettings]
         )
         #endif
 

--- a/rootshell/App/UIApplication+CommandFallback.swift
+++ b/rootshell/App/UIApplication+CommandFallback.swift
@@ -84,6 +84,10 @@ extension UIApplication {
         }?.session.persistentIdentifier
     }
 
+    @objc func menuToggleQuickSettings(_ sender: Any?) {
+        ghostty_postNotification(.toggleQuickSettings)
+    }
+
     // MARK: - Menu Actions (SwiftUI Commands)
 
     @objc func menuCreateLocalShell(_ sender: Any?) {

--- a/rootshell/Core/Keybinds/KeybindAction.swift
+++ b/rootshell/Core/Keybinds/KeybindAction.swift
@@ -135,6 +135,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     // Shell Operations
     /// Open settings
     case open_settings = "open_settings"
+    case toggle_quick_settings = "toggle_quick_settings"
     /// Open host browser
     case browse_hosts = "browse_hosts"
     /// Open profiles browser
@@ -311,7 +312,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
              .toggle_auto_redact:
             return .view
 
-        case .open_settings, .browse_hosts, .browse_profiles, .toggle_ai_agent, .toggle_voice_agent:
+        case .open_settings, .toggle_quick_settings, .browse_hosts, .browse_profiles, .toggle_ai_agent, .toggle_voice_agent:
             return .shell
 
         case .select_all, .clear_screen, .reset_terminal,
@@ -374,6 +375,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .toggle_split_zoom: return String(localized: "Toggle Split Zoom", comment: "Keybind action")
         case .equalize_splits: return String(localized: "Equalize Splits", comment: "Keybind action")
 
+        case .toggle_quick_settings: return String(localized: "Quick Settings")
         case .open_settings: return String(localized: "Settings", comment: "Keybind action: open settings")
         case .browse_hosts: return String(localized: "Browse Hosts", comment: "Keybind action")
         case .browse_profiles: return String(localized: "Browse Profiles", comment: "Keybind action")
@@ -461,6 +463,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .equalize_splits: return .equalizeSplits
 
         case .open_settings: return .openSettings
+        case .toggle_quick_settings: return .toggleQuickSettings
         case .browse_hosts: return .browseHosts
         case .browse_profiles: return .browseProfiles
         case .toggle_ai_agent: return .toggleAIAgent
@@ -596,7 +599,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
              .select_tab_4, .select_tab_5, .select_tab_6, .select_tab_7, .select_tab_8,
              .select_tab_9, .split_right, .split_down, .navigate_split_left,
              .navigate_split_right, .navigate_split_up, .navigate_split_down,
-             .toggle_split_zoom, .equalize_splits, .open_settings, .browse_hosts,
+             .toggle_split_zoom, .equalize_splits, .open_settings, .toggle_quick_settings, .browse_hosts,
              .browse_profiles, .toggle_ai_agent, .toggle_voice_agent, .toggle_tab_bar, .toggle_group_mode, .toggle_transparency,
              .toggle_titlebar, .toggle_auto_redact,
              .toggle_background_effect, .toggle_tab_switcher, .toggle_tab_expose, .show_tmux_sessions,

--- a/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
+++ b/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
@@ -126,7 +126,7 @@ final class KeybindCommandGenerator: ObservableObject {
              .select_tab_4, .select_tab_5, .select_tab_6, .select_tab_7, .select_tab_8,
              .select_tab_9, .split_right, .split_down, .navigate_split_left,
              .navigate_split_right, .navigate_split_up, .navigate_split_down,
-             .toggle_split_zoom, .equalize_splits, .open_settings, .browse_hosts,
+             .toggle_split_zoom, .equalize_splits, .open_settings, .toggle_quick_settings, .browse_hosts,
              .browse_profiles, .toggle_ai_agent, .toggle_voice_agent, .toggle_tab_bar, .toggle_group_mode, .toggle_tab_switcher,
              .toggle_tab_expose, .previous_group, .next_group, .show_tmux_sessions, .detach_other_clients,
              .toggle_transparency, .toggle_titlebar, .toggle_auto_redact, .toggle_background_effect, .toggle_compose,

--- a/rootshell/Core/Keybinds/KeybindManager.swift
+++ b/rootshell/Core/Keybinds/KeybindManager.swift
@@ -163,6 +163,7 @@ final class KeybindManager: ObservableObject {
 
             // Shell Operations
             Keybind(key: .comma, modifiers: .command, action: .open_settings),
+            Keybind(key: .comma, modifiers: [.command, .shift], action: .toggle_quick_settings),
             Keybind(key: .b, modifiers: .command, action: .browse_hosts),
             Keybind(key: .p, modifiers: [.command, .shift], action: .browse_profiles),
             Keybind(key: .i, modifiers: .command, action: .toggle_ai_agent),

--- a/rootshell/UI/Overlays/ClipboardManagerOverlay.swift
+++ b/rootshell/UI/Overlays/ClipboardManagerOverlay.swift
@@ -340,7 +340,7 @@ struct ClipboardManagerOverlay: View {
                 .frame(width: 380, height: Self.hudContentHeight)
         }
         .frame(width: 380)
-        .clipboardPanelBackground()
+        .floatingHUDPanelBackground()
         // Normally the HUD opens in passthrough and keyboard mode arrives via
         // onChange; onAppear covers a re-mount while the mode is already on.
         .onAppear {
@@ -1258,26 +1258,5 @@ private struct BoundedMonospacedTextBox: View {
 
         guard truncated else { return (text, false) }
         return (lines.joined(separator: "\n"), true)
-    }
-}
-
-// MARK: - Panel background
-
-private extension View {
-    /// Liquid-glass panel background matching the theme picker's
-    /// `themePickerBackground()` (duplicated because that helper is private).
-    @ViewBuilder
-    func clipboardPanelBackground() -> some View {
-        let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
-        #if os(visionOS)
-        self.background(.regularMaterial, in: shape)
-        #else
-        if #available(iOS 26.0, macOS 26.0, *) {
-            self.glassEffect(.regular, in: shape)
-        } else {
-            self.background(.ultraThinMaterial, in: shape)
-                .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
-        }
-        #endif
     }
 }

--- a/rootshell/UI/Overlays/DraggableHUDContainer.swift
+++ b/rootshell/UI/Overlays/DraggableHUDContainer.swift
@@ -31,6 +31,7 @@ struct DraggableHUDContainer<Content: View>: UIViewRepresentable {
     var inset: CGFloat
     var draggable: Bool
     var dismissShortcuts: [HUDKeyShortcut]
+    var forwardsQuickSettingsToggle: Bool
     var forwardsThemePickerToggle: Bool
     var forwardsFindToggle: Bool
     var forwardsClipboardManagerToggle: Bool
@@ -40,25 +41,30 @@ struct DraggableHUDContainer<Content: View>: UIViewRepresentable {
     /// first responder before keyboard mode is on (manual tap), and the toggle
     /// must then advance the cycle, not close.
     var onForwardedToggle: (() -> Void)?
+    var onFind: (() -> Void)?
     var onDismiss: (() -> Void)?
     var content: () -> Content
 
     init(inset: CGFloat = 12,
          draggable: Bool = true,
          dismissShortcuts: [HUDKeyShortcut] = [],
+         forwardsQuickSettingsToggle: Bool = false,
          forwardsThemePickerToggle: Bool = false,
          forwardsFindToggle: Bool = false,
          forwardsClipboardManagerToggle: Bool = false,
          onForwardedToggle: (() -> Void)? = nil,
+         onFind: (() -> Void)? = nil,
          onDismiss: (() -> Void)? = nil,
          @ViewBuilder content: @escaping () -> Content) {
         self.inset = inset
         self.draggable = draggable
         self.dismissShortcuts = dismissShortcuts
+        self.forwardsQuickSettingsToggle = forwardsQuickSettingsToggle
         self.forwardsThemePickerToggle = forwardsThemePickerToggle
         self.forwardsFindToggle = forwardsFindToggle
         self.forwardsClipboardManagerToggle = forwardsClipboardManagerToggle
         self.onForwardedToggle = onForwardedToggle
+        self.onFind = onFind
         self.onDismiss = onDismiss
         self.content = content
     }
@@ -68,10 +74,12 @@ struct DraggableHUDContainer<Content: View>: UIViewRepresentable {
         view.inset = inset
         view.isDraggable = draggable
         view.dismissShortcuts = dismissShortcuts
+        view.forwardsQuickSettingsToggle = forwardsQuickSettingsToggle
         view.forwardsThemePickerToggle = forwardsThemePickerToggle
         view.forwardsFindToggle = forwardsFindToggle
         view.forwardsClipboardManagerToggle = forwardsClipboardManagerToggle
         view.onForwardedToggle = onForwardedToggle
+        view.onFind = onFind
         view.onDismiss = onDismiss
 
         let host = UIHostingController(rootView: AnyView(content()))
@@ -92,8 +100,10 @@ struct DraggableHUDContainer<Content: View>: UIViewRepresentable {
         // Keep the hosted SwiftUI view + dismiss closure/shortcuts in sync. The HUD's
         // position lives on the UIView and is untouched by content updates.
         context.coordinator.host?.rootView = AnyView(content())
+        uiView.onFind = onFind
         uiView.onDismiss = onDismiss
         uiView.dismissShortcuts = dismissShortcuts
+        uiView.forwardsQuickSettingsToggle = forwardsQuickSettingsToggle
         uiView.forwardsThemePickerToggle = forwardsThemePickerToggle
         uiView.forwardsFindToggle = forwardsFindToggle
         uiView.forwardsClipboardManagerToggle = forwardsClipboardManagerToggle
@@ -131,10 +141,12 @@ final class DraggableHUDHostView: UIView, UIGestureRecognizerDelegate {
     var inset: CGFloat = 12
     var isDraggable = true
     var dismissShortcuts: [HUDKeyShortcut] = []
+    var forwardsQuickSettingsToggle = false
     var forwardsThemePickerToggle = false
     var forwardsFindToggle = false
     var forwardsClipboardManagerToggle = false
     var onForwardedToggle: (() -> Void)?
+    var onFind: (() -> Void)?
     var onDismiss: (() -> Void)?
 
     /// Once the user drags the HUD we preserve their chosen position. Before
@@ -153,10 +165,15 @@ final class DraggableHUDHostView: UIView, UIGestureRecognizerDelegate {
     // chain, so answering the selector lets the existing customizable shortcut dismiss
     // the HUD. Each is gated so only the matching HUD claims it.
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(menuToggleQuickSettings(_:)) { return forwardsQuickSettingsToggle }
         if action == #selector(menuToggleThemePicker(_:)) { return forwardsThemePickerToggle }
         if action == #selector(findInTerminal(_:)) { return forwardsFindToggle }
         if action == #selector(menuToggleClipboardManager(_:)) { return forwardsClipboardManagerToggle }
         return super.canPerformAction(action, withSender: sender)
+    }
+
+    @objc func menuToggleQuickSettings(_ sender: Any?) {
+        (onForwardedToggle ?? onDismiss)?()
     }
 
     @objc func menuToggleThemePicker(_ sender: Any?) {
@@ -168,7 +185,7 @@ final class DraggableHUDHostView: UIView, UIGestureRecognizerDelegate {
     }
 
     @objc func findInTerminal(_ sender: Any?) {
-        onDismiss?()
+        (onFind ?? onDismiss)?()
     }
 
     // MARK: Key commands
@@ -180,13 +197,26 @@ final class DraggableHUDHostView: UIView, UIGestureRecognizerDelegate {
     // even with wantsPriorityOverSystemBehavior — so those go through the menu action
     // (see canPerformAction / menuToggleThemePicker) instead.
     override var keyCommands: [UIKeyCommand]? {
-        guard !dismissShortcuts.isEmpty else { return nil }
-        return dismissShortcuts.map {
+        var commands = dismissShortcuts.map {
             let command = UIKeyCommand(input: $0.input, modifierFlags: $0.modifiers,
                                        action: #selector(handleDismissCommand(_:)))
             command.wantsPriorityOverSystemBehavior = true
             return command
         }
+        if forwardsQuickSettingsToggle,
+           let sequence = KeybindManager.shared.sequence(for: .toggle_quick_settings),
+           !sequence.isSequence, let trigger = sequence.first {
+            let command = UIKeyCommand(input: trigger.uiKeyInput, modifierFlags: trigger.uiModifierFlags,
+                                       action: #selector(menuToggleQuickSettings(_:)))
+            command.wantsPriorityOverSystemBehavior = true
+            commands.append(command)
+        }
+        if onFind != nil {
+            let command = UIKeyCommand(input: "f", modifierFlags: .command, action: #selector(findInTerminal(_:)))
+            command.wantsPriorityOverSystemBehavior = true
+            commands.append(command)
+        }
+        return commands.isEmpty ? nil : commands
     }
 
     @objc private func handleDismissCommand(_ command: UIKeyCommand) {

--- a/rootshell/UI/Overlays/FloatingHUDPanelBackground.swift
+++ b/rootshell/UI/Overlays/FloatingHUDPanelBackground.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+extension View {
+    /// Shared glass surface for floating pickers. Glass supplies its own
+    /// elevation; the manual shadow belongs only to the pre-26 fallback.
+    @ViewBuilder
+    func floatingHUDPanelBackground() -> some View {
+        let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+        #if os(visionOS)
+        self.background(.regularMaterial, in: shape)
+        #else
+        if #available(iOS 26.0, macOS 26.0, *) {
+            self.glassEffect(.regular, in: shape)
+        } else {
+            self.background(.ultraThinMaterial, in: shape)
+                .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
+        }
+        #endif
+    }
+}

--- a/rootshell/UI/Overlays/QuickSettingsOverlay.swift
+++ b/rootshell/UI/Overlays/QuickSettingsOverlay.swift
@@ -1,0 +1,365 @@
+import SwiftUI
+
+/// Owns the draft separately from persisted settings: incoming sync/config
+/// changes update result values without replacing text the user is editing.
+@MainActor @Observable
+final class QuickSettingsModel {
+    let entries: [QuickSetting]
+    private(set) var results: [QuickSetting]
+
+    init() {
+        let entries = QuickSettingsCatalog.makeEntries()
+        self.entries = entries
+        self.results = entries
+        self.selection = entries.first?.id
+    }
+    var query = ""
+    var selection: String?
+    var editing: QuickSetting?
+    var draft = ""
+    private(set) var choiceQuery = ""
+    var choiceSelection: String?
+    var error: String?
+    var feedback: String?
+    var focusRequest = 1
+    var catalogRevision = 0
+
+    private func matchingResults() -> [QuickSetting] {
+        return entries.compactMap { entry -> (QuickSetting, Int)? in
+            let metadata = [entry.definition.group.title, entry.definition.configKey ?? "", entry.keywords].joined(separator: " ")
+            guard let score = QuickSettingsInput.searchScore(query: query, title: entry.title, metadata: metadata) else { return nil }
+            return (entry, score)
+        }.sorted { lhs, rhs in
+            if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+            return (lhs.0.definition.group.title, lhs.0.title, lhs.0.id) < (rhs.0.definition.group.title, rhs.0.title, rhs.0.id)
+        }.map(\.0)
+    }
+
+    var choices: [QuickSetting.Choice] {
+        _ = catalogRevision
+        guard let editing, case .choices(let values) = editing.editor else { return [] }
+        let tokens = QuickSettingsInput.normalized(choiceQuery).split(whereSeparator: \.isWhitespace).map(String.init)
+        return values().filter { choice in tokens.allSatisfy(QuickSettingsInput.normalized(choice.title).contains) }
+    }
+
+    var selectedEntry: QuickSetting? { results.first { $0.id == selection } ?? results.first }
+    var selectedChoice: QuickSetting.Choice? { choices.first { $0.id == choiceSelection } ?? choices.first }
+
+    func searchChanged() {
+        results = matchingResults()
+        selection = results.first?.id
+        error = nil
+        feedback = nil
+    }
+
+    /// Only edits from the search field move selection to the first match.
+    /// activate() clears the query programmatically and selects the saved value.
+    func editChoiceQuery(_ query: String) {
+        choiceQuery = query
+        choiceSelection = choices.first?.id
+    }
+
+    func move(_ offset: Int) {
+        if let editing {
+            if case .number(let range, let step, let integral) = editing.editor {
+                let current = Double(draft) ?? 0
+                let value = min(range.upperBound, max(range.lowerBound, current - Double(offset) * step))
+                draft = integral ? String(Int(value)) : QuickSettingsInput.numberText(value)
+            } else {
+                choiceSelection = QuickSettingsInput.movedID(choices.map(\.id), current: choiceSelection, offset: offset)
+            }
+        } else {
+            selection = QuickSettingsInput.movedID(results.map(\.id), current: selection, offset: offset)
+        }
+    }
+
+    func activate(_ entry: QuickSetting) {
+        selection = entry.id
+        feedback = nil
+        if let reason = entry.disabledReason { error = reason; return }
+        if case .toggle = entry.editor {
+            guard case .bool(let value) = entry.read() else { return }
+            apply(entry, value: .bool(!value))
+            return
+        }
+        editing = entry
+        choiceQuery = ""
+        let value = entry.read()
+        switch value {
+        case .string(let text): draft = text
+        case .int(let number): draft = String(number)
+        case .double(let number): draft = QuickSettingsInput.numberText(number)
+        default: draft = ""
+        }
+        choiceSelection = choices.first { $0.value == value }?.id ?? choices.first?.id
+        error = nil
+        focusRequest += 1
+    }
+
+    func submit() {
+        guard let editing else {
+            if let selectedEntry { activate(selectedEntry) }
+            return
+        }
+        switch editing.editor {
+        case .choices:
+            if let selectedChoice { apply(editing, value: selectedChoice.value) }
+        case .number(_, _, let integral):
+            if integral {
+                guard let number = Int(draft) else { error = String(localized: "Enter a whole number."); return }
+                apply(editing, value: .int(number))
+            } else {
+                guard let number = Double(draft), number.isFinite else { error = String(localized: "Enter a number."); return }
+                apply(editing, value: .double(number))
+            }
+        case .color:
+            let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            apply(editing, value: text.isEmpty && editing.definition.isOptional ? nil : .string(text))
+        case .text: apply(editing, value: .string(draft))
+        case .toggle: break
+        }
+    }
+
+    func apply(_ entry: QuickSetting, value: CodableValue?) {
+        error = entry.commit(value)
+        guard error == nil else { return }
+        feedback = "\(entry.title): \(entry.valueLabel)"
+        editing = nil
+        focusRequest += 1
+    }
+
+    func cancelEditor() {
+        editing = nil
+        error = nil
+        focusRequest += 1
+    }
+
+    func focusSearch() {
+        cancelEditor()
+        focusRequest += 1
+    }
+}
+
+struct QuickSettingsHUD: View {
+    @Binding var isPresented: Bool
+    @State private var model = QuickSettingsModel()
+
+    var body: some View {
+        GeometryReader { geometry in
+            DraggableHUDContainer(
+                dismissShortcuts: [.escape],
+                forwardsQuickSettingsToggle: true,
+                forwardsFindToggle: true,
+                onForwardedToggle: { isPresented = false },
+                onFind: { model.focusSearch() },
+                onDismiss: {
+                    if model.editing != nil { model.cancelEditor() } else { isPresented = false }
+                }
+            ) {
+                QuickSettingsOverlay(model: model, isPresented: $isPresented,
+                    width: min(520, max(240, geometry.size.width - 24)),
+                    height: min(560, max(200, geometry.size.height - 24)))
+            }
+        }
+    }
+}
+
+struct QuickSettingsOverlay: View {
+    @Bindable var model: QuickSettingsModel
+    @Binding var isPresented: Bool
+    let width: CGFloat
+    let height: CGFloat
+    @State private var arrowRepeat = ArrowKeyRepeatManager()
+    // FontManager uses Combine rather than Observation.
+    @ObservedObject private var fonts = FontManager.shared
+
+    private var isChoiceEditor: Bool {
+        if let entry = model.editing, case .choices = entry.editor { return true }
+        return false
+    }
+
+    private var fieldText: Binding<String> {
+        if model.editing == nil { return $model.query }
+        if isChoiceEditor {
+            return Binding(
+                get: { model.choiceQuery },
+                set: { query in
+                    arrowRepeat.stop()
+                    model.editChoiceQuery(query)
+                }
+            )
+        }
+        return $model.draft
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                if model.editing != nil {
+                    Button { model.cancelEditor() } label: { Image(systemName: "chevron.left") }
+                        .accessibilityLabel("Back to Quick Settings")
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(model.editing?.title ?? String(localized: "Quick Settings")).font(.headline)
+                    Text(model.editing?.definition.group.title ?? String(localized: "Global preferences"))
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button { isPresented = false } label: { Image(systemName: "xmark.circle.fill").font(.title2) }
+                    .accessibilityLabel("Close Quick Settings")
+            }
+            .buttonStyle(.plain)
+            .padding(16)
+
+            HStack {
+                Image(systemName: model.editing == nil || isChoiceEditor ? "magnifyingglass" : "pencil")
+                    .foregroundStyle(.secondary)
+                SidebarSearchField(
+                    text: fieldText,
+                    placeholder: model.editing == nil ? String(localized: "Search settings") : isChoiceEditor ? String(localized: "Search values") : String(localized: "Enter a value"),
+                    fontSize: 17,
+                    canFocus: isPresented,
+                    focusRequestID: model.focusRequest,
+                    selectsAllOnFocus: true,
+                    onMoveUpBegan: { beginMovement(-1, .up) },
+                    onMoveUpEnded: { arrowRepeat.stop(direction: .up) },
+                    onMoveDownBegan: { beginMovement(1, .down) },
+                    onMoveDownEnded: { arrowRepeat.stop(direction: .down) },
+                    onEscape: {
+                        if model.editing != nil { model.cancelEditor() } else { isPresented = false }
+                    },
+                    onSubmit: { arrowRepeat.stop(); model.submit() },
+                    onFocusChange: { focused in if !focused { arrowRepeat.stop() } }
+                )
+                .frame(height: 24)
+                .accessibilityLabel(model.editing == nil ? String(localized: "Search settings") : String(localized: "Setting value"))
+            }
+            .padding(10)
+            .background(.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+            Divider()
+            if model.editing == nil { results }
+            else if isChoiceEditor { choiceResults }
+            else { valueEditor }
+            Divider()
+            VStack(alignment: .leading, spacing: 5) {
+                if let error = model.error {
+                    Text(error).foregroundStyle(.red).accessibilityLabel(String(localized: "Error: \(error)"))
+                } else if let feedback = model.feedback {
+                    Label(feedback, systemImage: "checkmark.circle.fill").foregroundStyle(.secondary)
+                }
+                Text(model.editing == nil ? "↑↓ Navigate   ↵ Change   ⌘F Search   Esc Close" : "↵ Apply   ⌘F Search   Esc Back")
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+        }
+        .frame(width: width, height: height)
+        .floatingHUDPanelBackground()
+        .onChange(of: model.query) { _, _ in arrowRepeat.stop(); model.searchChanged() }
+        .onChange(of: model.editing?.id) { _, _ in arrowRepeat.stop() }
+        .onChange(of: model.draft) { _, _ in model.error = nil }
+        .onDisappear { arrowRepeat.stop() }
+        .task {
+            await ThemeManager.shared.ensureThemesLoaded()
+            await fonts.ensureFontsLoaded()
+            model.catalogRevision += 1
+        }
+    }
+
+    private var results: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    if model.results.isEmpty { Text("No matching settings").foregroundStyle(.secondary).padding() }
+                    ForEach(model.results) { entry in
+                        Button { arrowRepeat.stop(); model.activate(entry) } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: entry.definition.group.systemImage).frame(width: 22).foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(entry.title).foregroundStyle(.primary)
+                                    Text(entry.definition.group.title).font(.caption).foregroundStyle(.secondary)
+                                }
+                                Spacer(minLength: 8)
+                                if entry.disabledReason != nil { Image(systemName: "lock.fill").font(.caption).foregroundStyle(.secondary) }
+                                Text(entry.valueLabel).foregroundStyle(.secondary).lineLimit(1).frame(maxWidth: 160, alignment: .trailing)
+                            }
+                            .padding(10)
+                            .background(model.selectedEntry?.id == entry.id ? Color.accentColor.opacity(0.15) : .clear, in: RoundedRectangle(cornerRadius: 8))
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityValue(entry.valueLabel)
+                        .accessibilityHint(entry.disabledReason ?? String(localized: "Change setting"))
+                        .id(entry.id)
+                    }
+                }.padding(8)
+            }
+            .onChange(of: model.selection) { _, id in if let id { proxy.scrollTo(id, anchor: .center) } }
+        }
+    }
+
+    private var choiceResults: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    if model.choices.isEmpty { Text("No matching values").foregroundStyle(.secondary).padding() }
+                    ForEach(model.choices) { choice in
+                        Button {
+                            if let entry = model.editing { model.apply(entry, value: choice.value) }
+                        } label: {
+                            HStack {
+                                Text(choice.title)
+                                Spacer()
+                                if model.editing?.read() == choice.value { Image(systemName: "checkmark") }
+                            }
+                            .padding(10)
+                            .background(model.selectedChoice?.id == choice.id ? Color.accentColor.opacity(0.15) : .clear, in: RoundedRectangle(cornerRadius: 8))
+                            .contentShape(Rectangle())
+                        }.buttonStyle(.plain).id(choice.id)
+                    }
+                }.padding(8)
+            }
+            .onAppear { if let id = model.choiceSelection { proxy.scrollTo(id, anchor: .center) } }
+            .onChange(of: model.choiceSelection) { _, id in if let id { proxy.scrollTo(id, anchor: .center) } }
+        }
+    }
+
+    private var valueEditor: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if let entry = model.editing {
+                Text("Current value: \(entry.valueLabel)").foregroundStyle(.secondary)
+                if !entry.note.isEmpty { Text(entry.note).font(.callout) }
+                if case .number(let range, let step, _) = entry.editor {
+                    Text("Range: \(range.lowerBound.formatted())–\(range.upperBound.formatted()). Step: \(step.formatted()).")
+                        .font(.callout).foregroundStyle(.secondary)
+                    HStack {
+                        Button { model.move(1) } label: { Label("Decrease", systemImage: "minus") }
+                        Button { model.move(-1) } label: { Label("Increase", systemImage: "plus") }
+                    }
+                    Text("Use ↑ and ↓ to adjust the value, then Return to apply.").font(.caption).foregroundStyle(.secondary)
+                }
+                if case .color = entry.editor {
+                    Text(entry.definition.isOptional ? "Enter #RRGGBB, or leave empty to use the theme default." : "Enter a color as #RRGGBB.")
+                        .font(.callout).foregroundStyle(.secondary)
+                    if QuickSettingsInput.isHexColor(model.draft), let color = Color(hex: model.draft) {
+                        RoundedRectangle(cornerRadius: 8).fill(color).frame(height: 44)
+                            .accessibilityLabel("Color preview")
+                    }
+                }
+                Button("Apply") { model.submit() }.buttonStyle(.borderedProminent)
+                if let reason = entry.disabledReason { Text(reason).font(.caption).foregroundStyle(.secondary) }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func beginMovement(_ offset: Int, _ direction: ArrowKeyRepeatManager.Direction) {
+        model.move(offset)
+        arrowRepeat.start(direction: direction) { model.move(offset) }
+    }
+}

--- a/rootshell/UI/Overlays/ThemePickerOverlay.swift
+++ b/rootshell/UI/Overlays/ThemePickerOverlay.swift
@@ -179,7 +179,7 @@ struct ThemePickerOverlay: View {
             .frame(height: 350)
         }
         .frame(width: 340)
-        .themePickerBackground()
+        .floatingHUDPanelBackground()
         // Cmd-Shift-T / Escape dismissal is handled by host-level UIKeyCommands in
         // DraggableHUDContainer — a SwiftUI .onKeyPress here is preempted on macOS by
         // the app's registered Cmd-Shift-T menu shortcut.
@@ -465,24 +465,4 @@ struct ThemePickerOverlay: View {
         favoriteManager.toggleFavorite(theme.id)
     }
 
-}
-
-private extension View {
-    /// Liquid-glass panel background matching the find HUD's `searchOverlayBackground()`,
-    /// at the picker's 16pt radius. `glassEffect` supplies its own elevation, so the
-    /// manual shadow is only kept in the pre-26 fallback.
-    @ViewBuilder
-    func themePickerBackground() -> some View {
-        let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
-        #if os(visionOS)
-        self.background(.regularMaterial, in: shape)
-        #else
-        if #available(iOS 26.0, macOS 26.0, *) {
-            self.glassEffect(.regular, in: shape)
-        } else {
-            self.background(.ultraThinMaterial, in: shape)
-                .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
-        }
-        #endif
-    }
 }

--- a/rootshell/UI/Settings/QuickSettingsCatalog.swift
+++ b/rootshell/UI/Settings/QuickSettingsCatalog.swift
@@ -1,0 +1,386 @@
+import SwiftUI
+
+/// Deliberate opt-in: being a scalar registry value does not make a setting safe
+/// to edit without its full workflow. Setters mirror the owning Settings screen.
+@MainActor
+struct QuickSetting: Identifiable {
+    struct Choice: Identifiable {
+        let id: String
+        let title: String
+        let value: CodableValue?
+    }
+
+    enum Editor {
+        case toggle
+        case choices(() -> [Choice])
+        case number(range: ClosedRange<Double>, step: Double, integral: Bool)
+        case text
+        case color
+    }
+
+    let definition: AnySettingDefinition
+    let editor: Editor
+    var keywords: String = ""
+    var note: String = ""
+    var unavailableReason: () -> String? = { nil }
+    let read: () -> CodableValue?
+    let write: (CodableValue?) -> Void
+    var id: String { definition.name }
+    var title: String { definition.title }
+
+    var disabledReason: String? {
+        if !ProtectedDataGuard.isAvailable { return String(localized: "Unlock your device to edit settings.") }
+        if SettingFileLock.isReadOnly(id) { return String(localized: "Managed by your config file. Enable write-back in Settings to edit.") }
+        return unavailableReason()
+    }
+
+    var valueLabel: String {
+        let value = read()
+        if case .choices(let choices) = editor,
+           let choice = choices().first(where: { $0.value == value }) { return choice.title }
+        return value?.displayString ?? String(localized: "Default")
+    }
+
+    func commit(_ value: CodableValue?) -> String? {
+        if let disabledReason { return disabledReason }
+        if let value {
+            guard definition.validate(value) else { return String(localized: "Invalid setting value.") }
+        } else if !definition.isOptional {
+            return String(localized: "A value is required.")
+        }
+        switch editor {
+        case .choices(let choices):
+            guard choices().contains(where: { $0.value == value }) else { return String(localized: "Choose an available value.") }
+        case .number(let range, _, let integral):
+            let number: Double
+            switch value {
+            case .int(let n): number = Double(n)
+            case .double(let n): number = n
+            default: return String(localized: "Enter a number.")
+            }
+            guard QuickSettingsInput.validNumber(number, range: range, integral: integral) else {
+                return String(localized: "Enter a value from \(range.lowerBound.formatted()) to \(range.upperBound.formatted()).")
+            }
+        case .color:
+            if case .string(let hex) = value, !QuickSettingsInput.isHexColor(hex) {
+                return String(localized: "Enter a six-digit hex color, such as #AABBCC.")
+            }
+        case .text:
+            if case .string(let text) = value, text.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) {
+                return String(localized: "Enter a single line of text.")
+            }
+        case .toggle: break
+        }
+        write(value)
+        return nil
+    }
+
+    func requiring(_ reason: @escaping () -> String?) -> Self {
+        var copy = self
+        copy.unavailableReason = reason
+        return copy
+    }
+
+    func annotated(_ text: String) -> Self {
+        var copy = self
+        copy.note = text
+        return copy
+    }
+}
+
+@MainActor
+enum QuickSettingsCatalog {
+    private static func entry<V: SettingValue>(
+        _ key: SettingKey<V>, _ editor: QuickSetting.Editor,
+        keywords: String = "", set: ((V) -> Void)? = nil
+    ) -> QuickSetting {
+        QuickSetting(definition: key.erased, editor: editor, keywords: keywords,
+            read: { SettingsStore.shared.box(for: key.name).value ?? key.defaultValue.codableValue },
+            write: { value in
+                let decoded = value.flatMap(V.init(codableValue:)) ?? key.defaultValue
+                if let set { set(decoded) } else { SettingsStore.shared.set(key, decoded) }
+            })
+    }
+
+    private static func toggle(_ key: SettingKey<Bool>, inverted: Bool = false, set: ((Bool) -> Void)? = nil) -> QuickSetting {
+        var result = entry(key, .toggle, set: set)
+        if inverted {
+            result = QuickSetting(definition: key.erased, editor: .toggle,
+                read: {
+                    let value = SettingsStore.shared.box(for: key.name).value.flatMap(Bool.init(codableValue:)) ?? key.defaultValue
+                    return .bool(!value)
+                },
+                write: { if case .bool(let value) = $0 { SettingsStore.shared.set(key, !value) } })
+        }
+        return result
+    }
+
+    private static func choices<V: SettingValue & CaseIterable>(
+        _ key: SettingKey<V>, label: @escaping (V) -> String, set: ((V) -> Void)? = nil
+    ) -> QuickSetting {
+        entry(key, .choices {
+            V.allCases.enumerated().map { .init(id: String($0.offset), title: label($0.element), value: $0.element.codableValue) }
+        }, set: set)
+    }
+
+    private static func number(_ key: SettingKey<Double>, _ range: ClosedRange<Double>, step: Double = 1, set: ((Double) -> Void)? = nil) -> QuickSetting {
+        entry(key, .number(range: range, step: step, integral: false), set: set)
+    }
+
+    private static func integer(_ key: SettingKey<Int>, _ range: ClosedRange<Int>, set: ((Int) -> Void)? = nil) -> QuickSetting {
+        entry(key, .number(range: Double(range.lowerBound)...Double(range.upperBound), step: 1, integral: true), set: set)
+    }
+
+    static func makeEntries() -> [QuickSetting] {
+        var entries: [QuickSetting] = [
+            choices(Settings.Theme.appearanceMode, label: { $0.displayName }, set: { AppearanceManager.shared.currentAppearanceMode = $0 }),
+            toggle(Settings.Theme.themedUI, set: { AppearanceManager.shared.themedUIEnabled = $0 }),
+            toggle(Settings.Theme.imNoFun),
+            entry(Settings.Theme.selected, .choices {
+                ThemeManager.shared.availableThemes.map { .init(id: $0.name, title: $0.name, value: .string($0.name)) }
+            }, keywords: "appearance colors colour scheme", set: { ThemeManager.shared.currentTheme = $0 })
+                .requiring { SettingsStore.shared.get(Settings.Theme.dayNightEnabled) ? String(localized: "Match System Theme is enabled. Change Day Theme or Night Theme instead.") : nil },
+            toggle(Settings.Theme.dayNightEnabled, set: { DayNightThemeManager.shared.enabled = $0 }),
+            entry(Settings.Theme.dayNightDay, .choices {
+                ThemeManager.shared.availableThemes.map { .init(id: $0.name, title: $0.name, value: .string($0.name)) }
+            }, set: { DayNightThemeManager.shared.dayTheme = $0 })
+                .requiring { SettingsStore.shared.get(Settings.Theme.dayNightEnabled) ? nil : String(localized: "Enable Match System Theme first.") },
+            entry(Settings.Theme.dayNightNight, .choices {
+                ThemeManager.shared.availableThemes.map { .init(id: $0.name, title: $0.name, value: .string($0.name)) }
+            }, set: { DayNightThemeManager.shared.nightTheme = $0 })
+                .requiring { SettingsStore.shared.get(Settings.Theme.dayNightEnabled) ? nil : String(localized: "Enable Match System Theme first.") },
+        ]
+        entries += [
+            number(Settings.Font.size, 4...24, set: { FontManager.shared.currentFontSize = $0 }),
+            toggle(Settings.Font.ligatures, set: { FontManager.shared.ligaturesEnabled = $0 }),
+            entry(Settings.Font.family, .choices {
+                let manager = FontManager.shared
+                let families = (manager.availableFamilies + manager.systemFontFamilies).map { ($0.configName, $0.displayName) }
+                    + manager.customFontFamilies.map { ($0.configName, $0.displayName) }
+                var seen: Set<String> = []
+                return [.init(id: "default", title: String(localized: "Default"), value: nil)] + families.filter { seen.insert($0.0).inserted }.map {
+                    .init(id: $0.0, title: $0.1, value: .string($0.0))
+                }
+            }, keywords: "typeface typography", set: { FontManager.shared.currentFontFamily = $0 }),
+        ]
+        entries += [
+            choices(Settings.Cursor.style, label: { $0.displayName }, set: { CursorManager.shared.cursorStyle = $0 }),
+            toggle(Settings.Cursor.blinkEnabled, set: { CursorManager.shared.cursorBlinkEnabled = $0 }),
+            choices(Settings.Cursor.blinkMode, label: { $0.displayName }, set: { CursorManager.shared.cursorBlinkMode = $0 })
+                .requiring { CursorManager.shared.cursorBlinkEnabled ? nil : String(localized: "Enable Cursor Blinking first.") },
+            choices(Settings.Cursor.effect, label: { $0.displayName }, set: { CursorManager.shared.cursorEffect = $0 }),
+            number(Settings.Cursor.opacity, 0...1, step: 0.05, set: { CursorManager.shared.cursorOpacity = $0 }),
+            integer(Settings.Cursor.thickness, -4...10, set: { CursorManager.shared.cursorThickness = $0 }),
+            integer(Settings.Cursor.height, -4...10, set: { CursorManager.shared.cursorHeight = $0 }),
+            entry(Settings.Cursor.color, .color, set: { CursorManager.shared.cursorColor = $0 }),
+            entry(Settings.Cursor.textColor, .color, set: { CursorManager.shared.cursorTextColor = $0 }),
+        ]
+        entries += [
+            toggle(Settings.Palette.generate, set: { PaletteManager.shared.paletteGenerateEnabled = $0 }),
+            toggle(Settings.Palette.harmonious, set: { PaletteManager.shared.paletteHarmoniousEnabled = $0 })
+                .requiring { PaletteManager.shared.paletteGenerateEnabled ? nil : String(localized: "Enable Generate Palette first.") },
+            choices(Settings.Selection.appearanceMode, label: { $0.displayName }, set: { SelectionManager.shared.selectionMode = $0 }),
+            entry(Settings.Selection.foregroundHex, .color, set: { SelectionManager.shared.customForegroundHex = $0 })
+                .requiring { SelectionManager.shared.selectionMode == .custom ? nil : String(localized: "Choose Custom Selection Style first.") },
+            entry(Settings.Selection.backgroundHex, .color, set: { SelectionManager.shared.customBackgroundHex = $0 })
+                .requiring { SelectionManager.shared.selectionMode == .custom ? nil : String(localized: "Choose Custom Selection Style first.") },
+            choices(Settings.Shaders.animationMode, label: { $0.displayName }, set: { ShaderManager.shared.animationMode = $0 }),
+            toggle(Settings.Selection.copyOnSelect, set: {
+                SettingsStore.shared.set(Settings.Selection.copyOnSelect, $0)
+                // Local writes do not dispatch SettingsRefreshHub. Push the
+                // regenerated config so existing terminals see the change.
+                Ghostty.App.shared?.reloadGlobalConfig()
+            }),
+        ]
+        entries += [
+            choices(Settings.Keyboard.optionKeyAsAlt, label: { $0.displayName }),
+            toggle(Settings.Keyboard.composeAutocorrect),
+            choices(Settings.Window.splitFocusBorderStyle, label: { $0.displayName }),
+            choices(Settings.Window.splitFocusBorderColor, label: { $0.displayName }),
+            entry(Settings.Window.splitFocusBorderCustomColor, .color).requiring {
+                SettingsStore.shared.get(Settings.Window.splitFocusBorderColor) == .custom ? nil : String(localized: "Choose Custom Split Border Color first.")
+            },
+        ]
+        entries += [
+            choices(Settings.Tabs.newTabAction, label: { $0.displayName }),
+            toggle(Settings.Tabs.barHidden, inverted: true),
+            toggle(Settings.Tabs.barAnimationsDisabled),
+            choices(Settings.Tabs.topTabStyle, label: { $0.displayName }),
+            toggle(Settings.Tabs.compactPillSpacing),
+            toggle(Settings.Tabs.showScopeMenu),
+            toggle(Settings.Tabs.showShortcutIndicators),
+            toggle(Settings.Tabs.exposeShowsCaptions),
+            toggle(Settings.Sidebar.autoHideOnSelect),
+            toggle(Settings.Sidebar.largeControls),
+            integer(Settings.Sidebar.rowLines, 1...3),
+        ]
+        entries += [
+            choices(Settings.Power.maxRefreshRate, label: { $0.displayName }, set: { PowerManager.shared.maxRefreshRate = $0 }),
+            choices(Settings.Power.batteryRefreshRate, label: { $0.displayName }, set: { PowerManager.shared.batteryRefreshRate = $0 })
+                .requiring { PowerManager.shared.maxRefreshRate == .adaptive ? nil : String(localized: "Choose Adaptive Maximum Refresh Rate first.") },
+            toggle(Settings.Power.autoSaver, set: { PowerManager.shared.autoSaverEnabled = $0 }),
+            toggle(Settings.SessionRestore.sessionPersistence),
+            entry(Settings.Terminal.terminalTypeLocal, .text, keywords: "TERM shell")
+                .annotated(String(localized: "Applies to new local sessions.")),
+            entry(Settings.Terminal.terminalTypeRemote, .text, keywords: "TERM ssh mosh tssh")
+                .annotated(String(localized: "Applies to new remote sessions.")),
+        ]
+        entries += [
+            choices(Settings.Locale.clockFormat, label: { $0.displayName }),
+            entry(Settings.Locale.mode, .choices {
+                [
+                    .init(id: "auto", title: String(localized: "Automatic"), value: .string("auto")),
+                    .init(id: "none", title: String(localized: "Don't Send"), value: .string("none")),
+                    .init(id: "custom", title: String(localized: "Custom"), value: .string("custom")),
+                ]
+            }),
+            entry(Settings.Locale.custom, .text).requiring {
+                SettingsStore.shared.get(Settings.Locale.mode) == .custom ? nil : String(localized: "Choose Custom Locale first.")
+            },
+            choices(Settings.Sounds.bellPreset, label: { $0.displayName }, set: { SoundManager.shared.bellPreset = $0 }),
+            choices(Settings.Sounds.notificationPreset, label: { $0.displayName }, set: { SoundManager.shared.notificationPreset = $0 }),
+            entry(Settings.Sounds.bellVolume, .number(range: 0...1, step: 0.05, integral: false), set: { SoundManager.shared.bellVolume = $0 }),
+        ]
+        entries += [
+            toggle(Settings.Connections.forceIPv4),
+            toggle(Settings.Connections.publicKeyAuthProbe),
+            toggle(Settings.Connections.hideNonPQKexWarning, inverted: true),
+            toggle(Settings.Connections.healthMonitoring, set: {
+                SettingsStore.shared.set(Settings.Connections.healthMonitoring, $0)
+                NotificationCenter.default.post(name: .sshHealthMonitoringToggled, object: nil, userInfo: ["enabled": $0])
+            }),
+            entry(Settings.Connections.healthProbeInterval, .choices {
+                [1, 5, 10, 15, 30, 60].map { .init(id: String($0), title: String(localized: "\($0) seconds"), value: .int($0)) }
+            }, set: {
+                SettingsStore.shared.set(Settings.Connections.healthProbeInterval, $0)
+                NotificationCenter.default.post(name: .sshHealthProbeIntervalChanged, object: nil, userInfo: ["interval": $0])
+            }).requiring { SettingsStore.shared.get(Settings.Connections.healthMonitoring) ? nil : String(localized: "Enable Connection Health Monitoring first.") },
+        ]
+        entries += [
+            toggle(Settings.Multiplexer.tmuxSessionDiscovery),
+            toggle(Settings.Multiplexer.zellijSessionDiscovery),
+            toggle(Settings.Multiplexer.herdrSessionDiscovery),
+            toggle(Settings.Multiplexer.zmxSessionDiscovery),
+            choices(Settings.Multiplexer.sessionDiscoverySortOrder, label: { $0.displayName }),
+            choices(Settings.Multiplexer.tmuxTabCloseAction, label: { $0.displayName }),
+            toggle(Settings.Multiplexer.tabExposeMultiplexer),
+        ]
+        entries += [
+            toggle(Settings.Roam.holePunch),
+            toggle(Settings.Roam.predictOverwrite),
+            toggle(Settings.Roam.moshAltScreen),
+            choices(Settings.Roam.predictionMode, label: { $0.displayName }),
+            choices(Settings.Roam.trzszTransportMode, label: { $0.displayName }),
+            toggle(Settings.ScreenSharing.controlOptionAsCommandDefault),
+            toggle(Settings.ScreenSharing.routeReservedShortcutsToVNCDefault),
+            choices(Settings.ScreenSharing.clipboardSyncDefault, label: { $0.displayName }),
+            choices(Settings.ScreenSharing.panningDefault, label: { $0.displayName }),
+        ]
+        entries += [
+            toggle(Settings.CodingAgents.detectionEnabled, set: {
+                SettingsStore.shared.set(Settings.CodingAgents.detectionEnabled, $0)
+                AgentAttentionCenter.shared.setDetectionEnabled($0)
+            }),
+            toggle(Settings.CodingAgents.attentionBadges),
+            toggle(Settings.Notifications.taskDetection, set: {
+                SettingsStore.shared.set(Settings.Notifications.taskDetection, $0)
+                AgentAttentionCenter.shared.setTaskDetectionEnabled($0)
+            }),
+            toggle(Settings.Notifications.agentIncludePrompt),
+            toggle(Settings.Notifications.pushAgentBackgroundOnly),
+            toggle(Settings.Notifications.pushAgentLogos),
+            toggle(Settings.Privacy.autoRedact, set: { RedactionManager.shared.isEnabled = $0 }),
+        ]
+        for key in [Settings.Notifications.taskDetectPrompts, Settings.Notifications.taskDetectTests,
+                    Settings.Notifications.taskDetectBuilds, Settings.Notifications.taskDetectInfra,
+                    Settings.Notifications.taskDetectTransfers] {
+            entries.append(toggle(key, set: {
+                SettingsStore.shared.set(key, $0)
+                AgentAttentionCenter.shared.taskFamiliesChanged()
+            }).requiring {
+                SettingsStore.shared.get(Settings.Notifications.taskDetection) ? nil : String(localized: "Enable Detect Long-Running Commands first.")
+            })
+        }
+        #if STANDALONE && targetEnvironment(macCatalyst)
+        entries += [
+            choices(Settings.Visor.position, label: { $0.displayName }, set: { VisorSettings.shared.position = $0 }),
+            choices(Settings.Visor.screen, label: { $0.displayName }, set: { VisorSettings.shared.screen = $0 }),
+            choices(Settings.Visor.spaceBehavior, label: { $0.displayName }, set: { VisorSettings.shared.spaceBehavior = $0 }),
+            toggle(Settings.Visor.autohide, set: { VisorSettings.shared.autohide = $0 }),
+            entry(Settings.Visor.animationDurationMs, .number(range: 50...500, step: 10, integral: true), set: { VisorSettings.shared.animationDurationMs = $0 }),
+        ]
+        #endif
+        #if !CHINA_BUILD
+        entries.append(number(Settings.AI.textSize, AIAgentFontManager.shared.textSizeRange, set: { AIAgentFontManager.shared.textSize = $0 }))
+        #endif
+        #if !targetEnvironment(macCatalyst)
+        entries += [
+            toggle(Settings.Keyboard.forceASCIIKeyboard, set: {
+                SettingsStore.shared.set(Settings.Keyboard.forceASCIIKeyboard, $0)
+                NotificationCenter.default.post(name: .forceASCIIKeyboardChanged, object: nil)
+            }),
+            choices(Settings.Keyboard.writingAssistance, label: { $0.title }),
+            toggle(Settings.Keyboard.doubleSpaceForPeriod),
+            toggle(Settings.KeyboardToolbar.persistent),
+            toggle(Settings.Prompt.useStarship),
+            toggle(Settings.Prompt.showGit),
+            toggle(Settings.Prompt.useRightPrompt),
+            toggle(Settings.Prompt.useTransientPrompt),
+            toggle(Settings.Prompt.addNewline),
+            entry(Settings.Prompt.customUsername, .text),
+            toggle(Settings.Selection.useNativeLoupe),
+            toggle(Settings.Gestures.tabExposeGesture),
+        ]
+        for key in [Settings.Gestures.scrollMode, Settings.Gestures.lineScrollback, Settings.Gestures.rubberBandScrollback] {
+            entries.append(toggle(key, set: {
+                SettingsStore.shared.set(key, $0)
+                NotificationCenter.default.post(name: .touchModeChanged, object: nil)
+            }))
+        }
+        #if !os(visionOS)
+        entries += [
+            toggle(Settings.Connections.backgroundKeepalive),
+            toggle(Settings.KeyboardToolbar.showWithHardwareKeyboard, set: {
+                SettingsStore.shared.set(Settings.KeyboardToolbar.showWithHardwareKeyboard, $0)
+                NotificationCenter.default.post(name: .keyboardToolbarHardwareSettingChanged, object: nil)
+            }),
+        ]
+        #endif
+        #else
+        entries += [
+            toggle(Settings.Multiplexer.localSessionDiscovery),
+            number(Settings.Transparency.backgroundOpacity, 0...1, step: 0.01, set: { TransparencyManager.shared.backgroundOpacity = $0 }),
+            toggle(Settings.Transparency.pinnedSidebarTransparency, set: { TransparencyManager.shared.pinnedSidebarTransparencyEnabled = $0 }),
+        ]
+        if TransparencyManager.isGlassAvailable {
+            entries.append(choices(Settings.Transparency.blurStyle, label: { $0.title }, set: { TransparencyManager.shared.blurStyle = $0 }))
+        }
+        if TransparencyManager.useSandboxBlur {
+            entries.append(toggle(Settings.Transparency.blurEnabled, set: { TransparencyManager.shared.blurEnabled = $0 })
+                .requiring { TransparencyManager.shared.usesGlass ? String(localized: "Choose Standard Blur Style first.") : nil })
+        } else {
+            entries.append(number(Settings.Transparency.backgroundBlurRadius, 0...80, set: { TransparencyManager.shared.backgroundBlurRadius = $0 })
+                .requiring { TransparencyManager.shared.usesGlass ? String(localized: "Choose Standard Blur Style first.") : nil })
+        }
+        #endif
+        if UIDevice.current.userInterfaceIdiom != .phone {
+            entries += [
+                toggle(Settings.Tabs.hoverPreviews),
+                choices(Settings.Tabs.hoverPreviewActivation, label: { $0.displayName }),
+            ]
+        }
+        #if DEBUG
+        assert(Set(entries.map(\.id)).count == entries.count, "Duplicate Quick Settings entries")
+        assert(entries.allSatisfy { SettingsRegistry.shared.definition(for: $0.id) != nil }, "Unregistered Quick Setting")
+        #endif
+        for index in entries.indices {
+            let metadata = SettingsSearchEntry.all.filter { $0.title == entries[index].title }.flatMap(\.keywords)
+            entries[index].keywords += " " + metadata.joined(separator: " ")
+        }
+        return entries.sorted {
+            let lhs = ($0.definition.group.title, $0.title, $0.id)
+            let rhs = ($1.definition.group.title, $1.title, $1.id)
+            return lhs < rhs
+        }
+    }
+}

--- a/rootshell/UI/Settings/QuickSettingsInput.swift
+++ b/rootshell/UI/Settings/QuickSettingsInput.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Pure input rules, shared by the keyboard UI and the commit boundary.
+nonisolated enum QuickSettingsInput {
+    static func normalized(_ text: String) -> String {
+        text.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+    }
+
+    static func searchScore(query: String, title: String, metadata: String) -> Int? {
+        let query = normalized(query).trimmingCharacters(in: .whitespacesAndNewlines)
+        let tokens = query.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !tokens.isEmpty else { return 0 }
+        let title = normalized(title)
+        let blob = title + " " + normalized(metadata)
+        guard tokens.allSatisfy(blob.contains) else { return nil }
+        return title == query ? 3 : title.hasPrefix(query) ? 2 : title.contains(query) ? 1 : 0
+    }
+
+    static func isHexColor(_ text: String) -> Bool {
+        let hex = text.hasPrefix("#") ? String(text.dropFirst()) : text
+        return hex.count == 6 && hex.unicodeScalars.allSatisfy {
+            CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0)
+        }
+    }
+
+    static func validNumber(_ value: Double, range: ClosedRange<Double>, integral: Bool) -> Bool {
+        value.isFinite && range.contains(value) && (!integral || value.rounded() == value)
+    }
+
+    static func numberText(_ value: Double) -> String {
+        String(format: "%.6f", locale: Locale(identifier: "en_US_POSIX"), value)
+            .replacingOccurrences(of: #"\.?0+$"#, with: "", options: .regularExpression)
+    }
+
+    static func movedID(_ ids: [String], current: String?, offset: Int) -> String? {
+        guard !ids.isEmpty else { return nil }
+        let index = current.flatMap { ids.firstIndex(of: $0) } ?? 0
+        return ids[min(ids.count - 1, max(0, index + offset))]
+    }
+}

--- a/rootshell/UI/Shared/SidebarSearchField.swift
+++ b/rootshell/UI/Shared/SidebarSearchField.swift
@@ -49,6 +49,7 @@ struct SidebarSearchField: UIViewRepresentable {
     /// keyboard-navigable (e.g. the clipboard HUD outside keyboard mode) so the
     /// arrows keep their default text-field caret behavior.
     var capturesNavigationKeys: Bool = true
+    var selectsAllOnFocus: Bool = false
 
     var onMoveUpBegan: () -> Void
     var onMoveUpEnded: () -> Void
@@ -174,10 +175,12 @@ struct SidebarSearchField: UIViewRepresentable {
             // so the request replays on the next update after resume.
             guard !Ghostty.isSecureDrawProhibitedAtomic else { return }
             if field.isFirstResponder {
+                if parent.selectsAllOnFocus { field.selectAll(nil) }
                 lastAppliedFocusRequestID = request
                 return
             }
             if field.becomeFirstResponder() || field.isFirstResponder {
+                if parent.selectsAllOnFocus { field.selectAll(nil) }
                 lastAppliedFocusRequestID = request
             }
         }

--- a/rootshell/UI/Shell/MainView+Notifications.swift
+++ b/rootshell/UI/Shell/MainView+Notifications.swift
@@ -420,8 +420,31 @@ extension MainView {
         }
         #endif
 
+        observerBag.observeOnMainActor(.toggleQuickSettings) { [self] notification in
+            guard self.shouldHandleNotification(notification) else { return }
+            if self.showQuickSettingsOverlay {
+                self.showQuickSettingsOverlay = false
+            } else {
+                // Avoid presenting through a modal workflow. Floating tools yield
+                // their keyboard ownership before Quick Settings takes focus.
+                self.showThemePickerOverlay = false
+                self.showClipboardManager = false
+                guard !self.isSheetPresentedBesidesFloatingTabSidebar else { return }
+                if !self.tabSidebarIsDocked { self.showingTabSwitcher = false }
+                if self.terminals.indices.contains(self.selectedTabIndex) {
+                    for terminal in self.terminals[self.selectedTabIndex].splitTree.terminalLeaves {
+                        terminal.closeSearch()
+                        terminal.showComposeOverlay = false
+                    }
+                }
+                self.showQuickSettingsOverlay = true
+                self.setOverlayOwnsKeyboardForAllTerminals(true)
+            }
+        }
+
         observerBag.observeOnMainActor(.toggleThemePicker) { [self] notification in
             guard self.shouldHandleNotification(notification) else { return }
+            self.showQuickSettingsOverlay = false
             self.showThemePickerOverlay.toggle()
         }
 

--- a/rootshell/UI/Shell/MainView+Presentation.swift
+++ b/rootshell/UI/Shell/MainView+Presentation.swift
@@ -53,6 +53,7 @@ extension MainView {
             showKeyResolutionSheet ||
             showYubiKeyPINPrompt ||
             showThemePickerOverlay ||
+            showQuickSettingsOverlay ||
             // The iPhone presentation is a sheet that owns the keyboard. On
             // regular width the clipboard manager is a passthrough glass HUD (like
             // the Find HUD, which is intentionally absent here) and must NOT count
@@ -427,6 +428,19 @@ extension MainView {
                 handleAIAgentSidebarVisibilityChange(oldValue: oldValue, newValue: newValue)
             }
             #endif
+            .onChange(of: showSettings) { _, presented in
+                if presented { showQuickSettingsOverlay = false }
+            }
+            .onChange(of: showClipboardManager) { _, presented in
+                if presented { showQuickSettingsOverlay = false }
+            }
+            .onChange(of: showConnectionSidebar) { _, presented in
+                if presented { showQuickSettingsOverlay = false }
+            }
+            .onChange(of: showQuickSettingsOverlay) { _, presented in
+                setOverlayOwnsKeyboardForAllTerminals(isAnySheetPresented)
+                if !presented { restoreFirstResponderAfterSheetDismissal() }
+            }
             .onChange(of: showThemePickerOverlay) { _, newValue in
                 handleThemePickerOverlayChange(newValue)
             }

--- a/rootshell/UI/Shell/MainView+TerminalContent.swift
+++ b/rootshell/UI/Shell/MainView+TerminalContent.swift
@@ -314,6 +314,11 @@ extension MainView {
             // tmux -CC window placeholder restored from disk, awaiting reconcile
             tmuxReconnectingOverlay
 
+            if showQuickSettingsOverlay {
+                QuickSettingsHUD(isPresented: $showQuickSettingsOverlay)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
             // Theme picker overlay
             themePickerOverlayView(isPresented: $showThemePickerOverlay)
 

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -279,6 +279,7 @@ struct MainView: View {
     
     // Theme picker overlay state
     @State var showThemePickerOverlay = false
+    @State var showQuickSettingsOverlay = false
 
     // Clipboard manager overlay state
     @State var showClipboardManager = false

--- a/rootshell/UI/Terminal/TerminalSplitTreeView.swift
+++ b/rootshell/UI/Terminal/TerminalSplitTreeView.swift
@@ -1171,6 +1171,7 @@ extension Notification.Name {
     static let toggleTransparency = Notification.Name("com.rootshell.toggleTransparency")
     static let toggleTitleBar = Notification.Name("com.rootshell.toggleTitleBar")
     static let toggleAutoRedact = Notification.Name("com.rootshell.toggleAutoRedact")
+    static let toggleQuickSettings = Notification.Name("com.rootshell.toggleQuickSettings")
     static let toggleThemePicker = Notification.Name("com.rootshell.toggleThemePicker")
     static let toggleClipboardManager = Notification.Name("com.rootshell.toggleClipboardManager")
     static let toggleBackgroundEffect = Notification.Name("com.rootshell.toggleBackgroundEffect")

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -2384,6 +2384,10 @@ extension Ghostty.TerminalView {
         performActionAsync("scroll_to_bottom")
     }
 
+    @objc func menuToggleQuickSettings(_ sender: Any?) {
+        NotificationCenter.default.post(name: .toggleQuickSettings, object: self)
+    }
+
     @objc func menuToggleThemePicker(_ sender: Any?) {
         NotificationCenter.default.post(name: .toggleThemePicker, object: self)
     }


### PR DESCRIPTION
Open with Cmd-Shift-comma to search and edit global preferences. Reuse glass panel styling and existing settings persistence. Refresh Copy on Select immediately and preserve choice selection when reopening editors.