### PR TITLE
Fix zmx exposé binding unprefixed session names and switching the wrong pane

### DIFF
--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -1001,8 +1001,10 @@ final class MultiplexerExposeFeed {
             let word = words[index]
             if word == "--labels" {
                 index += 2
+                if Self.holdsAnotherLabel(words, at: index) { return nil }
             } else if word.hasPrefix("--labels=") {
                 index += 1
+                if Self.holdsAnotherLabel(words, at: index) { return nil }
             } else if word.hasPrefix("-") {
                 return nil
             } else {
@@ -1010,6 +1012,22 @@ final class MultiplexerExposeFeed {
             }
         }
         return nil
+    }
+
+    /// Whether the word at `index` is a second label rather than the session
+    /// name, which means the name cannot be recovered at all.
+    ///
+    /// `ps` output has already lost the shell's quoting, so the single word
+    /// `--labels "project=x env=prod"` arrives split exactly like a one-word
+    /// label followed by a session called `env=prod`. Nothing distinguishes
+    /// them. An unknown name leaves the feed to other evidence; a wrong one
+    /// binds the pane to a session that does not exist, and the feed shuts
+    /// down on a pane that is still attached.
+    private static func holdsAnotherLabel(_ words: [String], at index: Int) -> Bool {
+        guard index < words.count else { return false }
+        let word = words[index]
+        guard !word.hasPrefix("-"), let equals = word.firstIndex(of: "=") else { return false }
+        return equals != word.startIndex
     }
 
     /// The session name when the host runs exactly one; nil leaves the feed

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -329,7 +329,6 @@ final class MultiplexerExposeFeed {
             return
         }
 
