### PR TITLE
Add per-profile keyboard shortcuts

### DIFF
--- a/rootshell/Core/Keybinds/KeybindAction.swift
+++ b/rootshell/Core/Keybinds/KeybindAction.swift
@@ -139,6 +139,8 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     case browse_hosts = "browse_hosts"
     /// Open profiles browser
     case browse_profiles = "browse_profiles"
+    /// Connect to a specific connection profile (parameter = profile UUID string)
+    case open_profile = "open_profile"
     /// Toggle AI agent panel
     case toggle_ai_agent = "toggle_ai_agent"
     /// Toggle voice agent mode
@@ -311,7 +313,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
              .toggle_auto_redact:
             return .view
 
-        case .open_settings, .browse_hosts, .browse_profiles, .toggle_ai_agent, .toggle_voice_agent:
+        case .open_settings, .browse_hosts, .browse_profiles, .open_profile, .toggle_ai_agent, .toggle_voice_agent:
             return .shell
 
         case .select_all, .clear_screen, .reset_terminal,
@@ -377,6 +379,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .open_settings: return String(localized: "Settings", comment: "Keybind action: open settings")
         case .browse_hosts: return String(localized: "Browse Hosts", comment: "Keybind action")
         case .browse_profiles: return String(localized: "Browse Profiles", comment: "Keybind action")
+        case .open_profile: return String(localized: "Open Profile", comment: "Keybind action: connect to a saved connection profile")
         case .toggle_ai_agent: return String(localized: "Toggle AI Agent", comment: "Keybind action")
         case .toggle_voice_agent: return String(localized: "Toggle Voice Agent", comment: "Keybind action")
         case .toggle_tab_bar: return String(localized: "Toggle Top Tab Bar", comment: "Keybind action")
@@ -463,6 +466,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
         case .open_settings: return .openSettings
         case .browse_hosts: return .browseHosts
         case .browse_profiles: return .browseProfiles
+        case .open_profile: return .openConnectionProfile
         case .toggle_ai_agent: return .toggleAIAgent
         case .toggle_voice_agent: return .toggleVoiceAgent
         case .toggle_tab_bar: return .toggleTabBar
