### PR TITLE
Fix Ctrl and Cmd shortcuts for alternate keyboard layouts

### DIFF
--- a/rootshell/Core/Keybinds/KeyTrigger.swift
+++ b/rootshell/Core/Keybinds/KeyTrigger.swift
@@ -288,68 +288,70 @@ enum KeyCode: String, Codable, CaseIterable, Hashable, Sendable {
     /// (for example Dvorak–QWERTY ⌘). Ctrl input still uses unmodified text.
     @MainActor
     init?(uiKey: UIKey, modifiers: UIKeyModifierFlags? = nil) {
+        let physicalKey = KeyCode(hidUsage: uiKey.keyCode)
+        guard physicalKey?.isPrintable == true
+                || uiKey.keyCode == .keyboardNonUSPound
+                || uiKey.keyCode == .keyboardNonUSBackslash else {
+            // Special and modifier-only keys need no layout translation.
+            guard let physicalKey else { return nil }
+            self = physicalKey
+            return
+        }
+
         let modifiers = modifiers ?? uiKey.modifierFlags
-        var text = uiKey.charactersIgnoringModifiers
+        var logicalKey = Self.printableKey(for: uiKey.charactersIgnoringModifiers)
         if modifiers.contains(.command) {
             // UIKey.characters preserves Command, but can also contain an
             // Option-composed character or a Control byte. Use it only when
             // those modifiers are absent. Shifted letters normalize safely;
-            // shifted punctuation needs the base-key identity instead.
+            // shifted punctuation needs a Command-only layout translation.
+            // UIKit has no API for removing just Shift/Option/Control, so if
+            // Carbon is unavailable these chords retain the base-layout
+            // fallback; do not guess a US key from a composed character.
             let characters = uiKey.characters
-            if uiKey.modifierFlags.contains(.command),
-               uiKey.modifierFlags.intersection([.control, .alternate]).isEmpty,
-               characters.unicodeScalars.count == 1,
-               let scalar = characters.unicodeScalars.first,
-               (0x20..<0x7F).contains(scalar.value),
-               !uiKey.modifierFlags.contains(.shift) || characters.first?.isLetter == true {
-                text = characters
+            if modifiers.intersection([.control, .alternate]).isEmpty,
+               let characterKey = Self.printableKey(for: characters),
+               !modifiers.contains(.shift) || characters.first?.isLetter == true {
+                logicalKey = characterKey
             }
 
             #if targetEnvironment(macCatalyst)
             // Ask the active layout for Command alone, dropping Shift/Option/
             // Control without losing its Command-specific key map. This also
             // handles virtual Command from mod-tap and combined modifiers.
-            if let nativeKeyCode = Ghostty.Input.nativeKeyCode(for: uiKey.keyCode),
-               let translated = CatalystKeyboardLayout.shared.translateKey(
+            let layout = CatalystKeyboardLayout.shared
+            if layout.isAvailable,
+               let nativeKeyCode = Ghostty.Input.nativeKeyCode(for: uiKey.keyCode),
+               let translated = layout.translateKey(
                    cgKeyCode: UInt16(nativeKeyCode), shift: false, command: true
-               ), !translated.isEmpty {
-                text = translated
+               ), let translatedKey = Self.printableKey(for: translated) {
+                // An unusable translation must not discard valid UIKit text.
+                logicalKey = translatedKey
             }
             #endif
         }
-        self.init(hidUsage: uiKey.keyCode, charactersIgnoringModifiers: text)
+        guard let resolvedKey = logicalKey ?? physicalKey else { return nil }
+        self = resolvedKey
     }
 
-    /// Resolve a named key from layout text with Shift/Option/Control removed.
-    /// Keep special keys physical: their UIKit text may be a control byte or a
-    /// sentinel, and must not turn (for example) Forward Delete into Backspace.
-    /// Missing/unsupported layout text retains the physical fallback for IMEs.
-    init?(hidUsage: UIKeyboardHIDUsage, charactersIgnoringModifiers: String) {
-        let physicalKey = KeyCode(hidUsage: hidUsage)
-        switch hidUsage {
-        case .keyboardNonUSPound, .keyboardNonUSBackslash:
-            // ISO printable positions have no US KeyCode, but UIKit can still
-            // provide a supported character for them.
-            break
-        default:
-            guard let text = physicalKey?.literalKeyInput,
-                  text.unicodeScalars.count == 1,
-                  let scalar = text.unicodeScalars.first,
-                  (0x20..<0x7F).contains(scalar.value) else {
-                self.init(hidUsage: hidUsage)
-                return
-            }
+    private var isPrintable: Bool {
+        switch self {
+        case .tab, .escape, .enter, .backspace, .delete,
+             .up, .down, .left, .right, .home, .end, .pageUp, .pageDown,
+             .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12:
+            return false
+        default: return true
         }
+    }
 
-        let text = charactersIgnoringModifiers.precomposedStringWithCanonicalMapping
-        if text.unicodeScalars.count == 1,
-           let scalar = text.unicodeScalars.first,
-           (0x20..<0x7F).contains(scalar.value),
-           let logicalKey = KeyCode(uiKeyInput: text) {
-            self = logicalKey
-        } else {
-            self.init(hidUsage: hidUsage)
-        }
+    /// A translation is usable only when it names a supported printable key.
+    /// In particular, non-ASCII, multi-scalar, and sentinel text cannot replace
+    /// a valid key that was already resolved from another source.
+    private static func printableKey(for text: String) -> KeyCode? {
+        guard text.utf8.count == 1,
+              let ascii = text.utf8.first,
+              (0x20..<0x7F).contains(ascii) else { return nil }
+        return KeyCode(uiKeyInput: text)
     }
 
     /// Legacy terminal Ctrl encoding for a resolved logical key. Do not retry

--- a/rootshell/Core/Keybinds/KeyTrigger.swift
+++ b/rootshell/Core/Keybinds/KeyTrigger.swift
@@ -284,7 +284,96 @@ enum KeyCode: String, Codable, CaseIterable, Hashable, Sendable {
         KeyCode.isUIKeyInputSentinel(uiKeyInput) ? nil : uiKeyInput
     }
 
-    /// Initialize from UIKeyboardHIDUsage
+    /// Resolve a shortcut while retaining layout changes caused by Command
+    /// (for example Dvorak–QWERTY ⌘). Ctrl input still uses unmodified text.
+    @MainActor
+    init?(uiKey: UIKey, modifiers: UIKeyModifierFlags? = nil) {
+        let modifiers = modifiers ?? uiKey.modifierFlags
+        var text = uiKey.charactersIgnoringModifiers
+        if modifiers.contains(.command) {
+            // UIKey.characters preserves Command, but can also contain an
+            // Option-composed character or a Control byte. Use it only when
+            // those modifiers are absent. Shifted letters normalize safely;
+            // shifted punctuation needs the base-key identity instead.
+            let characters = uiKey.characters
+            if uiKey.modifierFlags.contains(.command),
+               uiKey.modifierFlags.intersection([.control, .alternate]).isEmpty,
+               characters.unicodeScalars.count == 1,
+               let scalar = characters.unicodeScalars.first,
+               (0x20..<0x7F).contains(scalar.value),
+               !uiKey.modifierFlags.contains(.shift) || characters.first?.isLetter == true {
+                text = characters
+            }
+
+            #if targetEnvironment(macCatalyst)
+            // Ask the active layout for Command alone, dropping Shift/Option/
+            // Control without losing its Command-specific key map. This also
+            // handles virtual Command from mod-tap and combined modifiers.
+            if let nativeKeyCode = Ghostty.Input.nativeKeyCode(for: uiKey.keyCode),
+               let translated = CatalystKeyboardLayout.shared.translateKey(
+                   cgKeyCode: UInt16(nativeKeyCode), shift: false, command: true
+               ), !translated.isEmpty {
+                text = translated
+            }
+            #endif
+        }
+        self.init(hidUsage: uiKey.keyCode, charactersIgnoringModifiers: text)
+    }
+
+    /// Resolve a named key from layout text with Shift/Option/Control removed.
+    /// Keep special keys physical: their UIKit text may be a control byte or a
+    /// sentinel, and must not turn (for example) Forward Delete into Backspace.
+    /// Missing/unsupported layout text retains the physical fallback for IMEs.
+    init?(hidUsage: UIKeyboardHIDUsage, charactersIgnoringModifiers: String) {
+        let physicalKey = KeyCode(hidUsage: hidUsage)
+        switch hidUsage {
+        case .keyboardNonUSPound, .keyboardNonUSBackslash:
+            // ISO printable positions have no US KeyCode, but UIKit can still
+            // provide a supported character for them.
+            break
+        default:
+            guard let text = physicalKey?.literalKeyInput,
+                  text.unicodeScalars.count == 1,
+                  let scalar = text.unicodeScalars.first,
+                  (0x20..<0x7F).contains(scalar.value) else {
+                self.init(hidUsage: hidUsage)
+                return
+            }
+        }
+
+        let text = charactersIgnoringModifiers.precomposedStringWithCanonicalMapping
+        if text.unicodeScalars.count == 1,
+           let scalar = text.unicodeScalars.first,
+           (0x20..<0x7F).contains(scalar.value),
+           let logicalKey = KeyCode(uiKeyInput: text) {
+            self = logicalKey
+        } else {
+            self.init(hidUsage: hidUsage)
+        }
+    }
+
+    /// Legacy terminal Ctrl encoding for a resolved logical key. Do not retry
+    /// with the physical key when this returns nil: Colemak's semicolon, for
+    /// example, occupies QWERTY's P position but must never emit Ctrl-P.
+    var controlCharacterByte: UInt8? {
+        if rawValue.utf8.count == 1,
+           let ascii = rawValue.utf8.first,
+           (97...122).contains(ascii) {
+            return ascii - 96
+        }
+        switch self {
+        case .space, .digit2, .grave: return 0
+        case .leftBracket, .digit3: return 27
+        case .backslash, .digit4: return 28
+        case .rightBracket, .digit5: return 29
+        case .digit6: return 30
+        case .minus, .underscore, .slash, .digit7: return 31
+        case .questionMark, .digit8: return 127
+        default: return nil
+        }
+    }
+
+    /// Initialize a physical key identity from UIKeyboardHIDUsage.
     init?(hidUsage: UIKeyboardHIDUsage) {
         switch hidUsage {
         case .keyboardA: self = .a
@@ -606,9 +695,9 @@ struct KeyTrigger: Codable, Hashable, CustomStringConvertible, Sendable {
         self.modifiers = modifiers
     }
 
-    /// Symbol spelling of a shifted physical trigger. The keybind system uses
-    /// US physical key identities; menu bindings can instead spell Shift+[ as
-    /// "{". Do not use the IME-produced characters to resolve these shortcuts.
+    /// Symbol alias for a shifted base-key trigger using the existing US shift
+    /// pairs. Menu bindings can spell Shift+[ as "{". The base key has already
+    /// been resolved from the layout; composed IME text is not a shortcut alias.
     var shiftedSymbolEquivalent: KeyTrigger? {
         guard modifiers.contains(.shift) else { return nil }
         let symbol: KeyCode
@@ -709,9 +798,10 @@ struct KeyTrigger: Codable, Hashable, CustomStringConvertible, Sendable {
     }
 
     /// Create from UIPress
+    @MainActor
     init?(press: UIPress) {
         guard let uiKey = press.key,
-              let key = KeyCode(hidUsage: uiKey.keyCode) else {
+              let key = KeyCode(uiKey: uiKey) else {
             return nil
         }
         self.key = key

--- a/rootshell/UI/Keyboard/CatalystKeyboardLayout.swift
+++ b/rootshell/UI/Keyboard/CatalystKeyboardLayout.swift
@@ -92,10 +92,11 @@ final class CatalystKeyboardLayout {
     /// - Parameters:
     ///   - keyCode: Native macOS CGKeyCode (NOT HID usage code)
     ///   - shift: Whether Shift is held
+    ///   - command: Whether to use the layout's Command-specific mapping
     /// - Returns: The character the key produces, or nil if translation fails.
-    func translateKey(cgKeyCode: UInt16, shift: Bool) -> String? {
-        guard let tisGetSource, let tisGetProperty, let ucKeyTranslate,
-              let lmGetKbdType, let kTISPropertyUnicodeKeyLayoutData else {
+    func translateKey(cgKeyCode: UInt16, shift: Bool, command: Bool = false) -> String? {
+        guard let tisGetSource, let tisGetProperty,
+              let kTISPropertyUnicodeKeyLayoutData else {
             return nil
         }
 
@@ -106,13 +107,19 @@ final class CatalystKeyboardLayout {
         guard let dataRef = tisGetProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
             return nil
         }
-        let layoutData = dataRef.takeUnretainedValue() as CFData
+        return translateKey(cgKeyCode: cgKeyCode, shift: shift, command: command,
+                            layoutData: dataRef.takeUnretainedValue() as CFData)
+    }
+
+    /// Translate against resolved layout data, preserving the same modifier
+    /// semantics as the current-input-source entry point above.
+    func translateKey(cgKeyCode: UInt16, shift: Bool, command: Bool, layoutData: CFData) -> String? {
+        guard let ucKeyTranslate, let lmGetKbdType else { return nil }
         let layoutPtr = CFDataGetBytePtr(layoutData)!
 
-        // Build modifier state: bit 9 = Shift (matching Carbon modifier bit layout)
-        let modifierState: UInt32 = shift ? (0x0200 >> 8) : 0
-        // Shift bit is at position 9 in the event flags, but UCKeyTranslate
-        // expects modifiers >> 8, so Shift = 0x02
+        // Carbon has Command at bit 8 and Shift at bit 9. UCKeyTranslate
+        // expects the event modifier bits shifted right by 8.
+        let modifierState: UInt32 = (command ? 0x01 : 0) | (shift ? 0x02 : 0)
 
         let kbdType = UInt32(lmGetKbdType())
         let kUCKeyActionDown: UInt16 = 0

--- a/rootshell/UI/Keyboard/CatalystKeyboardLayout.swift
+++ b/rootshell/UI/Keyboard/CatalystKeyboardLayout.swift
@@ -95,8 +95,8 @@ final class CatalystKeyboardLayout {
     ///   - command: Whether to use the layout's Command-specific mapping
     /// - Returns: The character the key produces, or nil if translation fails.
     func translateKey(cgKeyCode: UInt16, shift: Bool, command: Bool = false) -> String? {
-        guard let tisGetSource, let tisGetProperty,
-              let kTISPropertyUnicodeKeyLayoutData else {
+        guard let tisGetSource, let tisGetProperty, let ucKeyTranslate,
+              let lmGetKbdType, let kTISPropertyUnicodeKeyLayoutData else {
             return nil
         }
 
@@ -107,14 +107,7 @@ final class CatalystKeyboardLayout {
         guard let dataRef = tisGetProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
             return nil
         }
-        return translateKey(cgKeyCode: cgKeyCode, shift: shift, command: command,
-                            layoutData: dataRef.takeUnretainedValue() as CFData)
-    }
-
-    /// Translate against resolved layout data, preserving the same modifier
-    /// semantics as the current-input-source entry point above.
-    func translateKey(cgKeyCode: UInt16, shift: Bool, command: Bool, layoutData: CFData) -> String? {
-        guard let ucKeyTranslate, let lmGetKbdType else { return nil }
+        let layoutData = dataRef.takeUnretainedValue() as CFData
         let layoutPtr = CFDataGetBytePtr(layoutData)!
 
         // Carbon has Command at bit 8 and Shift at bit 9. UCKeyTranslate

--- a/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
+++ b/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
@@ -537,7 +537,8 @@ class ShortcutCaptureUIView: UIView {
             // delivery dedups via duplicateDeliveryWindow since both produce
             // the identical trigger.
             if (key.keyCode != .keyboardEscape && KeyCode.sentinelKey(for: key.characters) == .escape)
-                || ((key.keyCode == .keyboardPeriod || key.keyCode == .keyboardEscape)
+                || ((KeyCode(uiKey: key) == .period
+                     || key.keyCode == .keyboardEscape)
                     && KeyboardTracker.isSystemCancelChordPhysicallyDown()) {
                 processCapture(trigger: .commandPeriod)
                 return

--- a/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
+++ b/rootshell/UI/Settings/Keyboard/KeybindEditorView.swift
@@ -535,10 +535,10 @@ class ShortcutCaptureUIView: UIView {
             // Command stripped or as a translated Escape. Normalize either
             // representation so the chord is recordable; the twin keyCommands
             // delivery dedups via duplicateDeliveryWindow since both produce
-            // the identical trigger.
+            // the identical trigger. For stripped events, use the physical
+            // chord proven by GCKeyboard; layout text has lost Command too.
             if (key.keyCode != .keyboardEscape && KeyCode.sentinelKey(for: key.characters) == .escape)
-                || ((KeyCode(uiKey: key) == .period
-                     || key.keyCode == .keyboardEscape)
+                || ((key.keyCode == .keyboardPeriod || key.keyCode == .keyboardEscape)
                     && KeyboardTracker.isSystemCancelChordPhysicallyDown()) {
                 processCapture(trigger: .commandPeriod)
                 return

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -461,7 +461,7 @@ extension Ghostty.TerminalView {
         heldHardwareModifiers = ghosttyInputMods(from: effectiveModifiers, virtualModifier: virtualModifier)
 
         let hasOption = effectiveModifiers.contains(.alternate)
-        let logicalKey = KeyCode(uiKey: key, modifiers: effectiveModifiers)
+        lazy var logicalKey = KeyCode(uiKey: key, modifiers: effectiveModifiers)
 
         // The reserved Cmd+Period system-cancel chord can arrive translated as
         // plain Escape. Give a cmd+period binding first refusal; a twin of a
@@ -486,8 +486,8 @@ extension Ghostty.TerminalView {
         let isTranslatedCancelChord = key.keyCode != .keyboardEscape
             && KeyCode.sentinelKey(for: key.characters) == .escape
         if isTranslatedCancelChord
-            || (logicalKey == .period
-                && KeybindModifiers(uiModifierFlags: effectiveModifiers) == .command) {
+            || (KeybindModifiers(uiModifierFlags: effectiveModifiers) == .command
+                && logicalKey == .period) {
             // Translation only happens with Command physically down, so the
             // snapshot is live again.
             if isTranslatedCancelChord {
@@ -1079,7 +1079,8 @@ extension Ghostty.TerminalView {
             guard let key = press.key else { continue }
             // A translated Cmd+Period press can be tracked as Escape by the
             // overlay handlers but released at the layout's Period position.
-            if KeyCode(uiKey: key, modifiers: .command) == .period {
+            if keysConsumedByOverlayAction.contains(.keyboardEscape),
+               KeyCode(uiKey: key, modifiers: .command) == .period {
                 keysConsumedByOverlayAction.remove(.keyboardEscape)
             }
             keyRepeatManager.stopIfMatches(key.keyCode)

--- a/rootshell/UI/Terminal/TerminalView+Keyboard.swift
+++ b/rootshell/UI/Terminal/TerminalView+Keyboard.swift
@@ -461,6 +461,7 @@ extension Ghostty.TerminalView {
         heldHardwareModifiers = ghosttyInputMods(from: effectiveModifiers, virtualModifier: virtualModifier)
 
         let hasOption = effectiveModifiers.contains(.alternate)
+        let logicalKey = KeyCode(uiKey: key, modifiers: effectiveModifiers)
 
         // The reserved Cmd+Period system-cancel chord can arrive translated as
         // plain Escape. Give a cmd+period binding first refusal; a twin of a
@@ -485,7 +486,7 @@ extension Ghostty.TerminalView {
         let isTranslatedCancelChord = key.keyCode != .keyboardEscape
             && KeyCode.sentinelKey(for: key.characters) == .escape
         if isTranslatedCancelChord
-            || (key.keyCode == .keyboardPeriod
+            || (logicalKey == .period
                 && KeybindModifiers(uiModifierFlags: effectiveModifiers) == .command) {
             // Translation only happens with Command physically down, so the
             // snapshot is live again.
@@ -596,7 +597,7 @@ extension Ghostty.TerminalView {
 
         commitKoreanCompositionIfNeeded(external: true)
 
-        let hardwareTrigger = KeyCode(hidUsage: key.keyCode).map {
+        let hardwareTrigger = logicalKey.map {
             KeyTrigger(key: $0, modifiers: KeybindModifiers(uiModifierFlags: effectiveModifiers))
         }
         let bindingTrigger = hardwareTrigger.map { trigger in
@@ -612,7 +613,7 @@ extension Ghostty.TerminalView {
                 }
                 return manager.keybind(for: candidate) != nil || manager.isSequencePrefix(candidate)
             }
-            // Explicit physical-key bindings take precedence over symbol aliases.
+            // Explicit base-key bindings take precedence over symbol aliases.
             return !isClaimed(trigger) && isClaimed(symbolTrigger) ? symbolTrigger : trigger
         }
 
@@ -786,8 +787,6 @@ extension Ghostty.TerminalView {
             }
         }
 
-        // FAST PATH: Handle Ctrl+A-Z directly without KeybindManager lookup
-        // This avoids object creation and linear search overhead
         // Ctrl+key fast path: send raw control bytes for legacy terminal mode.
         // When Shift or Alt is also held, skip this path and let the Ghostty
         // encoder handle it (for correct CSI u / Kitty protocol encoding).
@@ -802,10 +801,7 @@ extension Ghostty.TerminalView {
             }
             #endif
 
-            // Check if this is a letter key (A-Z) or Ctrl+symbol
-            let keyCode = key.keyCode
-
-            if let controlByte = controlCharacterByte(for: keyCode) {
+            if let controlByte = logicalKey?.controlCharacterByte {
                 let controlData = Data([controlByte])
 
                 // Handle Ctrl-C for local shell interrupt (non-Catalyst only)
@@ -849,11 +845,11 @@ extension Ghostty.TerminalView {
         }
 
         // Handle other key combinations via KeybindManager
-        // Note: Ctrl+A-Z are handled via GCKeyboard in KeyboardTracker on all platforms
+        // Ctrl+A-Z use the fast path above or UIKeyCommand on Catalyst.
         if let trigger = bindingTrigger,
            let keybind = KeybindManager.shared.keybind(for: trigger) {
 
-            // Skip control characters - handled by fast path above (iOS) or GCKeyboard (all platforms)
+            // Skip control characters - handled by the fast path or Catalyst UIKeyCommands.
             if keybind.action.isControlCharacter {
                 return (false, false)
             }
@@ -1082,8 +1078,8 @@ extension Ghostty.TerminalView {
 
             guard let key = press.key else { continue }
             // A translated Cmd+Period press can be tracked as Escape by the
-            // overlay handlers but released as physical Period.
-            if key.keyCode == .keyboardPeriod {
+            // overlay handlers but released at the layout's Period position.
+            if KeyCode(uiKey: key, modifiers: .command) == .period {
                 keysConsumedByOverlayAction.remove(.keyboardEscape)
             }
             keyRepeatManager.stopIfMatches(key.keyCode)
@@ -1615,54 +1611,6 @@ extension Ghostty.TerminalView {
         }
 
         return 0
-    }
-
-    /// Fast lookup: Convert UIKeyboardHIDUsage to control character byte (0-31)
-    /// Returns nil if not a recognized control key
-    func controlCharacterByte(for keyCode: UIKeyboardHIDUsage) -> UInt8? {
-        switch keyCode {
-        case .keyboardSpacebar: return 0       // Ctrl+Space = NUL
-        case .keyboardA: return 1
-        case .keyboardB: return 2
-        case .keyboardC: return 3
-        case .keyboardD: return 4
-        case .keyboardE: return 5
-        case .keyboardF: return 6
-        case .keyboardG: return 7
-        case .keyboardH: return 8
-        case .keyboardI: return 9
-        case .keyboardJ: return 10
-        case .keyboardK: return 11
-        case .keyboardL: return 12
-        case .keyboardM: return 13
-        case .keyboardN: return 14
-        case .keyboardO: return 15
-        case .keyboardP: return 16
-        case .keyboardQ: return 17
-        case .keyboardR: return 18
-        case .keyboardS: return 19
-        case .keyboardT: return 20
-        case .keyboardU: return 21
-        case .keyboardV: return 22
-        case .keyboardW: return 23
-        case .keyboardX: return 24
-        case .keyboardY: return 25
-        case .keyboardZ: return 26
-        case .keyboardOpenBracket: return 27   // Ctrl+[ = ESC
-        case .keyboardBackslash: return 28     // Ctrl+\ = FS
-        case .keyboardCloseBracket: return 29  // Ctrl+] = GS
-        case .keyboard2: return 0              // Ctrl+2 = NUL
-        case .keyboard3: return 27             // Ctrl+3 = ESC
-        case .keyboard4: return 28             // Ctrl+4 = FS
-        case .keyboard5: return 29             // Ctrl+5 = GS
-        case .keyboard6: return 30             // Ctrl+6 = RS
-        case .keyboard7: return 31             // Ctrl+7 = US
-        case .keyboard8: return 127            // Ctrl+8 = DEL
-        case .keyboardHyphen: return 31        // Ctrl+- = US
-        case .keyboardSlash: return 31         // Ctrl+/ = US
-        case .keyboardGraveAccentAndTilde: return 0  // Ctrl+` = NUL
-        default: return nil
-        }
     }
 }
 


### PR DESCRIPTION
Resolve Ctrl input, shortcuts, and shortcut recording using layout-aware characters. Preserve Command-specific mappings such as Dvorak-QWERTY and physical special-key handling.