-        claimZmxLeadershipIfShared(on: terminal, session: session)
         guard adapter.canFocus(session: session, tabID: tabID) else {
             Self.logger.info("focus declined by the adapter; leaving the pane where it is")
             return
@@ -374,26 +373,6 @@ final class MultiplexerExposeFeed {
         "echo \"::SESSIONS::\"; ZMX_SESSION= zmx list 2>/dev/null",
         nonce: "detach-census"
     )
-
-    /// Makes this pane's client the session's leader when another client
-    /// currently is.
-    ///
-    /// zmx sends a switch to the leader alone, so on a session held by several
-    /// terminals the tapped tab moves only if it happens to be the leader, and
-    /// leadership does not rotate on its own. An older client keeps it
-    /// indefinitely while this pane is only ever renamed. User input is the one
-    /// thing that transfers it, and the sequence still reaches the running
-    /// program, so it is sent only where it buys something: a session this pane
-    /// holds alone has no one to lose the switch to, and when no client is
-    /// leader the adapter's resize already covers it at no cost.
-    private func claimZmxLeadershipIfShared(on terminal: Ghostty.TerminalView, session: String?) {
-        guard let session, !session.isEmpty,
-              let zmxAdapter = adapter as? ZmxExposeAdapter,
-              let clients = zmxAdapter.clientCount(for: session), clients > 1
-        else { return }
-        Self.logger.info("claiming zmx leadership before switching; \(clients, privacy: .public) clients on \(session, privacy: .public)")
-        terminal.sendUserInput(ZmxExposeAdapter.leadershipClaim)
-    }
 
     /// Move a detachable zmx pane by typing into its own PTY.
     private func performZmxDetachSwitch(

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -686,9 +686,29 @@ final class MultiplexerExposeFeed {
         body += " awk -v i=\"$_i\" \"\\$7==i && \\$8 ~ /^\\// {print \\$8}\" /proc/net/unix 2>/dev/null;"
         body += " done; fi; done; done"
         // Exported by the user's own shell where it was used (`HERDR_SESSION=x herdr`).
-        body += "; echo \"::MX_ENV::\"; for _p in \(candidatePIDs); do echo \"::MX_PID:$_p::\";"
-        body += " [ -r \"/proc/$_p/environ\" ] && tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
-        body += " | grep -E \"^(HERDR_SESSION|HERDR_SOCKET_PATH|ZELLIJ_SESSION_NAME|ZMX_SESSION_PREFIX|SSH_CONNECTION|\(TerminalIdentity.paneTokenVariable))=\"; done"
+        //
+        // `/proc` gives one NUL-separated variable per line. macOS has none, so
+        // `ps -E` stands in: it appends the environment to the argument line,
+        // flattened on spaces. A value containing a space cannot be recovered
+        // from that, which is why SSH_CONNECTION is read from `/proc` alone --
+        // absent, its readers fall back to other evidence, where a value
+        // truncated at the first space would instead never match anything.
+        // One scan is taken, narrowed to lines that carry a variable worth
+        // having, and re-read per candidate from the pid each line starts
+        // with, rather than spawning a `ps` for every candidate.
+        let envKeys = "HERDR_SESSION|HERDR_SOCKET_PATH|ZELLIJ_SESSION_NAME|ZMX_SESSION_PREFIX"
+            + "|\(TerminalIdentity.paneTokenVariable)"
+        body += "; echo \"::MX_ENV::\""
+        body += "; _mxenv=\"\"; [ -r /proc/self/environ ]"
+        body += " || _mxenv=$(ps -xEo pid=,command= 2>/dev/null | grep -E \" (\(envKeys))=\")"
+        body += "; for _p in \(candidatePIDs); do echo \"::MX_PID:$_p::\";"
+        body += " if [ -r \"/proc/$_p/environ\" ]; then"
+        body += " tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
+        body += " | grep -E \"^(\(envKeys)|SSH_CONNECTION)=\";"
+        body += " else"
+        body += " printf \"%s\\n\" \"$_mxenv\" | awk -v p=\"$_p\" \"\\$1==p\""
+        body += " | tr \" \" \"\\n\" | grep -E \"^(\(envKeys))=\";"
+        body += " fi; done"
         // zellij's server runs as `zellij --server <sock dir>/<session>`.
         body += "; echo \"::MX_SERVERS::\"; ps -xo pid=,ppid=,args= 2>/dev/null | grep -- \"--server\" | grep -v grep"
 

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -31,6 +31,8 @@ final class MultiplexerExposeFeed {
     var ghosttyApp: Ghostty.App? { terminal?.ghosttyApp }
 
     private var adapter: (any MultiplexerExposeAdapter)?
+    /// Pane the current `adapter` was built for; see `configure(_:)`.
+    private var adapterPaneToken: String?
     private var frames: [String: MuxPaneFrame] = [:]
     private var loop: Task<Void, Never>?
     private var focusTask: Task<Void, Never>?
@@ -200,6 +202,7 @@ final class MultiplexerExposeFeed {
             type = nil
             sessionName = nil
             adapter = nil
+            adapterPaneToken = nil
             state = .detecting
         }
         onChange?()
@@ -228,11 +231,19 @@ final class MultiplexerExposeFeed {
     }
 
     private func configure(_ binding: Ghostty.TerminalView.RawMultiplexerBinding) {
+        // The adapter carries the pane's own token, which a zmx switch uses to
+        // pick this pane's client out of the session's others. One feed serves
+        // every pane in the window, so an adapter held across a change of pane
+        // would go looking for the previous pane's processes: identity belongs
+        // in the test alongside the multiplexer type.
+        let paneToken = terminal?.uuid.uuidString
         let sameMultiplexer = type == binding.type && adapter != nil
+            && adapterPaneToken == paneToken
         type = binding.type
         sessionName = binding.sessionName
         if !sameMultiplexer {
-            adapter = Self.adapter(for: binding.type, paneToken: terminal?.uuid.uuidString)
+            adapter = Self.adapter(for: binding.type, paneToken: paneToken)
+            adapterPaneToken = paneToken
         }
         interval = floorInterval
         if let terminal, let cache, cache.owner == ObjectIdentifier(terminal),

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -681,7 +681,7 @@ final class MultiplexerExposeFeed {
         // Exported by the user's own shell where it was used (`HERDR_SESSION=x herdr`).
         body += "; echo \"::MX_ENV::\"; for _p in \(candidatePIDs); do echo \"::MX_PID:$_p::\";"
         body += " [ -r \"/proc/$_p/environ\" ] && tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
-        body += " | grep -E \"^(HERDR_SESSION|HERDR_SOCKET_PATH|ZELLIJ_SESSION_NAME|SSH_CONNECTION|\(TerminalIdentity.paneTokenVariable))=\"; done"
+        body += " | grep -E \"^(HERDR_SESSION|HERDR_SOCKET_PATH|ZELLIJ_SESSION_NAME|ZMX_SESSION_PREFIX|SSH_CONNECTION|\(TerminalIdentity.paneTokenVariable))=\"; done"
         // zellij's server runs as `zellij --server <sock dir>/<session>`.
         body += "; echo \"::MX_SERVERS::\"; ps -xo pid=,ppid=,args= 2>/dev/null | grep -- \"--server\" | grep -v grep"
 
@@ -778,9 +778,14 @@ final class MultiplexerExposeFeed {
                 // fork's socket shows up here, or a host with neither `lsof`
                 // nor `/proc`.
                 var session = Self.zmxSession(in: sockets[pid] ?? [])
-                if session == nil, let index = words.firstIndex(where: { $0 == "attach" || $0 == "a" }),
-                   index + 1 < words.count, !words[index + 1].hasPrefix("-") {
-                    session = words[index + 1]
+                if session == nil, let argument = Self.zmxAttachArgument(in: words) {
+                    // The socket is named for the session; argv is named for
+                    // what the user typed. zmx resolves one to the other by
+                    // prepending `ZMX_SESSION_PREFIX` (`getSeshName`,
+                    // socket.zig), and the census lists resolved names, so a
+                    // pane bound to the typed name matches nothing there and
+                    // reads as a session that has gone away.
+                    session = ((environments[pid] ?? [:])["ZMX_SESSION_PREFIX"] ?? "") + argument
                 }
                 // Nothing to focus or to key the exposé's tab identity by
                 // without a name, and guessing one would risk moving a
@@ -946,6 +951,27 @@ final class MultiplexerExposeFeed {
         }
         guard let highest = hits.values.max() else { return nil }
         return hits.filter { $0.value == highest }.keys.sorted().first
+    }
+
+    /// The session `zmx attach` was pointed at, as typed. Mirrors zmx's own
+    /// `parseAttachArgs`: flags are recognized only ahead of the name, and
+    /// everything past it is the command the session should run.
+    private static func zmxAttachArgument(in words: [String]) -> String? {
+        guard let start = words.firstIndex(where: { $0 == "attach" || $0 == "a" }) else { return nil }
+        var index = words.index(after: start)
+        while index < words.count {
+            let word = words[index]
+            if word == "--labels" {
+                index += 2
+            } else if word.hasPrefix("--labels=") {
+                index += 1
+            } else if word.hasPrefix("-") {
+                return nil
+            } else {
+                return word
+            }
+        }
+        return nil
     }
 
     /// The session name when the host runs exactly one; nil leaves the feed

--- a/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
+++ b/rootshell/Features/Multiplexer/Expose/MultiplexerExposeFeed.swift
@@ -117,12 +117,17 @@ final class MultiplexerExposeFeed {
     }
 
     /// Returns the adapter for a supported multiplexer type.
-    static func adapter(for type: MultiplexerType) -> (any MultiplexerExposeAdapter)? {
+    /// `paneToken` is what lets a zmx switch act on this pane's own client;
+    /// callers testing only whether a type is supported can leave it out.
+    static func adapter(
+        for type: MultiplexerType,
+        paneToken: String? = nil
+    ) -> (any MultiplexerExposeAdapter)? {
         switch type {
         case .herdr: HerdrExposeAdapter()
         case .tmux: TmuxExposeAdapter()
         case .zellij: ZellijExposeAdapter()
-        case .zmx: ZmxExposeAdapter()
+        case .zmx: ZmxExposeAdapter(paneToken: paneToken)
         }
     }
 
@@ -226,7 +231,9 @@ final class MultiplexerExposeFeed {
         let sameMultiplexer = type == binding.type && adapter != nil
         type = binding.type
         sessionName = binding.sessionName
-        if !sameMultiplexer { adapter = Self.adapter(for: binding.type) }
+        if !sameMultiplexer {
+            adapter = Self.adapter(for: binding.type, paneToken: terminal?.uuid.uuidString)
+        }
         interval = floorInterval
         if let terminal, let cache, cache.owner == ObjectIdentifier(terminal),
            cache.session == "\(binding.type.rawValue):\(binding.sessionName ?? "")",
@@ -322,6 +329,7 @@ final class MultiplexerExposeFeed {
             return
         }
 
+        claimZmxLeadershipIfShared(on: terminal, session: session)
         guard adapter.canFocus(session: session, tabID: tabID) else {
             Self.logger.info("focus declined by the adapter; leaving the pane where it is")
             return
@@ -366,6 +374,26 @@ final class MultiplexerExposeFeed {
         "echo \"::SESSIONS::\"; ZMX_SESSION= zmx list 2>/dev/null",
         nonce: "detach-census"
     )
+
+    /// Makes this pane's client the session's leader when another client
+    /// currently is.
+    ///
+    /// zmx sends a switch to the leader alone, so on a session held by several
+    /// terminals the tapped tab moves only if it happens to be the leader, and
+    /// leadership does not rotate on its own. An older client keeps it
+    /// indefinitely while this pane is only ever renamed. User input is the one
+    /// thing that transfers it, and the sequence still reaches the running
+    /// program, so it is sent only where it buys something: a session this pane
+    /// holds alone has no one to lose the switch to, and when no client is
+    /// leader the adapter's resize already covers it at no cost.
+    private func claimZmxLeadershipIfShared(on terminal: Ghostty.TerminalView, session: String?) {
+        guard let session, !session.isEmpty,
+              let zmxAdapter = adapter as? ZmxExposeAdapter,
+              let clients = zmxAdapter.clientCount(for: session), clients > 1
+        else { return }
+        Self.logger.info("claiming zmx leadership before switching; \(clients, privacy: .public) clients on \(session, privacy: .public)")
+        terminal.sendUserInput(ZmxExposeAdapter.leadershipClaim)
+    }
 
     /// Move a detachable zmx pane by typing into its own PTY.
     private func performZmxDetachSwitch(

--- a/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
@@ -8,6 +8,14 @@ import Foundation
 nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
     var type: MultiplexerType { .zmx }
 
+    /// Identifies this pane's own processes on the host, so a switch can act
+    /// on the client belonging to it rather than any other attached terminal.
+    let paneToken: String?
+
+    init(paneToken: String? = nil) {
+        self.paneToken = paneToken
+    }
+
     /// `zmx list` probes session sockets serially, so use a slower tick rate.
     var minInterval: TimeInterval { 1.5 }
 
@@ -46,22 +54,27 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         return MuxScript.wrap(body, nonce: nonce)
     }
 
-    /// Exec-channel switching targets zmx's leader client, not necessarily this
-    /// pane. Only use it when this pane is the session's sole client; detachable
-    /// panes use their own PTY instead.
-    func canFocus(session: String?, tabID: String) -> Bool {
-        guard let session, !session.isEmpty, session != tabID else { return true }
-        // The before/after census still verifies a switch when no count exists.
-        guard let clients = census.clients[session] else { return true }
-        return clients <= 1
-    }
-
+    /// Switching is deliberately not gated on the session's client count.
+    /// Several clients on one session is a supported setup, and declining the
+    /// switch left a pane on a shared session unable to move at all. What zmx
+    /// will not do is pick the pane that asked: it sends the switch to the
+    /// session's leader client. So the caller takes leadership first, by
+    /// resize when no client holds it and by `leadershipClaim` when one does.
     func focusScript(session: String?, tabID: String) -> String {
         guard let session, !session.isEmpty, session != tabID else {
             return MuxScript.wrap("true", nonce: Self.focusNonce)
         }
         var body = "echo \(MuxScript.dq(MuxScript.topology(Self.focusNonce)))"
         body += "; echo \(MuxScript.dq(Self.focusBeforeMarker)); \(Self.prefix)zmx list 2>/dev/null"
+        if let paneToken, !paneToken.isEmpty {
+            // Nothing in the protocol orders these, so the margin is wall
+            // clock: the signalled client has to have sent its size before
+            // `zmx attach` opens its own connection. Both hops are local to
+            // the host and the switch still has a process to fork, so the
+            // margin is wide. Losing the race costs only the switch, which
+            // is what happened before any of this ran.
+            body += "; \(Self.claimLeadershipBody(paneToken: paneToken)); sleep 0.15"
+        }
         body += "; ZMX_SESSION=\(MuxScript.dq(session)) \(Self.prefix)zmx attach \(MuxScript.dq(tabID)) >/dev/null 2>&1"
         // The switch is fire-and-forget; wait before collecting confirmation.
         body += "; sleep 0.3"
@@ -69,7 +82,60 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         return MuxScript.wrap(body, nonce: Self.focusNonce)
     }
 
-    /// Confirms the fire-and-forget switch by comparing client counts.
+    /// A kitty-protocol tap of the left Shift key: press, then release.
+    ///
+    /// zmx switches whichever client is the session's leader, and transfers
+    /// leadership on user input and nothing else. A resize only fills a
+    /// vacancy, so leadership already held stays held however long this pane
+    /// sits idle. Input is the only way to ask zmx to move this pane, and it
+    /// reaches the running program whether or not it wins leadership, so the
+    /// sequence has to be one the program can receive without acting on it.
+    ///
+    /// A bare modifier is the closest thing to that. Programs speaking the
+    /// kitty protocol read what tapping Shift on a real keyboard sends, which
+    /// is why the release is included: a press on its own would leave them
+    /// believing Shift is held down. Programs that do not speak it see one
+    /// unrecognized CSI ending in `u` and discard it, the same way they
+    /// discard a stray device-status reply. Neither is true of every program,
+    /// so this is sent only when it decides whether the tapped tab moves or
+    /// some other terminal does.
+    static let leadershipClaim = Data("\u{1B}[57441;2:1u\u{1B}[57441;1:3u".utf8)
+
+    /// Makes this pane's client the session's leader when no client is.
+    ///
+    /// zmx clears the leader when that client disconnects, and only user input
+    /// sets it again, so a session routinely outlives its leader with none. A
+    /// switch sent in that state is fatal: the daemon answers with an
+    /// unhandled error and takes the session down, along with every terminal
+    /// still attached to it.
+    ///
+    /// SIGWINCH makes a client resend its size, and a size takes leadership
+    /// when no client holds it. It puts no bytes into the running program the
+    /// way a synthesized keystroke does, and zmx ignores it outright while
+    /// another client is leader, so it can never pull a session out from under
+    /// somebody else's terminal.
+    ///
+    /// Only the pane's own zmx processes are signalled. Its forked daemon
+    /// carries the same token and installs no handler, so reaching that one
+    /// costs nothing. Hosts without `/proc` cannot narrow the search to this
+    /// pane and are left alone.
+    private static func claimLeadershipBody(paneToken: String) -> String {
+        let needle = MuxScript.dq("\(TerminalIdentity.paneTokenVariable)=\(paneToken)")
+        var body = "if [ -r /proc/self/environ ]; then"
+        body += " for _p in $(ps -xo pid=,comm= 2>/dev/null | grep -E \"[ /]zmx$\""
+        body += " | awk \"{print \\$1}\"); do"
+        body += " tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
+        body += " | grep -qxF \(needle) || continue;"
+        body += " kill -WINCH \"$_p\" 2>/dev/null;"
+        body += " done; fi"
+        return body
+    }
+
+    /// Confirms the fire-and-forget switch by comparing client counts. The
+    /// deltas cannot say which client moved, so on a session held by several
+    /// clients a switch zmx applied to a different terminal still reads as
+    /// success. Telling them apart needs a switch addressed to one client,
+    /// which zmx has no way to express.
     func parseFocusResult(output: String, session: String?, tabID: String) -> Bool {
         guard let session, !session.isEmpty, session != tabID else {
             return true
@@ -110,7 +176,8 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         census.sessions = Set(sessions.map(\.name))
         guard !sessions.isEmpty else { return nil }
 
-        // Feeds `focusScript`'s leader guard from the listing already in hand.
+        // Feeds the detach switch's confirmation and the bound-session
+        // liveness check from the listing already in hand.
         census.clients = sessions.reduce(into: [:]) { counts, info in
             if let clients = info.clientCount { counts[info.name] = clients }
         }

--- a/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
@@ -90,30 +90,49 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
     /// Makes this pane's client the session's leader when no client is.
     ///
     /// zmx clears the leader when that client disconnects, and only user input
-    /// sets it again, so a session routinely outlives its leader with none. A
-    /// switch sent in that state is fatal: the daemon answers with an
-    /// unhandled error and takes the session down, along with every terminal
-    /// still attached to it.
+    /// sets it again, so a session routinely outlives its leader with none.
+    /// Through zmx 0.8.1 a switch sent in that state is fatal: the daemon
+    /// answers with an unhandled error and takes the session down, along with
+    /// every terminal still attached to it. Fixed upstream in `fca1964d`, where
+    /// the switch becomes a no-op instead, so this also stops mattering on
+    /// hosts running a newer zmx (neurosnap/zmx#259).
     ///
     /// SIGWINCH makes a client resend its size, and a size takes leadership
-    /// when no client holds it. It puts no bytes into the running program the
-    /// way a synthesized keystroke does, and zmx ignores it outright while
-    /// another client is leader, so it can never pull a session out from under
-    /// somebody else's terminal.
+    /// when no client holds it. It puts no bytes into the running program, and
+    /// zmx ignores it outright while another client is leader, so it can never
+    /// pull a session out from under somebody else's terminal.
     ///
     /// Only the pane's own zmx processes are signalled. Its forked daemon
     /// carries the same token and installs no handler, so reaching that one
-    /// costs nothing. Hosts without `/proc` cannot narrow the search to this
-    /// pane and are left alone.
+    /// costs nothing.
+    ///
+    /// The token lives in the client's environment, which `/proc` exposes
+    /// directly and macOS does not. There `ps -E` prints each process's
+    /// environment after its arguments, flattened onto one line, so the match
+    /// is against a whitespace-split token rather than a whole line. One scan
+    /// is taken and reused, rather than a `ps` per candidate.
+    ///
+    /// macOS hides the environment of platform binaries, so this reads a zmx
+    /// the user installed and would come back empty for one shipped with the
+    /// system. zmx is not, and the pane simply keeps its leadership alone if
+    /// that ever changes.
     private static func claimLeadershipBody(paneToken: String) -> String {
         let needle = MuxScript.dq("\(TerminalIdentity.paneTokenVariable)=\(paneToken)")
-        var body = "if [ -r /proc/self/environ ]; then"
-        body += " for _p in $(ps -xo pid=,comm= 2>/dev/null | grep -E \"[ /]zmx$\""
+        // Only scanned when /proc is absent, and narrowed to lines carrying the
+        // token so the environments of unrelated processes are never held.
+        var body = "_mxenv=\"\"; [ -r /proc/self/environ ]"
+        body += " || _mxenv=$(ps -xEo pid=,command= 2>/dev/null | grep -F \(needle))"
+        body += "; for _p in $(ps -xo pid=,comm= 2>/dev/null | grep -E \"[ /]zmx$\""
         body += " | awk \"{print \\$1}\"); do"
+        body += " if [ -r \"/proc/$_p/environ\" ]; then"
         body += " tr \"\\0\" \"\\n\" < \"/proc/$_p/environ\" 2>/dev/null"
         body += " | grep -qxF \(needle) || continue;"
+        body += " else"
+        body += " printf \"%s\\n\" \"$_mxenv\" | awk -v p=\"$_p\" \"\\$1==p\""
+        body += " | tr \" \" \"\\n\" | grep -qxF \(needle) || continue;"
+        body += " fi;"
         body += " kill -WINCH \"$_p\" 2>/dev/null;"
-        body += " done; fi"
+        body += " done"
         return body
     }
 

--- a/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
@@ -58,8 +58,13 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
     /// Several clients on one session is a supported setup, and declining the
     /// switch left a pane on a shared session unable to move at all. What zmx
     /// will not do is pick the pane that asked: it sends the switch to the
-    /// session's leader client. So the caller takes leadership first, by
-    /// resize when no client holds it and by `leadershipClaim` when one does.
+    /// session's leader client. A vacant leadership is taken by resize, which
+    /// costs the running program nothing. One another client already holds is
+    /// left alone: the only way to move it is to write bytes into the pty, and
+    /// no byte sequence is inert for every program. The switch then lands on
+    /// that other client instead, which the client-count deltas cannot tell
+    /// apart from success (neurosnap/zmx#260 asks for a switch addressed to
+    /// one client, which would settle both halves of this).
     func focusScript(session: String?, tabID: String) -> String {
         guard let session, !session.isEmpty, session != tabID else {
             return MuxScript.wrap("true", nonce: Self.focusNonce)
@@ -81,25 +86,6 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         body += "; echo \(MuxScript.dq(Self.focusAfterMarker)); \(Self.prefix)zmx list 2>/dev/null"
         return MuxScript.wrap(body, nonce: Self.focusNonce)
     }
-
-    /// A kitty-protocol tap of the left Shift key: press, then release.
-    ///
-    /// zmx switches whichever client is the session's leader, and transfers
-    /// leadership on user input and nothing else. A resize only fills a
-    /// vacancy, so leadership already held stays held however long this pane
-    /// sits idle. Input is the only way to ask zmx to move this pane, and it
-    /// reaches the running program whether or not it wins leadership, so the
-    /// sequence has to be one the program can receive without acting on it.
-    ///
-    /// A bare modifier is the closest thing to that. Programs speaking the
-    /// kitty protocol read what tapping Shift on a real keyboard sends, which
-    /// is why the release is included: a press on its own would leave them
-    /// believing Shift is held down. Programs that do not speak it see one
-    /// unrecognized CSI ending in `u` and discard it, the same way they
-    /// discard a stray device-status reply. Neither is true of every program,
-    /// so this is sent only when it decides whether the tapped tab moves or
-    /// some other terminal does.
-    static let leadershipClaim = Data("\u{1B}[57441;2:1u\u{1B}[57441;1:3u".utf8)
 
     /// Makes this pane's client the session's leader when no client is.
     ///

--- a/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
+++ b/rootshell/Features/Multiplexer/Expose/ZmxExposeAdapter.swift
@@ -62,9 +62,10 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
     /// costs the running program nothing. One another client already holds is
     /// left alone: the only way to move it is to write bytes into the pty, and
     /// no byte sequence is inert for every program. The switch then lands on
-    /// that other client instead, which the client-count deltas cannot tell
-    /// apart from success (neurosnap/zmx#260 asks for a switch addressed to
-    /// one client, which would settle both halves of this).
+    /// that other client instead, and `parseFocusResult` declines to confirm a
+    /// switch on a session other clients are attached to for that reason
+    /// (neurosnap/zmx#260 asks for a switch addressed to one client, which
+    /// would settle both halves of this).
     func focusScript(session: String?, tabID: String) -> String {
         guard let session, !session.isEmpty, session != tabID else {
             return MuxScript.wrap("true", nonce: Self.focusNonce)
@@ -136,11 +137,17 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         return body
     }
 
-    /// Confirms the fire-and-forget switch by comparing client counts. The
-    /// deltas cannot say which client moved, so on a session held by several
-    /// clients a switch zmx applied to a different terminal still reads as
-    /// success. Telling them apart needs a switch addressed to one client,
-    /// which zmx has no way to express.
+    /// Confirms the fire-and-forget switch by comparing client counts.
+    ///
+    /// The deltas say that a client moved, never which one, and zmx routes the
+    /// switch to whichever client leads the session. Confirmation is therefore
+    /// claimed only for a session this pane holds alone, where the client that
+    /// left can only be ours. With other clients attached, a switch zmx applied
+    /// to somebody else's terminal produces the same deltas, so this declines
+    /// rather than name the pane after a session it may never have entered; the
+    /// feed keeps the name it has until the next detect reads the real one.
+    /// Telling the two apart needs a switch addressed to one client, which zmx
+    /// has no way to express (neurosnap/zmx#260).
     func parseFocusResult(output: String, session: String?, tabID: String) -> Bool {
         guard let session, !session.isEmpty, session != tabID else {
             return true
@@ -157,7 +164,7 @@ nonisolated struct ZmxExposeAdapter: MultiplexerExposeAdapter {
         let after = ZmxDiscoveryParser.parse(output: "::SESSIONS::\n" + afterText)
 
         guard let beforeSessionClients = before.first(where: { $0.name == session })?.clientCount,
-              beforeSessionClients > 0
+              beforeSessionClients == 1
         else { return false }
         guard let afterSessionClients = after.first(where: { $0.name == session })?.clientCount,
               let beforeTargetClients = before.first(where: { $0.name == tabID })?.clientCount,


### PR DESCRIPTION
Five zmx exposé fixes, all independent of #439. Applies to `main` on its own.

## Session names ignore `ZMX_SESSION_PREFIX`

When a pane's zmx socket is not visible, `detect()` falls back to reading the session name out of argv, which holds the name the user typed. zmx stores the session under that name with `ZMX_SESSION_PREFIX` prepended, and `zmx list` reports the stored name.

So with the variable set to `work.`, `zmx a general` binds the pane to `general` while the listing says `work.general`. The bound name matches nothing, exposé reads the session as gone, and the feed shuts down on a pane that is still attached. The socket cannot fill the gap, since its name is only readable while the session daemon is a child of this client — not the case when the attach joined a session that already existed.

Fixed by reading `ZMX_SESSION_PREFIX` with the other pane variables and prepending it, matching `getSeshName` in zmx's `socket.zig`.

The argv walk now follows `parseAttachArgs`, so `zmx attach --labels "k=v" general` no longer comes back empty. Where `ps` has flattened the quoting past recovery it reports nothing instead of guessing: `--labels "project=x env=prod" general` splits exactly like a one-word label followed by a session called `env=prod`, and nothing distinguishes them. An unknown name leaves the feed to other evidence; a wrong one binds the pane to a session that does not exist.

## Switches move the session's leader, not the pane you tapped

zmx sends a switch to the leader client and no other, so exposé refused to switch once a session had more than one client. That left a pane sharing a session unable to move at all, which is worse than the problem it avoided. Two tabs on one session is a normal setup.

The refusal is gone. The switch script signals SIGWINCH to the pane's own zmx client, located by pane token. A resize takes leadership when no client holds it, is ignored when one does, and puts no bytes into the program.

The SIGWINCH also avoids a switch reaching a daemon whose leader has disconnected, which zmx through 0.8.1 answers with an unhandled error that kills the session and every terminal attached to it (neurosnap/zmx#259). Fixed upstream in `fca1964d`, where the switch becomes a no-op instead.

When another client already holds leadership the switch still lands on that client, and this does not change that. The only lever is writing bytes into the pty, and none are inert for every program: a sequence a kitty-protocol program reads as a bare modifier is pushed into the command line by bash's readline, and which program is running is not visible from outside the session. Addressing a switch to one client is the fix, and zmx has no way to express it (neurosnap/zmx#260).

## Exposé kept the previous pane's adapter

One feed serves every pane in the window, and it rebuilt its adapter only when the multiplexer type changed. Opening exposé on zmx pane A and then on zmx pane B therefore kept A's adapter, holding A's pane token — so a switch in B went looking for A's processes. Selecting another tab while the tray is open is enough to reach it. Pane identity is now part of the test.

## Reading the pane token without `/proc`

The token lives in the zmx client's environment. `/proc` exposes that directly; macOS has none, so `ps -E`, which appends the environment to the argument line, stands in. One scan is taken and re-read per candidate from the pid each line starts with, rather than a `ps` per process.

macOS hides the environment of platform binaries, so this finds a zmx the user installed and would come back empty for one shipped with the system. zmx is not one; if that ever changed, the switch would go out unclaimed, which is what happened before any of this existed.

`SSH_CONNECTION` stays `/proc`-only: `ps -E` flattens the environment on spaces and its value contains them, so it cannot be recovered. Absent, its readers fall back to other evidence; truncated at the first space it would instead match nothing.

## A switch is confirmed only on a session the pane holds alone

Confirmation compares client counts across the switch. The deltas say that a client moved, never which one, so on a session with other clients attached a switch zmx routed to somebody else's terminal reads exactly like this pane moving.

That case is now declined instead of confirmed, and the pane keeps the session name it has until the next detect reads the real one. A name that is briefly stale is corrected on the next reveal; one that is confidently wrong binds the pane to a session it never entered.

(NOTE: updated this description from its original version based upon the following two replies in the thread)