@@ -538,7 +542,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     /// Parameterized actions skip action-based dedup in KeybindManager.reloadBindings().
     var isParameterized: Bool {
         switch self {
-        case .send_text, .send_esc, .send_csi:
+        case .send_text, .send_esc, .send_csi, .open_profile:
             return true
         default:
             return false
@@ -549,7 +553,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     var needsSystemPriority: Bool {
         switch self {
         case .close_tab, .new_tab, .new_window, .new_local_shell, .start_search, .toggle_compose,
-             .send_text, .send_esc, .send_csi,
+             .send_text, .send_esc, .send_csi, .open_profile,
              // ⌘⌥[ / ⌘⌥]: Option composes a different character, so the menu
              // key-equivalent path can't claim the press before the terminal
              // encodes it as Alt-[; a prioritized UIKeyCommand must own it.
@@ -564,7 +568,8 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
     static var customizableActions: [KeybindAction] {
         allCases.filter { action in
             switch action {
-            case .unbind, .send_text, .send_esc, .send_csi:
+            case .unbind, .send_text, .send_esc, .send_csi, .open_profile:
+                // Profile shortcuts are assigned per-profile in the profile editor.
                 return false
             default:
                 return !action.isControlCharacter
@@ -621,7 +626,7 @@ enum KeybindAction: String, CaseIterable, Codable, Identifiable, Hashable {
             return true
 
         // These actions don't have menu entries.
-        case .reset_terminal, .send_text, .send_esc, .send_csi:
+        case .reset_terminal, .send_text, .send_esc, .send_csi, .open_profile:
             return false
 
         // Control characters are handled separately

--- a/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
+++ b/rootshell/Core/Keybinds/KeybindCommandGenerator.swift
@@ -133,7 +133,7 @@ final class KeybindCommandGenerator: ObservableObject {
              .toggle_full_screen, .toggle_mouse_capture, .cycle_input_source,
              .increase_font_size, .decrease_font_size,
              .reset_font_size, .start_search, .select_all, .toggle_theme_picker,
-             .toggle_clipboard_manager, .brightness_boost:
+             .toggle_clipboard_manager, .brightness_boost, .open_profile:
             return true
 
         // Terminal actions are handled via ghostty_surface_binding_action
@@ -205,7 +205,17 @@ final class KeybindCommandGenerator: ObservableObject {
 
         // Set discoverability title for iPad keyboard shortcuts overlay
         #if !os(visionOS)
-        command.discoverabilityTitle = binding.action.displayName
+        if binding.action == .open_profile,
+           let param = binding.actionParameter,
+           let profileID = UUID(uuidString: param),
+           let profile = ConnectionProfileManager.shared.profile(for: profileID) {
+            command.discoverabilityTitle = String(
+                localized: "Open \(profile.name)",
+                comment: "Keyboard shortcut discoverability title for opening a connection profile"
+            )
+        } else {
+            command.discoverabilityTitle = binding.action.displayName
+        }
         #endif
 
         // User overrides and external config bindings need priority to override

--- a/rootshell/Core/Keybinds/KeybindManager.swift
+++ b/rootshell/Core/Keybinds/KeybindManager.swift
@@ -237,6 +237,21 @@ final class KeybindManager: ObservableObject {
         activeBindings.first { $0.action == action }
     }
 
+    /// Get the keybind for a parameterized action (e.g. open_profile:<uuid>)
+    func keybind(for action: KeybindAction, parameter: String) -> Keybind? {
+        activeBindings.first { $0.action == action && $0.actionParameter == parameter }
+    }
+
+    /// Shortcut sequence currently bound to a connection profile, if any
+    func keybind(forProfileID profileID: UUID) -> Keybind? {
+        keybind(for: .open_profile, parameter: profileID.uuidString)
+    }
+
+    /// Human-readable shortcut glyphs for a profile (e.g. "⌘⇧1"), or nil when unbound
+    func shortcutDescription(forProfileID profileID: UUID) -> String? {
+        keybind(forProfileID: profileID)?.sequence.symbolDescription
+    }
+
     /// Get the keybind for a given sequence (includes action parameter)
     func keybind(for sequence: KeySequence) -> Keybind? {
         activeBindings.first { $0.sequence == sequence }
@@ -250,8 +265,9 @@ final class KeybindManager: ObservableObject {
     // MARK: - User Overrides
 
     /// Set a user override for an action
-    func setOverride(sequence: KeySequence, action: KeybindAction) {
-        Self.logger.info("Setting override: \(sequence.ghosttyFormat) -> \(action.rawValue)")
+    func setOverride(sequence: KeySequence, action: KeybindAction, parameter: String? = nil) {
+        let paramLabel = parameter.map { ":\($0)" } ?? ""
+        Self.logger.info("Setting override: \(sequence.ghosttyFormat) -> \(action.rawValue)\(paramLabel)")
 
         if action == .unbind {
             // Unbind is special: multiple actions can be unbound simultaneously.
@@ -259,6 +275,12 @@ final class KeybindManager: ObservableObject {
             // overrides (e.g., custom remaps) — reloadBindings() processes them in
             // order, so the later unbind suppresses the earlier remap.
             userOverrides.removeAll { $0.action == .unbind && $0.sequence == sequence }
+        } else if action.isParameterized, let parameter {
+            // Parameterized actions (open_profile, send_text, …) can have many
+            // bindings that share the same action with different params.
+            userOverrides.removeAll {
+                $0.action == action && $0.actionParameter == parameter
+            }
         } else {
             // Normal action: one key per action, remove old override for this action
             userOverrides.removeAll { $0.action == action }
@@ -272,6 +294,7 @@ final class KeybindManager: ObservableObject {
         let override = Keybind(
             sequence: sequence,
             action: action,
+            actionParameter: parameter,
             isUserOverride: true,
             source: .userOverride
         )
@@ -282,8 +305,18 @@ final class KeybindManager: ObservableObject {
     }
 
     /// Set a user override from a single trigger
-    func setOverride(trigger: KeyTrigger, action: KeybindAction) {
-        setOverride(sequence: KeySequence(trigger: trigger), action: action)
+    func setOverride(trigger: KeyTrigger, action: KeybindAction, parameter: String? = nil) {
+        setOverride(sequence: KeySequence(trigger: trigger), action: action, parameter: parameter)
+    }
+
+    /// Bind or replace the keyboard shortcut for a connection profile
+    func setProfileShortcut(sequence: KeySequence, profileID: UUID) {
+        setOverride(sequence: sequence, action: .open_profile, parameter: profileID.uuidString)
+    }
+
+    /// Remove the keyboard shortcut for a connection profile (default: none)
+    func clearProfileShortcut(profileID: UUID) {
+        removeOverride(for: .open_profile, parameter: profileID.uuidString)
     }
 
     /// Explicitly unbind an action (removes its shortcut entirely)
@@ -325,6 +358,16 @@ final class KeybindManager: ObservableObject {
         // Also remove any unbind override targeting this action
         userOverrides.removeAll {
             $0.action == .unbind && $0.actionParameter == action.rawValue
+        }
+        saveUserOverrides()
+        reloadBindings()
+    }
+
+    /// Remove a parameterized user override (e.g. a single profile shortcut)
+    func removeOverride(for action: KeybindAction, parameter: String) {
+        Self.logger.info("Removing override for: \(action.rawValue):\(parameter)")
+        userOverrides.removeAll {
+            $0.action == action && $0.actionParameter == parameter
         }
         saveUserOverrides()
         reloadBindings()

--- a/rootshell/Features/Profiles/ConnectionProfileManager.swift
+++ b/rootshell/Features/Profiles/ConnectionProfileManager.swift
@@ -291,6 +291,7 @@ final class ConnectionProfileManager {
 
     /// Delete a profile (soft delete for sync)
     func deleteProfile(id: UUID) throws {
+        KeybindManager.shared.clearProfileShortcut(profileID: id)
         try store.softDelete(id: id)
         updateProfilesFromStore()
 
@@ -657,6 +658,7 @@ final class ConnectionProfileManager {
                 identity: profile.id.uuidString
             )
             if recordNames.contains(recordName) {
+                KeybindManager.shared.clearProfileShortcut(profileID: profile.id)
                 var deleted = profile
                 deleted.isDeleted = true
                 deleted.modifiedAt = Date()

--- a/rootshell/Features/Profiles/ConnectionProfileManager.swift
+++ b/rootshell/Features/Profiles/ConnectionProfileManager.swift
@@ -291,8 +291,8 @@ final class ConnectionProfileManager {
 
     /// Delete a profile (soft delete for sync)
     func deleteProfile(id: UUID) throws {
-        KeybindManager.shared.clearProfileShortcut(profileID: id)
         try store.softDelete(id: id)
+        KeybindManager.shared.clearProfileShortcut(profileID: id)
         updateProfilesFromStore()
 
         Self.logger.info("Deleted profile \(id.uuidString)")
@@ -630,6 +630,9 @@ final class ConnectionProfileManager {
 
             do {
                 try persistProfile(remote, updateTimestamp: false, notifySync: false)
+                if remote.isDeleted {
+                    KeybindManager.shared.clearProfileShortcut(profileID: remote.id)
+                }
                 applied += 1
             } catch {
                 failures.append((id: remote.id, error: error))
@@ -658,12 +661,18 @@ final class ConnectionProfileManager {
                 identity: profile.id.uuidString
             )
             if recordNames.contains(recordName) {
-                KeybindManager.shared.clearProfileShortcut(profileID: profile.id)
                 var deleted = profile
                 deleted.isDeleted = true
                 deleted.modifiedAt = Date()
-                try? persistProfile(deleted, updateTimestamp: false, notifySync: false)
-                deletedCount += 1
+                do {
+                    try persistProfile(deleted, updateTimestamp: false, notifySync: false)
+                    KeybindManager.shared.clearProfileShortcut(profileID: profile.id)
+                    deletedCount += 1
+                } catch {
+                    let idString = profile.id.uuidString
+                    let desc = error.localizedDescription
+                    Self.logger.error("Failed to persist remote profile deletion \(idString): \(desc)")
+                }
             }
         }
 

--- a/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
@@ -130,7 +130,13 @@ struct ProfileEditorSheet: View {
     // UI state
     @State private var showingIconPicker: Bool = false
     @State private var showingFolderPicker: Bool = false
+    @State private var showingShortcutEditor: Bool = false
     @State private var errorMessage: String?
+
+    /// Draft keyboard shortcut for this profile. nil = no shortcut (the default).
+    /// Applied to KeybindManager only when the profile is saved.
+    @State private var draftShortcut: KeySequence?
+    @State private var pendingShortcutOutcome: KeybindEditorOutcome?
 
     // Existing profile (nil for new)
     private let existingProfile: ConnectionProfile?
@@ -320,6 +326,21 @@ struct ProfileEditorSheet: View {
             FolderPickerSheet(selectedPath: $folderPath)
                 .themedSubSheet(sheetThemeColors)
         }
+        .sheet(isPresented: $showingShortcutEditor, onDismiss: applyPendingShortcutOutcome) {
+            KeybindEditorView(
+                action: .open_profile,
+                actionParameter: existingProfile?.id.uuidString,
+                titleOverride: name.isEmpty
+                    ? String(localized: "Profile Shortcut", comment: "Title when editing a profile keyboard shortcut")
+                    : name,
+                allowsRestoreDefault: false,
+                draftSequence: .some(draftShortcut),
+                onOutcome: { outcome in
+                    pendingShortcutOutcome = outcome
+                }
+            )
+            .themedSubSheet(sheetThemeColors)
+        }
         .sheet(isPresented: $showingAddPortForward) {
             AddPortForwardSheet { newForward in
                 let wasEmpty = portForwards.isEmpty
@@ -403,6 +424,25 @@ struct ProfileEditorSheet: View {
                 Spacer()
                 colorPicker
             }
+            .themedRow()
+
+            Button {
+                showingShortcutEditor = true
+            } label: {
+                HStack {
+                    Text("Keyboard Shortcut")
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Text(draftShortcut?.symbolDescription ?? String(localized: "None"))
+                        .font(.system(.title3, design: .monospaced))
+                        .foregroundColor(.secondary)
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
             .themedRow()
         }
     }
@@ -1813,6 +1853,26 @@ struct ProfileEditorSheet: View {
 
     // MARK: - Actions
 
+    private func applyPendingShortcutOutcome() {
+        guard let outcome = pendingShortcutOutcome else { return }
+        pendingShortcutOutcome = nil
+        switch outcome {
+        case .captured(let sequence):
+            draftShortcut = sequence
+        case .restoreDefault, .unbind:
+            draftShortcut = nil
+        }
+    }
+
+    /// Persist the draft keyboard shortcut for a profile after create/update.
+    private func persistDraftShortcut(for profileID: UUID) {
+        if let draftShortcut {
+            KeybindManager.shared.setProfileShortcut(sequence: draftShortcut, profileID: profileID)
+        } else {
+            KeybindManager.shared.clearProfileShortcut(profileID: profileID)
+        }
+    }
+
     private func loadExistingProfile() {
         guard !didLoadProfile else { return }
         didLoadProfile = true
@@ -1825,6 +1885,7 @@ struct ProfileEditorSheet: View {
             colorTag = profile.colorTag
             folderPath = profile.folderPath
             tags = profile.tags
+            draftShortcut = KeybindManager.shared.keybind(forProfileID: profile.id)?.sequence
 
             // Load connection protocol and transport mode
             connectionProtocol = profile.connectionProtocol
@@ -2297,9 +2358,10 @@ struct ProfileEditorSheet: View {
                 updated.localConfig = nil
                 updated.themeName = profileThemeName.isEmpty ? nil : profileThemeName
                 try profileManager.updateProfile(updated)
+                persistDraftShortcut(for: updated.id)
             } else {
                 // Create new profile
-                try profileManager.createProfile(
+                let created = try profileManager.createProfile(
                     name: trimmedName,
                     sshConfig: finalConfig,
                     connectionProtocol: connectionProtocol,
@@ -2322,6 +2384,7 @@ struct ProfileEditorSheet: View {
                     vpnBlockQUIC: vpnBlockQUIC,
                     extensionPayload: ProfileExtensionPayload(themeName: profileThemeName.isEmpty ? nil : profileThemeName)
                 )
+                persistDraftShortcut(for: created.id)
             }
             dismiss()
         } catch {
@@ -2353,14 +2416,16 @@ struct ProfileEditorSheet: View {
                     useCount: existing.useCount, extensionPayload: payload
                 )
                 try profileManager.updateProfile(updated)
+                persistDraftShortcut(for: updated.id)
             } else {
-                try profileManager.createProfile(
+                let created = try profileManager.createProfile(
                     name: trimmedName, sshConfig: ConnectionProfile.localPlaceholderSSHConfig(),
                     connectionProtocol: .local,
                     notes: notes.isEmpty ? nil : notes, iconName: iconName,
                     colorTag: colorTag, folderPath: folderPath, tags: tags,
                     extensionPayload: payload
                 )
+                persistDraftShortcut(for: created.id)
             }
             dismiss()
         } catch {
@@ -2410,8 +2475,9 @@ struct ProfileEditorSheet: View {
                 updated.themeName = profileThemeName.isEmpty ? nil : profileThemeName
                 updated.sshConfig = ConnectionProfile.vncPlaceholderSSHConfig(for: config)
                 try profileManager.updateProfile(updated)
+                persistDraftShortcut(for: updated.id)
             } else {
-                try profileManager.createProfile(
+                let created = try profileManager.createProfile(
                     name: trimmedName,
                     sshConfig: ConnectionProfile.vncPlaceholderSSHConfig(for: config),
                     connectionProtocol: .vnc,
@@ -2422,6 +2488,7 @@ struct ProfileEditorSheet: View {
                     tags: tags,
                     extensionPayload: ProfileExtensionPayload(vncConfig: config, themeName: profileThemeName.isEmpty ? nil : profileThemeName)
                 )
+                persistDraftShortcut(for: created.id)
             }
             dismiss()
         } catch {

--- a/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfileEditorSheet.swift
@@ -7,10 +7,84 @@
 
 import SwiftUI
 
+struct ProfileShortcutEditorRequest: Identifiable {
+    let id = UUID()
+    let actionParameter: String?
+    let title: String
+    let draftSequence: KeySequence?
+    let onOutcome: (KeybindEditorOutcome) -> Void
+}
+
+struct ProfileShortcutEditorPresenter {
+    let present: (ProfileShortcutEditorRequest) -> Void
+
+    func callAsFunction(_ request: ProfileShortcutEditorRequest) {
+        present(request)
+    }
+}
+
+private struct ProfileShortcutEditorPresenterKey: EnvironmentKey {
+    static let defaultValue: ProfileShortcutEditorPresenter? = nil
+}
+
+extension EnvironmentValues {
+    var profileShortcutEditorPresenter: ProfileShortcutEditorPresenter? {
+        get { self[ProfileShortcutEditorPresenterKey.self] }
+        set { self[ProfileShortcutEditorPresenterKey.self] = newValue }
+    }
+}
+
+/// Owns the shortcut sheet above profile navigation destinations. Catalyst
+/// then gives it the same responder isolation as the Settings shortcut sheet.
+private struct ProfileShortcutEditorHostModifier: ViewModifier {
+    @Environment(\.sheetThemeColors) private var sheetThemeColors
+    @State private var request: ProfileShortcutEditorRequest?
+    @State private var pendingOutcome: KeybindEditorOutcome?
+    @State private var outcomeHandler: ((KeybindEditorOutcome) -> Void)?
+
+    func body(content: Content) -> some View {
+        content
+            .environment(
+                \.profileShortcutEditorPresenter,
+                ProfileShortcutEditorPresenter { newRequest in
+                    pendingOutcome = nil
+                    outcomeHandler = newRequest.onOutcome
+                    request = newRequest
+                }
+            )
+            .sheet(item: $request, onDismiss: applyPendingOutcome) { request in
+                KeybindEditorView(
+                    action: .open_profile,
+                    actionParameter: request.actionParameter,
+                    titleOverride: request.title,
+                    allowsRestoreDefault: false,
+                    draftSequence: .some(request.draftSequence),
+                    onOutcome: { pendingOutcome = $0 }
+                )
+                .themedSubSheet(sheetThemeColors)
+            }
+    }
+
+    private func applyPendingOutcome() {
+        if let pendingOutcome {
+            outcomeHandler?(pendingOutcome)
+        }
+        pendingOutcome = nil
+        outcomeHandler = nil
+    }
+}
+
+extension View {
+    func profileShortcutEditorHost() -> some View {
+        modifier(ProfileShortcutEditorHostModifier())
+    }
+}
+
 /// Sheet for creating or editing a connection profile
 struct ProfileEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.sheetThemeColors) private var sheetThemeColors
+    @Environment(\.profileShortcutEditorPresenter) private var shortcutEditorPresenter
 
     // Manager
     private var profileManager: ConnectionProfileManager { ConnectionProfileManager.shared }
@@ -427,14 +501,14 @@ struct ProfileEditorSheet: View {
             .themedRow()
 
             Button {
-                showingShortcutEditor = true
+                presentShortcutEditor()
             } label: {
                 HStack {
                     Text("Keyboard Shortcut")
                         .foregroundColor(.primary)
                     Spacer()
                     Text(draftShortcut?.symbolDescription ?? String(localized: "None"))
-                        .font(.system(.title3, design: .monospaced))
+                        .font(.system(.body, design: .monospaced))
                         .foregroundColor(.secondary)
                     Image(systemName: "chevron.right")
                         .font(.caption)
@@ -1853,9 +1927,30 @@ struct ProfileEditorSheet: View {
 
     // MARK: - Actions
 
+    private func presentShortcutEditor() {
+        let title = name.isEmpty
+            ? String(localized: "Profile Shortcut", comment: "Title when editing a profile keyboard shortcut")
+            : name
+
+        if let shortcutEditorPresenter {
+            shortcutEditorPresenter(ProfileShortcutEditorRequest(
+                actionParameter: existingProfile?.id.uuidString,
+                title: title,
+                draftSequence: draftShortcut,
+                onOutcome: applyShortcutOutcome
+            ))
+        } else {
+            showingShortcutEditor = true
+        }
+    }
+
     private func applyPendingShortcutOutcome() {
-        guard let outcome = pendingShortcutOutcome else { return }
-        pendingShortcutOutcome = nil
+        guard let pendingShortcutOutcome else { return }
+        self.pendingShortcutOutcome = nil
+        applyShortcutOutcome(pendingShortcutOutcome)
+    }
+
+    private func applyShortcutOutcome(_ outcome: KeybindEditorOutcome) {
         switch outcome {
         case .captured(let sequence):
             draftShortcut = sequence

--- a/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
@@ -715,6 +715,7 @@ struct ProfileRow: View {
     var action: (() -> Void)? = nil
 
     @ObservedObject private var sessionTracker = SessionTracker.shared
+    @ObservedObject private var keybindManager = KeybindManager.shared
 
     var body: some View {
         rowContent
@@ -722,11 +723,11 @@ struct ProfileRow: View {
 
     @ViewBuilder
     private var rowContent: some View {
-        HStack {
+        HStack(alignment: .center, spacing: 12) {
             // Icon
             profileIcon
 
-            // Info
+            // Title + subtitle
             VStack(alignment: .leading, spacing: 2) {
                 Text(profile.name)
                     .foregroundColor(.primary)
@@ -746,7 +747,17 @@ struct ProfileRow: View {
                     .foregroundColor(.secondary)
             }
 
-            Spacer()
+            Spacer(minLength: 8)
+
+            // Keyboard shortcut — trailing, sized to read clearly beside the text block
+            if let shortcut = keybindManager.shortcutDescription(forProfileID: profile.id) {
+                Text(shortcut)
+                    .font(.system(.title3, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .layoutPriority(1)
+            }
 
             // Key availability warning badge
             ProfileKeyAvailabilityBadge(profile: profile)

--- a/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
+++ b/rootshell/Features/Profiles/Views/ProfilesBrowseSheet.swift
@@ -106,6 +106,7 @@ struct ProfilesBrowseSheet: View {
                     profileListView(folder: folder)
                 }
         }
+        .profileShortcutEditorHost()
         .overlay {
             // Hidden button to handle Esc at the UIKit key command level,
             // which fires before SwiftUI's .onKeyPress and before the sheet's

--- a/rootshell/Features/SSH/Views/SSHConnectionView.swift
+++ b/rootshell/Features/SSH/Views/SSHConnectionView.swift
@@ -431,6 +431,7 @@ struct SSHConnectionView: View {
         NavigationStack(path: $inlineProfilesPath) {
             navigationStackContent
         }
+        .profileShortcutEditorHost()
         .overlay {
             // Single Esc handler for the entire connection view.
             // Navigates back through profile folders first, then closes.

--- a/rootshell/Features/SSH/Views/SSHHostBrowseSheet.swift
+++ b/rootshell/Features/SSH/Views/SSHHostBrowseSheet.swift
@@ -173,6 +173,7 @@ struct SSHHostBrowseListContent: View {
                 ProfileEditorSheet(historyEntry: entry, embedded: true)
             }
         }
+        .profileShortcutEditorHost()
     }
 
     // MARK: - Search Section

--- a/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
+++ b/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
@@ -24,6 +24,15 @@ struct KeybindEditorView: View {
     @ObservedObject private var keybindManager = KeybindManager.shared
 
     let action: KeybindAction
+    /// Optional parameter for parameterized actions (e.g. profile UUID for `open_profile`)
+    var actionParameter: String? = nil
+    /// Optional title override (e.g. profile name). Falls back to `action.displayName`.
+    var titleOverride: String? = nil
+    /// When false, hide "Restore Default" (used for profile shortcuts whose default is none).
+    var allowsRestoreDefault: Bool = true
+    /// When non-nil, display this sequence instead of looking up the live KeybindManager
+    /// binding. Lets parents (e.g. profile editor) keep a draft until Save.
+    var draftSequence: KeySequence?? = nil
     /// Reports the user's choice to the parent. All paths that mutate
     /// `KeybindManager` route through this callback so the actual write
     /// happens in the parent's sheet-onDismiss closure.
@@ -34,8 +43,28 @@ struct KeybindEditorView: View {
     @State private var captureError: String?
 
     /// Current binding for this action (may be nil if displaced by external config)
-    private var binding: Keybind? {
-        keybindManager.keybind(for: action)
+    private var managerBinding: Keybind? {
+        if let actionParameter {
+            keybindManager.keybind(for: action, parameter: actionParameter)
+        } else {
+            keybindManager.keybind(for: action)
+        }
+    }
+
+    /// Sequence shown in the "Current Shortcut" section
+    private var displayedSequence: KeySequence? {
+        if let draftSequence {
+            return draftSequence
+        }
+        return managerBinding?.sequence
+    }
+
+    private var showsCustomBadge: Bool {
+        draftSequence == nil && (managerBinding?.isUserOverride == true)
+    }
+
+    private var displayTitle: String {
+        titleOverride ?? action.displayName
     }
 
     private var sheetBackground: Color {
@@ -51,7 +80,7 @@ struct KeybindEditorView: View {
             VStack(spacing: 24) {
                 // Action info
                 VStack(spacing: 8) {
-                    Text(action.displayName)
+                    Text(displayTitle)
                         .font(.title2)
                         .fontWeight(.semibold)
 
@@ -73,15 +102,15 @@ struct KeybindEditorView: View {
                         .font(.headline)
                         .foregroundColor(.secondary)
 
-                    if let binding {
-                        Text(binding.sequence.symbolDescription)
+                    if let displayedSequence {
+                        Text(displayedSequence.symbolDescription)
                             .font(.system(size: 28, weight: .medium, design: .monospaced))
                             .padding(.horizontal, 24)
                             .padding(.vertical, 16)
                             .background(rowBackground)
                             .cornerRadius(12)
 
-                        if binding.isUserOverride {
+                        if showsCustomBadge {
                             Label("Custom", systemImage: "star.fill")
                                 .font(.caption)
                                 .foregroundStyle(.tint)
@@ -147,7 +176,9 @@ struct KeybindEditorView: View {
 
                 // Action buttons
                 VStack(spacing: 8) {
-                    if (binding != nil && binding!.isUserOverride) || keybindManager.isActionUnbound(action) {
+                    if allowsRestoreDefault,
+                       draftSequence == nil,
+                       (managerBinding != nil && managerBinding!.isUserOverride) || keybindManager.isActionUnbound(action) {
                         Button("Restore Default") {
                             onOutcome(.restoreDefault)
                             dismiss()
@@ -155,8 +186,8 @@ struct KeybindEditorView: View {
                         .foregroundColor(.orange)
                     }
 
-                    if binding != nil {
-                        Button("Unbind Shortcut") {
+                    if displayedSequence != nil {
+                        Button(allowsRestoreDefault ? "Unbind Shortcut" : "Clear Shortcut") {
                             onOutcome(.unbind)
                             dismiss()
                         }

--- a/rootshell/UI/Shell/MainView+Notifications.swift
+++ b/rootshell/UI/Shell/MainView+Notifications.swift
@@ -404,6 +404,17 @@ extension MainView {
             self.showConnectionSidebar = true
         }
 
+        observerBag.observeOnMainActor(.openConnectionProfile) { [self] notification in
+            guard self.shouldHandleNotification(notification) else { return }
+            guard let rawID = notification.userInfo?["profileID"] as? String,
+                  let profileID = UUID(uuidString: rawID) else { return }
+            // Same connect path as Shortcuts / AppleScript profile open.
+            self.handleProfileIntent(ProfileIntentRequest(
+                profileID: profileID,
+                launchCommandOverride: nil
+            ))
+        }
+
         #if !CHINA_BUILD
         observerBag.observeOnMainActor(.toggleAIAgent) { [self] notification in
             Ghostty.logger.info("toggleAIAgent notification received, object: \(String(describing: notification.object))")

--- a/rootshell/UI/Terminal/TerminalSplitTreeView.swift
+++ b/rootshell/UI/Terminal/TerminalSplitTreeView.swift
@@ -1155,6 +1155,7 @@ extension Notification.Name {
     static let createLocalShell = Notification.Name("com.rootshell.createLocalShell")
     static let browseHosts = Notification.Name("com.rootshell.browseHosts")
     static let browseProfiles = Notification.Name("com.rootshell.browseProfiles")
+    static let openConnectionProfile = Notification.Name("com.rootshell.openConnectionProfile")
     static let ghosttyDidUpdateScrollbar = Notification.Name("com.rootshell.didUpdateScrollbar")
     static let ghosttySelectionScrollIndicatorActivity = Notification.Name("com.rootshell.selectionScrollIndicatorActivity")
     static let ghosttyDidReceiveInput = Notification.Name("com.rootshell.didReceiveInput")

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -2597,6 +2597,10 @@ extension Ghostty.TerminalView {
             userInfo["tabIndex"] = 9
         case .new_tab, .new_window, .close_tab:
             userInfo["windowId"] = windowId
+        case .open_profile:
+            if let parameter {
+                userInfo["profileID"] = parameter
+            }
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Add an optional keyboard shortcut on each connection profile (default: none), configured from the profile editor using the existing shortcut capture UI
- Triggering the shortcut opens the profile through the same `handleProfileIntent` / `connectToProfile` path used by Shortcuts and AppleScript
- Show the assigned shortcut as trailing monospaced sub-text in the profile list

## Test plan
- [ ] Create/edit a profile, assign a shortcut, save — confirm it appears beside the profile in the list
- [ ] Press the shortcut from a terminal session — confirm it opens/connects that profile in a new tab
- [ ] Clear the shortcut and save — confirm list no longer shows it and the chord does nothing
- [ ] Delete a profile that had a shortcut — confirm the binding is removed
- [ ] Confirm unrelated global shortcuts in Settings → Keyboard are unchanged

https://github.com/user-attachments/assets/0dfd25f9-4cf9-4cf3-8eb9-41dc76244580

Made with [Cursor](https://cursor.com)