### PR TITLE
Add keyboard-triggered Liquid Glass Visor for iPad

### DIFF
--- a/rootshell/Core/Ghostty/GhosttyApp.swift
+++ b/rootshell/Core/Ghostty/GhosttyApp.swift
@@ -691,6 +691,14 @@ extension Ghostty {
                 let (themeName, source) = ThemeOverrideManager.shared.resolveTheme(
                     tabId: surfaceTabMap[surfaceId],
                     windowId: surfaceWindowMap[surfaceId])
+                #if os(iOS) && !targetEnvironment(macCatalyst)
+                if surfaceWindowMap[surfaceId]?.hasPrefix("ipad-visor-") == true,
+                   let visorConfig = Self.makeVisorOverlayConfig(globalConfig) {
+                    overridden += 1
+                    overrideSurfaces.append((surface, visorConfig))
+                    continue
+                }
+                #endif
                 guard source != .global else { continue }
 
                 overridden += 1
@@ -837,6 +845,13 @@ extension Ghostty {
         ///   - tabId: The tab UUID (for tab-level override lookup)
         ///   - windowId: The window ID (for window-level override lookup)
         func refreshSurfaceTheme(_ surface: ghostty_surface_t, tabId: UUID?, windowId: String?) {
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            if windowId?.hasPrefix("ipad-visor-") == true, let base = config.config,
+               let visorConfig = Self.makeVisorOverlayConfig(base) {
+                pushConfig(toSurface: surface, config: visorConfig, owned: true)
+                return
+            }
+            #endif
             let (themeName, source) = ThemeOverrideManager.shared.resolveTheme(tabId: tabId, windowId: windowId)
 
             switch source {
@@ -853,6 +868,27 @@ extension Ghostty {
                 logger.info("Surface theme refreshed to \(sourceStr) override: \(themeName)")
             }
         }
+
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        /// Clone the complete config and override only this surface's backdrop.
+        /// Never write the shared config file or change ordinary terminals.
+        private static func makeVisorOverlayConfig(_ base: ghostty_config_t) -> ghostty_config_t? {
+            guard let result = ghostty_config_clone(base) else { return nil }
+            let file = FileManager.default.temporaryDirectory
+                .appendingPathComponent("visor-\(UUID().uuidString).conf")
+            defer { try? FileManager.default.removeItem(at: file) }
+            do {
+                let opacity = UIAccessibility.isReduceTransparencyEnabled ? 1.0 : 0.72
+                try "background-opacity = \(opacity)\n".write(to: file, atomically: true, encoding: .utf8)
+                file.path.withCString { ghostty_config_load_file(result, $0) }
+                ghostty_config_finalize(result)
+                return result
+            } catch {
+                ghostty_config_free(result)
+                return nil
+            }
+        }
+        #endif
 
         // MARK: - Font Size Management
 

--- a/rootshell/Core/Keybinds/KeybindAction.swift
+++ b/rootshell/Core/Keybinds/KeybindAction.swift
@@ -135,6 +135,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     // Shell Operations
     /// Open settings
     case open_settings = "open_settings"
+    case toggle_visor = "toggle_visor"
     case toggle_quick_settings = "toggle_quick_settings"
     /// Open host browser
     case browse_hosts = "browse_hosts"
@@ -312,7 +313,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
              .toggle_auto_redact:
             return .view
 
-        case .open_settings, .toggle_quick_settings, .browse_hosts, .browse_profiles, .toggle_ai_agent, .toggle_voice_agent:
+        case .toggle_visor, .open_settings, .toggle_quick_settings, .browse_hosts, .browse_profiles, .toggle_ai_agent, .toggle_voice_agent:
             return .shell
 
         case .select_all, .clear_screen, .reset_terminal,
@@ -375,6 +376,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .toggle_split_zoom: return String(localized: "Toggle Split Zoom", comment: "Keybind action")
         case .equalize_splits: return String(localized: "Equalize Splits", comment: "Keybind action")
 
+        case .toggle_visor: return String(localized: "Toggle Visor")
         case .toggle_quick_settings: return String(localized: "Quick Settings")
         case .open_settings: return String(localized: "Settings", comment: "Keybind action: open settings")
         case .browse_hosts: return String(localized: "Browse Hosts", comment: "Keybind action")
@@ -463,6 +465,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .equalize_splits: return .equalizeSplits
 
         case .open_settings: return .openSettings
+        case .toggle_visor: return .toggleVisorOverlay
         case .toggle_quick_settings: return .toggleQuickSettings
         case .browse_hosts: return .browseHosts
         case .browse_profiles: return .browseProfiles
@@ -551,7 +554,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     /// Whether this action needs wantsPriorityOverSystemBehavior
     var needsSystemPriority: Bool {
         switch self {
-        case .close_tab, .new_tab, .new_window, .new_local_shell, .start_search, .toggle_compose,
+        case .toggle_visor, .close_tab, .new_tab, .new_window, .new_local_shell, .start_search, .toggle_compose,
              .send_text, .send_esc, .send_csi,
              // ⌘⌥[ / ⌘⌥]: Option composes a different character, so the menu
              // key-equivalent path can't claim the press before the terminal
@@ -567,6 +570,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     static var customizableActions: [KeybindAction] {
         allCases.filter { action in
             switch action {
+            case .toggle_visor: return supportsVisorOverlay
             case .unbind, .send_text, .send_esc, .send_csi:
                 return false
             default:
@@ -624,7 +628,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
             return true
 
         // These actions don't have menu entries.
-        case .reset_terminal, .send_text, .send_esc, .send_csi:
+        case .toggle_visor, .reset_terminal, .send_text, .send_esc, .send_csi:
             return false
 
         // Control characters are handled separately

--- a/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
+++ b/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
@@ -68,7 +68,7 @@ final class KeybindCommandGenerator: ObservableObject {
 
         for binding in keybindManager.activeBindings {
             // Skip control character actions - these are handled specially in pressesBegan
-            guard !binding.action.isControlCharacter else { continue }
+            guard binding.action.isAvailableForVisorDispatch, !binding.action.isControlCharacter else { continue }
 
             // Skip terminal-only actions that don't need UIKeyCommands
             // (handled directly via ghostty_surface_binding_action)
@@ -121,7 +121,7 @@ final class KeybindCommandGenerator: ObservableObject {
     private func shouldGenerateCommand(for binding: Keybind) -> Bool {
         switch binding.action {
         // App actions need UIKeyCommands to trigger
-        case .new_local_shell, .new_tab, .new_window, .close_tab, .duplicate_ssh_tab,
+        case .toggle_visor, .new_local_shell, .new_tab, .new_window, .close_tab, .duplicate_ssh_tab,
              .previous_tab, .next_tab, .select_tab_1, .select_tab_2, .select_tab_3,
              .select_tab_4, .select_tab_5, .select_tab_6, .select_tab_7, .select_tab_8,
              .select_tab_9, .split_right, .split_down, .navigate_split_left,

--- a/rootshell/Core/Keybinds/KeybindManager.swift
+++ b/rootshell/Core/Keybinds/KeybindManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import Combine
 import os
 
@@ -197,13 +198,18 @@ final class KeybindManager: ObservableObject {
             Keybind(key: .y, modifiers: .control, action: .ctrl_y),
             Keybind(key: .z, modifiers: .control, action: .ctrl_z),
         ]
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            defaultBindings.append(Keybind(key: .escape, modifiers: .shift, action: .toggle_visor))
+        }
+        #endif
     }
 
     // MARK: - Binding Lookup
 
     /// Get the action for a given sequence
     func action(for sequence: KeySequence) -> KeybindAction? {
-        activeBindings.first { $0.sequence == sequence }?.action
+        activeBindings.first { $0.sequence == sequence && $0.action.isAvailableForVisorDispatch }?.action
     }
 
     /// Get the action for a single trigger
@@ -223,13 +229,13 @@ final class KeybindManager: ObservableObject {
 
     /// Get bindings that start with a specific trigger (for sequence matching)
     func bindingsStartingWith(trigger: KeyTrigger) -> [Keybind] {
-        activeBindings.filter { $0.sequence.matchesPrefix(trigger) }
+        activeBindings.filter { $0.sequence.matchesPrefix(trigger) && $0.action.isAvailableForVisorDispatch }
     }
 
     /// Check if a trigger is a sequence prefix (has bindings that start with it)
     func isSequencePrefix(_ trigger: KeyTrigger) -> Bool {
         activeBindings.contains { keybind in
-            keybind.sequence.isSequence && keybind.sequence.matchesPrefix(trigger)
+            keybind.action.isAvailableForVisorDispatch && keybind.sequence.isSequence && keybind.sequence.matchesPrefix(trigger)
         }
     }
 
@@ -240,7 +246,7 @@ final class KeybindManager: ObservableObject {
 
     /// Get the keybind for a given sequence (includes action parameter)
     func keybind(for sequence: KeySequence) -> Keybind? {
-        activeBindings.first { $0.sequence == sequence }
+        activeBindings.first { $0.sequence == sequence && $0.action.isAvailableForVisorDispatch }
     }
 
     /// Get the keybind for a single trigger (includes action parameter)

--- a/rootshell/Core/SettingsSync/Registry/Settings+Visor.swift
+++ b/rootshell/Core/SettingsSync/Registry/Settings+Visor.swift
@@ -49,11 +49,11 @@ nonisolated extension Settings {
             configKey: "visor-space-behavior",
             title: String(localized: "Visor Space Behavior", comment: "Setting title"))
         static let hotkeyKeyCode = SettingKey(
-            "visor.hotkeyKeyCode", default: -1, group: .visor, policy: .localByDefault,
+            "visor.hotkeyKeyCode", default: VisorDefaultShortcut.carbonKeyCode, group: .visor, policy: .localByDefault,
             configKey: "visor-hotkey-key-code",
             title: String(localized: "Visor Hotkey", comment: "Setting title"))
         static let hotkeyModifiers = SettingKey(
-            "visor.hotkeyModifiers", default: 0, group: .visor, policy: .localByDefault,
+            "visor.hotkeyModifiers", default: VisorDefaultShortcut.carbonModifiers, group: .visor, policy: .localByDefault,
             configKey: "visor-hotkey-modifiers",
             title: String(localized: "Visor Hotkey Modifiers", comment: "Setting title"))
         static let useEventTap = SettingKey(
@@ -77,7 +77,11 @@ nonisolated extension Settings {
 
 nonisolated extension Settings {
     enum Visor {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        static let all: [AnySettingDefinition] = [Settings.iPadVisor.enabled.erased]
+        #else
         static let all: [AnySettingDefinition] = []
+        #endif
     }
 }
 

--- a/rootshell/Features/Visor/Views/iPadVisorOverlay.swift
+++ b/rootshell/Features/Visor/Views/iPadVisorOverlay.swift
@@ -1,0 +1,440 @@
+import SwiftUI
+import UIKit
+import Observation
+
+extension View {
+    @ViewBuilder
+    func iPadVisor(ghosttyApp: Ghostty.App, windowID: String, modalPresented: Bool) -> some View {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            modifier(iPadVisorModifier(ghosttyApp: ghosttyApp, windowID: windowID,
+                                       modalPresented: modalPresented))
+        } else { self }
+        #else
+        self
+        #endif
+    }
+}
+
+#if os(iOS) && !targetEnvironment(macCatalyst)
+@MainActor
+@Observable
+final class iPadVisorController {
+    private static let owners = NSMapTable<UIWindow, iPadVisorController>.weakToWeakObjects()
+    private(set) var visible = false
+    private(set) var terminal: Ghostty.TerminalView?
+    private(set) var scrollView: Ghostty.TerminalScrollView?
+    weak var window: UIWindow?
+    weak var previousResponder: UIView?
+    var modalPresented = false
+    var terminalID = UUID()
+    var owningWindowID: String?
+
+    /// Only window-level commands may escape the standalone terminal. Keep
+    /// close/search/compose/font and split commands local to their source.
+    /// Nil means the sender is not a Visor terminal and normal tab routing applies.
+    static func routeWindowAction(_ notification: Notification, to windowID: String) -> Bool? {
+        guard let source = notification.object as? Ghostty.TerminalView,
+              let owner = (owners.objectEnumerator()?.allObjects as? [iPadVisorController])?
+                .first(where: { $0.terminal === source }) else { return nil }
+        guard owner.owningWindowID == windowID, owner.visible else { return false }
+        switch notification.name {
+        case .openSettings, .toggleQuickSettings, .newTab, .createLocalShell, .newWindow,
+             .previousTab, .nextTab, .selectTab, .previousGroup, .nextGroup,
+             .showTabSwitcher, .toggleTabExpose, .toggleTabBar, .toggleGroupMode,
+             .browseHosts, .browseProfiles, .toggleAIAgent, .toggleVoiceAgent,
+             .toggleThemePicker, .toggleClipboardManager, .toggleFullScreen,
+             .toggleBackgroundEffect, .toggleTitleBar, .toggleTransparency, .toggleAutoRedact:
+            owner.hide()
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func permitsFocus(_ terminal: Ghostty.TerminalView) -> Bool {
+        guard let window = terminal.window, let owner = owners.object(forKey: window) else { return true }
+        if terminal === owner.terminal { return owner.visible }
+        return !owner.visible
+    }
+
+    func attach(to window: UIWindow?) {
+        if let previous = self.window, previous !== window {
+            Self.owners.removeObject(forKey: previous)
+        }
+        self.window = window
+        if let window { Self.owners.setObject(self, forKey: window) }
+    }
+
+    func install(_ terminal: Ghostty.TerminalView) -> Ghostty.TerminalScrollView {
+        self.terminal = terminal
+        let scrollView = Ghostty.TerminalScrollView(terminalView: terminal)
+        self.scrollView = scrollView
+        return scrollView
+    }
+
+    func toggle() {
+        guard iPadVisorSettings.shared.enabled, let window,
+              window.windowScene?.activationState == .foregroundActive,
+              !modalPresented, !Self.hasPresentation(window.rootViewController) else { return }
+        if visible { hide() } else {
+            previousResponder = Self.firstResponder(in: window)
+            if let terminal = previousResponder as? Ghostty.TerminalView {
+                terminal.focusDidChange(false)
+            } else { previousResponder?.resignFirstResponder() }
+            visible = true
+            terminal?.isLogicallyFocused = true
+            terminal?.setOcclusion(true)
+            terminal?.setWindowActive(true)
+            terminal?.focusDidChange(true)
+        }
+    }
+
+    func hide(restoreFocus: Bool = true) {
+        guard visible else { return }
+        if terminal?.searchState != nil { terminal?.closeSearch() }
+        // Keep the compose draft, but dismiss its editor with the panel.
+        terminal?.showComposeOverlay = false
+        terminal?.focusDidChange(false)
+        terminal?.isLogicallyFocused = false
+        terminal?.setWindowActive(false)
+        terminal?.setOcclusion(false)
+        visible = false
+        if restoreFocus, window?.windowScene?.activationState == .foregroundActive {
+            if let terminal = previousResponder as? Ghostty.TerminalView {
+                terminal.isLogicallyFocused = true
+                terminal.focusDidChange(true)
+            } else { previousResponder?.becomeFirstResponder() }
+        }
+        previousResponder = nil
+    }
+
+    func sessionEnded() {
+        hide()
+        terminal?.cleanup(reason: .userClose)
+        terminal = nil
+        scrollView = nil
+        terminalID = UUID()
+    }
+
+    func dispose() {
+        hide(restoreFocus: false)
+        terminal?.cleanup(reason: .userClose)
+        terminal = nil
+        scrollView = nil
+        if let window { Self.owners.removeObject(forKey: window) }
+    }
+
+    private static func hasPresentation(_ controller: UIViewController?) -> Bool {
+        guard let controller else { return false }
+        if controller.presentedViewController != nil { return true }
+        return controller.children.contains { hasPresentation($0) }
+    }
+
+    private static func firstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder { return view }
+        return view.subviews.lazy.compactMap { firstResponder(in: $0) }.first
+    }
+}
+
+private struct iPadVisorModifier: ViewModifier {
+    let ghosttyApp: Ghostty.App
+    let windowID: String
+    let modalPresented: Bool
+    @State private var controller = iPadVisorController()
+    @State private var settings = iPadVisorSettings.shared
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @SceneStorage("ipad.visor.heightFraction") private var heightFraction = 0.3
+    @GestureState private var resizeTranslation: CGFloat = 0
+    @State private var keyboardOverlap: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                iPadVisorWindowProbe(controller: controller, windowID: windowID)
+                    .frame(width: 0, height: 0)
+                iPadVisorShortcut(controller: controller, modalPresented: modalPresented)
+            }
+            .overlay {
+                GeometryReader { geometry in
+                    let available = max(1, geometry.size.height - keyboardOverlap)
+                    let baseHeight = min(available, max(min(160, available), available * heightFraction))
+                    let height = min(available, max(min(160, available),
+                        min(available * 0.85, baseHeight + resizeTranslation)))
+                    ZStack(alignment: .top) {
+                        if controller.visible {
+                            Color.clear.contentShape(Rectangle())
+                                .onTapGesture { controller.hide() }
+                                .accessibilityLabel("Dismiss Visor")
+                                .accessibilityAddTraits(.isButton)
+                        }
+                        if controller.visible {
+                            Group {
+                                if ghosttyApp.readiness == .ready, ghosttyApp.app != nil {
+                                    iPadVisorTerminal(controller: controller, app: ghosttyApp,
+                                                      windowID: "ipad-visor-" + windowID)
+                                        .id(controller.terminalID)
+                                } else if ghosttyApp.readiness == .error {
+                                    Text("Failed to initialize terminal").frame(maxWidth: .infinity, maxHeight: .infinity)
+                                } else {
+                                    ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                                }
+                            }
+                            .frame(height: height)
+                            .overlay {
+                                if let terminal = controller.terminal {
+                                    iPadVisorTerminalOverlays(terminal: terminal)
+                                        .id(terminal.uuid)
+                                }
+                            }
+                            .overlay(alignment: .bottom) {
+                                Capsule()
+                                    .fill(.secondary.opacity(0.65))
+                                    .frame(width: 36, height: 4)
+                                    .padding(.bottom, 4)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 24, alignment: .bottom)
+                                    .contentShape(Rectangle())
+                                    // The bottom edge moves during resizing. A local
+                                    // translation feeds that movement back into the
+                                    // gesture and makes the height oscillate.
+                                    .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                                        .updating($resizeTranslation) { value, translation, transaction in
+                                            transaction.disablesAnimations = true
+                                            translation = value.translation.height
+                                        }
+                                        .onEnded { value in
+                                            heightFraction = min(0.85, max(min(160 / available, 0.85),
+                                                (baseHeight + value.translation.height) / available))
+                                        })
+                                    .accessibilityLabel("Visor height")
+                                    .accessibilityValue("\(Int(heightFraction * 100)) percent")
+                                    .accessibilityAdjustableAction { direction in
+                                        heightFraction = min(0.85, max(min(160 / available, 0.85),
+                                            heightFraction + (direction == .increment ? 0.05 : -0.05)))
+                                    }
+                            }
+                            .accessibilityAction(named: "Dismiss Visor") { controller.hide() }
+                            .modifier(iPadVisorGlass())
+                            .clipShape(RoundedRectangle(cornerRadius: 22))
+                            .padding(.horizontal, 12)
+                            .allowsHitTesting(controller.visible)
+                            .accessibilityHidden(!controller.visible)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                        }
+                    }
+                }
+                .clipped()
+            }
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: controller.visible)
+        .onAppear { controller.modalPresented = modalPresented }
+        .onChange(of: modalPresented) { _, presented in
+            controller.modalPresented = presented
+            if presented { controller.hide(restoreFocus: false) }
+        }
+        .onChange(of: settings.enabled) { _, enabled in
+            if !enabled { controller.hide() }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase != .active { controller.hide(restoreFocus: false) }
+            if phase == .background { controller.terminal?.session?.pauseForBackground() }
+            if phase == .active { controller.terminal?.session?.resumeForForeground() }
+        }
+        .task {
+            for await notification in NotificationCenter.default.notifications(named: .toggleVisorOverlay) {
+                guard let source = notification.object as? UIView, source.window === controller.window else { continue }
+                controller.toggle()
+            }
+        }
+        .task {
+            for await notification in NotificationCenter.default.notifications(named: .closeSplit) {
+                guard let source = notification.object as? Ghostty.TerminalView,
+                      source === controller.terminal else { continue }
+                controller.sessionEnded()
+            }
+        }
+        .task {
+            for await notification in NotificationCenter.default.notifications(named: UIResponder.keyboardWillChangeFrameNotification) {
+                guard let window = controller.window, window.isKeyWindow,
+                      let value = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { continue }
+                let frame = window.convert(value.cgRectValue, from: window.screen.coordinateSpace)
+                let intersection = window.bounds.intersection(frame)
+                keyboardOverlap = !intersection.isNull && intersection.maxY >= window.bounds.maxY - 1
+                    ? intersection.height : 0
+            }
+        }
+        .task {
+            for await _ in NotificationCenter.default.notifications(named: UIResponder.keyboardWillHideNotification) {
+                keyboardOverlap = 0
+            }
+        }
+    }
+}
+
+private struct iPadVisorGlass: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    func body(content: Content) -> some View {
+        if reduceTransparency {
+            content.background(Color(uiColor: .systemBackground))
+        } else if #available(iOS 26.0, *) {
+            content.glassEffect(.regular, in: RoundedRectangle(cornerRadius: 22))
+        } else {
+            content.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22))
+        }
+    }
+}
+
+/// These controls belong to the Visor surface, never the selected main tab.
+private struct iPadVisorTerminalOverlays: View {
+    let terminal: Ghostty.TerminalView
+    @State private var revision = 0
+
+    var body: some View {
+        let _ = revision
+        ZStack {
+            if let searchState = terminal.searchState {
+                DraggableHUDContainer(
+                    dismissShortcuts: [.escape],
+                    forwardsFindToggle: true,
+                    onDismiss: { terminal.closeSearch() }
+                ) {
+                    TerminalSearchOverlay(
+                        searchState: searchState,
+                        onSearch: { terminal.performSearch($0) },
+                        onNavigate: { terminal.navigateSearch(direction: $0) },
+                        onClose: { terminal.closeSearch() }
+                    )
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            if terminal.showComposeOverlay {
+                TerminalComposeOverlay(
+                    initialText: terminal.composeText,
+                    onSend: { text in
+                        terminal.sendComposedText(text)
+                        terminal.composeText = ""
+                    },
+                    onClose: {
+                        terminal.becomeFirstResponder()
+                        terminal.showComposeOverlay = false
+                        NotificationCenter.default.post(name: .ghosttyComposeStateChanged, object: terminal)
+                    },
+                    onTextChanged: { terminal.composeText = $0 },
+                    keyboardAccessory: terminal.shouldShowKeyboardToolbar ? terminal.keyboardAccessory : nil,
+                    onTextViewCreated: { terminal.activeComposeTextView = $0 }
+                )
+            }
+        }
+        .task {
+            for await notification in NotificationCenter.default.notifications(named: .ghosttySearchStateChanged) {
+                guard notification.object as? Ghostty.TerminalView === terminal else { continue }
+                revision &+= 1
+            }
+        }
+        .task {
+            for await notification in NotificationCenter.default.notifications(named: .ghosttyComposeStateChanged) {
+                guard notification.object as? Ghostty.TerminalView === terminal else { continue }
+                revision &+= 1
+            }
+        }
+    }
+}
+
+private struct iPadVisorTerminal: UIViewRepresentable {
+    let controller: iPadVisorController
+    let app: Ghostty.App
+    let windowID: String
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    final class Coordinator {
+        var reduceTransparency: Bool?
+        var visible: Bool?
+    }
+    func makeCoordinator() -> Coordinator { Coordinator() }
+    func makeUIView(context: Context) -> Ghostty.TerminalScrollView {
+        // The panel leaves the view tree when hidden. Retain the UIKit terminal
+        // independently so reopening preserves its shell, scrollback, and size.
+        if let scrollView = controller.scrollView { return scrollView }
+        let terminal = Ghostty.TerminalView(app.app!, ghosttyApp: app, uuid: controller.terminalID,
+                                           connectionConfig: .local(), windowId: windowID)
+        let scrollView = controller.install(terminal)
+        terminal.isLogicallyFocused = controller.visible
+        terminal.setOcclusion(controller.visible)
+        terminal.setWindowActive(controller.visible)
+        terminal.focusDidChange(controller.visible)
+        return scrollView
+    }
+    func updateUIView(_ view: Ghostty.TerminalScrollView, context: Context) {
+        if context.coordinator.reduceTransparency != reduceTransparency,
+           let surface = view.terminalView.surface {
+            context.coordinator.reduceTransparency = reduceTransparency
+            app.refreshSurfaceTheme(surface, tabId: nil, windowId: windowID)
+        }
+        if context.coordinator.visible != controller.visible {
+            context.coordinator.visible = controller.visible
+            view.terminalView.isLogicallyFocused = controller.visible
+            view.terminalView.setOcclusion(controller.visible)
+            view.terminalView.setWindowActive(controller.visible)
+            view.terminalView.focusDidChange(controller.visible)
+        }
+    }
+}
+
+/// Register the shortcut in the existing SwiftUI window hierarchy, without
+/// rehosting its content or adding any visible controls or layout space.
+private struct iPadVisorShortcut: View {
+    let controller: iPadVisorController
+    let modalPresented: Bool
+    @State private var settings = iPadVisorSettings.shared
+    @ObservedObject private var keybinds = KeybindManager.shared
+
+    var body: some View {
+        if settings.enabled, !modalPresented,
+           let sequence = keybinds.keybind(for: .toggle_visor)?.sequence,
+           !sequence.isSequence, let trigger = sequence.first,
+           let key = trigger.swiftUIKeyEquivalent {
+            Button("Toggle Visor") { controller.toggle() }
+                .keyboardShortcut(key, modifiers: trigger.swiftUIEventModifiers)
+                .buttonStyle(.plain)
+                .frame(width: 0, height: 0)
+                .clipped()
+                .opacity(0)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+/// Read the original window without inserting another hosting controller or
+/// changing safe-area/keyboard layout. Its lifetime also owns terminal cleanup.
+private struct iPadVisorWindowProbe: UIViewRepresentable {
+    let controller: iPadVisorController
+    let windowID: String
+
+    func makeUIView(context: Context) -> Probe {
+        let view = Probe()
+        controller.owningWindowID = windowID
+        view.visor = controller
+        view.backgroundColor = .clear
+        view.isOpaque = false
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ view: Probe, context: Context) {
+        controller.owningWindowID = windowID
+    }
+
+    static func dismantleUIView(_ view: Probe, coordinator: ()) {
+        view.visor?.dispose()
+    }
+
+    final class Probe: UIView {
+        weak var visor: iPadVisorController?
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            visor?.attach(to: window)
+        }
+    }
+}
+#endif

--- a/rootshell/Features/Visor/iPadVisorSettings.swift
+++ b/rootshell/Features/Visor/iPadVisorSettings.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import Observation
+import UIKit
+
+extension Notification.Name {
+    nonisolated static let toggleVisorOverlay = Notification.Name("com.rootshell.toggleVisorOverlay")
+}
+
+nonisolated extension Settings {
+    enum iPadVisor {
+        static let enabled = SettingKey("ipad.visor.enabled", default: false,
+            group: .visor, policy: .localByDefault,
+            title: String(localized: "Enable iPad Visor"))
+    }
+}
+
+/// Shared defaults; persisted overrides retain their existing values.
+nonisolated enum VisorDefaultShortcut {
+    static let carbonKeyCode = 53 // Escape
+    static let carbonModifiers = 512 // shiftKey
+}
+
+extension KeybindAction {
+    static var supportsVisorOverlay: Bool {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        return UIDevice.current.userInterfaceIdiom == .pad
+        #else
+        return false
+        #endif
+    }
+
+    /// Keep the binding editable while disabled, but release its keys to the terminal.
+    var isAvailableForVisorDispatch: Bool {
+        guard self == .toggle_visor else { return true }
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        return UIDevice.current.userInterfaceIdiom == .pad && iPadVisorSettings.shared.enabled
+        #else
+        return false
+        #endif
+    }
+}
+
+@MainActor
+@Observable
+final class iPadVisorSettings {
+    static let shared = iPadVisorSettings()
+    var enabled: Bool {
+        didSet {
+            SettingsStore.shared.set(Settings.iPadVisor.enabled, enabled)
+            KeybindManager.shared.keybindsDidChange.send()
+        }
+    }
+    private init() {
+        enabled = SettingsStore.shared.get(Settings.iPadVisor.enabled)
+        SettingsRefreshHub.shared.register(keys: [Settings.iPadVisor.enabled.name]) { [weak self] _ in
+            let value = SettingsStore.shared.get(Settings.iPadVisor.enabled)
+            if self?.enabled != value { self?.enabled = value }
+        }
+    }
+}
+
+struct iPadVisorSettingsView: View {
+    @Environment(\.sheetThemeColors) private var sheetThemeColors
+    @Bindable private var settings = iPadVisorSettings.shared
+    @ObservedObject private var keybinds = KeybindManager.shared
+    @State private var editing = false
+    @State private var outcome: KeybindEditorOutcome?
+
+    var body: some View {
+        Form {
+            Section {
+                SettingToggle(Settings.iPadVisor.enabled, isOn: $settings.enabled, title: "Enable Visor")
+                    .themedRow()
+                Button { editing = true } label: {
+                    HStack {
+                        Text("Keyboard Shortcut")
+                        Spacer()
+                        Text(keybinds.keybind(for: .toggle_visor)?.sequence.symbolDescription ?? String(localized: "Unassigned"))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .themedRow()
+            } footer: {
+                Text("A separate local terminal above each iPad window. Shift–Escape toggles Visor by default. Drag its bottom edge to resize.")
+            }
+        }
+        .themedList()
+        .navigationTitle("Visor")
+        .sheet(isPresented: $editing, onDismiss: applyOutcome) {
+            KeybindEditorView(action: .toggle_visor) { outcome = $0 }
+                .themedSubSheet(sheetThemeColors)
+        }
+    }
+
+    private func applyOutcome() {
+        guard let outcome else { return }
+        switch outcome {
+        case .captured(let sequence): keybinds.setOverride(sequence: sequence, action: .toggle_visor)
+        case .restoreDefault: keybinds.removeOverride(for: .toggle_visor)
+        case .unbind: keybinds.unbindAction(.toggle_visor)
+        }
+        self.outcome = nil
+    }
+}

--- a/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
+++ b/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
@@ -122,15 +122,17 @@ struct KeybindEditorView: View {
                         }
                         .buttonStyle(.borderedProminent)
 
-                        Button {
-                            captureError = nil
-                            isCapturing = true
-                            showSequenceCapture = true
-                        } label: {
-                            Label("Record Key Sequence", systemImage: "keyboard.badge.ellipsis")
-                                .frame(maxWidth: .infinity)
+                        if action != .toggle_visor {
+                            Button {
+                                captureError = nil
+                                isCapturing = true
+                                showSequenceCapture = true
+                            } label: {
+                                Label("Record Key Sequence", systemImage: "keyboard.badge.ellipsis")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
                         }
-                        .buttonStyle(.bordered)
 
                         if let captureError {
                             Text(captureError)

--- a/rootshell/UI/Settings/SettingsSearchCatalog.swift
+++ b/rootshell/UI/Settings/SettingsSearchCatalog.swift
@@ -328,7 +328,13 @@ extension SettingsSearchDestination {
             return !SearchBuild.isCatalyst
         case .liveActivity:
             return SearchBuild.hasActivityKit && !SearchBuild.isCatalyst
-        case .localShell, .visor, .localSSHAgent, .externalSSHAgents:
+        case .visor:
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            return UIDevice.current.userInterfaceIdiom == .pad
+            #else
+            return SearchBuild.isStandalone && SearchBuild.isCatalyst
+            #endif
+        case .localShell, .localSSHAgent, .externalSSHAgents:
             return SearchBuild.isStandalone && SearchBuild.isCatalyst
         case .vpn:
             return !SearchBuild.isChinaBuild && (!SearchBuild.isCatalyst || SearchBuild.isStandalone)
@@ -652,13 +658,13 @@ struct SettingsSearchEntry: Identifiable, Hashable {
             row("visor-hotkey", String(localized: "Visor Hotkey"), in: .visor, icon: "command",
                 keywords: ["combination", "key", "global shortcut", "modifier"]),
             row("visor-position", String(localized: "Visor Position"), in: .visor,
-                keywords: ["edge", "screen", "space"]),
+                keywords: ["edge", "screen", "space"], available: isCatalyst),
             row("visor-size", String(localized: "Visor Size"), in: .visor,
-                keywords: ["slide size", "cross axis", "percent", "pixels"]),
+                keywords: ["slide size", "cross axis", "percent", "pixels"], available: isCatalyst),
             row("visor-auto-hide", String(localized: "Auto-hide when focus moves to another app"), in: .visor,
-                keywords: ["auto hide", "focus"]),
+                keywords: ["auto hide", "focus"], available: isCatalyst),
             row("visor-event-tap", String(localized: "Use event tap"), in: .visor,
-                keywords: ["accessibility", "permission", "event tap"]),
+                keywords: ["accessibility", "permission", "event tap"], available: isCatalyst),
 
             // MARK: Terminal › Keyboard (inline)
             row("terminal-writing-assistance", String(localized: "Writing Assistance"), in: .terminal,
@@ -1017,6 +1023,8 @@ func settingsSearchDestinationView(for destination: SettingsSearchDestination) -
     case .visor:
         #if STANDALONE && targetEnvironment(macCatalyst)
         VisorSettingsView()
+        #elseif os(iOS)
+        iPadVisorSettingsView()
         #else
         EmptyView()
         #endif

--- a/rootshell/UI/Settings/SettingsSections.swift
+++ b/rootshell/UI/Settings/SettingsSections.swift
@@ -221,6 +221,14 @@ struct SettingsAppearanceSection: View {
                 }
                 .themedRow()
                 .settingGroupContextMenu(.visor)
+                #elseif os(iOS)
+                if UIDevice.current.userInterfaceIdiom == .pad {
+                    NavigationLink(value: SettingsSearchDestination.visor) {
+                        Label("Visor", systemImage: "rectangle.topthird.inset.filled")
+                    }
+                    .themedRow()
+                    .settingGroupContextMenu(.visor)
+                }
                 #endif
             }
         }

--- a/rootshell/UI/Shell/MainView+Notifications.swift
+++ b/rootshell/UI/Shell/MainView+Notifications.swift
@@ -662,6 +662,11 @@ extension MainView {
     /// Check if notification should be handled by this window
     /// Notifications may include a terminal object or a window scene identifier
     func shouldHandleNotification(_ notification: Notification) -> Bool {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        if let handled = iPadVisorController.routeWindowAction(notification, to: windowId) {
+            return handled
+        }
+        #endif
         guard let pane = notification.object as? SplitPaneView else {
             // No terminal view in notification - check for scene ID targeting
             if let targetSceneID = notification.userInfo?[GhosttyCommandRouting.windowSceneSessionIDKey] as? String,

--- a/rootshell/UI/Shell/MainView.swift
+++ b/rootshell/UI/Shell/MainView.swift
@@ -677,6 +677,7 @@ struct MainView: View {
         let overlayContent = applyOverlayChangeHandlers(sheetContent)
         let alertContent = applyAlertModifiers(overlayContent)
         return applyLifecycleHandlers(alertContent)
+            .iPadVisor(ghosttyApp: ghosttyApp, windowID: windowId, modalPresented: isAnySheetPresented)
     }
 
 }

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -357,11 +357,22 @@ extension Ghostty.TerminalView {
         #endif
 
         var remainingPresses = presses
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // A configured Visor chord owns its physical key before Escape's
+        // mod-tap, tmux-detach, or overlay-dismiss paths can consume it.
+        for press in presses {
+            if let trigger = KeyTrigger(press: press), consumeVisorShortcut(trigger) {
+                remainingPresses.remove(press)
+                handled = true
+                shouldSkipSuper = true
+            }
+        }
+        #endif
 
         // Mod-tap interception: check each press against active rules
         let modTapRules = ModTapManager.shared.activeRulesByKey
         if !modTapRules.isEmpty {
-            for press in presses {
+            for press in remainingPresses {
                 if modTapInterceptor.handlePressBegan(press, rules: modTapRules) {
                     remainingPresses.remove(press)
                     handled = true
@@ -1824,6 +1835,15 @@ extension Ghostty.TerminalView {
     }
 
     @objc func handleEscapeKey(_ command: UIKeyCommand) {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // UIKit can route modified Escape through its plain-Escape command.
+        // Recover the held modifiers before treating it as terminal Escape.
+        if !KeyboardTracker.isSystemCancelChordPhysicallyDown() {
+            let modifiers = command.modifierFlags.union(KeyboardTracker.shared.shortcutRecoveryModifierFlags)
+            if consumeVisorShortcut(KeyTrigger(key: .escape,
+                modifiers: KeybindModifiers(uiModifierFlags: modifiers))) { return }
+        }
+        #endif
         if enclosingSplitHost?.cancelPaneDrag() == true {
             keysConsumedByOverlayAction.insert(.keyboardEscape)
             return
@@ -2428,6 +2448,8 @@ extension Ghostty.TerminalView {
             return
         }
 
+        if consumeVisorShortcut(commandTrigger) { return }
+
         // A custom plain-Escape binding may own the command that a translated
         // Cmd+Period delivery lands on. Give the physical chord first refusal
         // at a cmd+period binding before dispatching Escape.
@@ -2452,6 +2474,25 @@ extension Ghostty.TerminalView {
             Ghostty.logger.debug("handleKeybindCommand: No action for trigger \(trigFormat)")
             return
         }
+    }
+
+    /// Claim only the user's active Visor binding. Plain Escape and previous
+    /// bindings remain terminal input after a remap or when Visor is disabled.
+    @discardableResult
+    private func consumeVisorShortcut(_ trigger: KeyTrigger) -> Bool {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        guard let binding = KeybindManager.shared.keybind(for: trigger),
+              binding.action == .toggle_visor else { return false }
+        if trigger.key == .escape {
+            guard !keysConsumedByOverlayAction.contains(.keyboardEscape) else { return true }
+            keysConsumedByOverlayAction.insert(.keyboardEscape)
+        }
+        commitKoreanCompositionIfNeeded(external: true)
+        NotificationCenter.default.post(name: .toggleVisorOverlay, object: self)
+        return true
+        #else
+        return false
+        #endif
     }
 
     /// Route a normalized trigger through sequence handling and then the active

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -3494,6 +3494,9 @@ extension Ghostty {
 
         @discardableResult
         override func becomeFirstResponder() -> Bool {
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            guard iPadVisorController.permitsFocus(self) else { return false }
+            #endif
             if !isFirstResponder { invalidateWritingAssistance(resetDocument: true) }
             refreshWritingAssistanceTraits()
             // Gate: while a keyboard-owning overlay (tab sidebar, connection
@@ -4416,6 +4419,9 @@ extension Ghostty {
         /// `skipResign` is safe when unfocusing the old terminal.
         @discardableResult
         override func focusDidChange(_ focused: Bool, skipResign: Bool = false) -> Bool {
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            if focused && !iPadVisorController.permitsFocus(self) { return false }
+            #endif
             invalidateWritingAssistance(resetDocument: true)
             // Update mouse capture state when focus changes to ensure scroll handling
             // has accurate state for this terminal (fixes split view mouse capture scrolling)


### PR DESCRIPTION
Add resizable per-window terminals with themed settings and configurable shortcuts. Preserve sessions while hidden and support focus, window-action routing, Search, and Compose.