### PR TITLE
Restore shell-launched multiplexers in macOS local sessions

### DIFF
--- a/rootshell-helper/Sources/LocalMultiplexerRecovery.swift
+++ b/rootshell-helper/Sources/LocalMultiplexerRecovery.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+/// Runs on the helper's connection queue. The PTY, connected socket, and server
+/// process must all agree; display titles and argv session names are not proof.
+enum LocalMultiplexerRecovery {
+    typealias Record = [String: Any]
+
+    final class ProbeCache {
+        private struct Key: Hashable {
+            let executable: String
+            let arguments: [String]
+            let environment: [String]
+        }
+        private var replies: [Key: String?] = [:]
+
+        func run(_ executable: String, _ arguments: [String], environment: [String: String], deadline: Date) -> String? {
+            let key = Key(executable: executable, arguments: arguments,
+                          environment: environment.sorted { $0.key < $1.key }.flatMap { [$0.key, $0.value] })
+            if let reply = replies[key] { return reply }
+            let reply = LocalMultiplexerRecovery.run(executable, arguments, environment: environment, deadline: deadline)
+            replies.updateValue(reply, forKey: key)
+            return reply
+        }
+    }
+
+    static func processes() -> [Record] {
+        ProcessSpawner.localMultiplexerProcesses(Array(LocalMultiplexerAttachment.environmentKeys))
+    }
+
+    static func number(_ record: Record, _ key: String) -> UInt64 {
+        (record[key] as? NSNumber)?.uint64Value ?? 0
+    }
+
+    static func canonical(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+    }
+
+    static func paths(_ record: Record, _ key: String) -> Set<String> {
+        Set((record[key] as? [String] ?? []).map(canonical))
+    }
+
+    static func socketIdentity(_ path: String) -> (device: UInt64, inode: UInt64)? {
+        var info = stat()
+        guard lstat(path, &info) == 0, info.st_mode & S_IFMT == S_IFSOCK else { return nil }
+        return (UInt64(UInt32(bitPattern: info.st_dev)), UInt64(info.st_ino))
+    }
+
+    static func inspect(shellPID: Int32, pty: PTYPair, records: [Record], deadline: Date,
+                        cache: ProbeCache = ProbeCache()) -> LocalMultiplexerAttachment? {
+        // PROC_PIDTBSDINFO can return EPERM for the privileged login parent.
+        // The helper already owns this PTY and knows the PID it spawned; use
+        // the slave device for terminal identity, and stop ancestry traversal
+        // at that known PID without requiring a readable record for it.
+        var terminal = stat()
+        guard stat(pty.slavePath, &terminal) == 0, terminal.st_mode & S_IFMT == S_IFCHR else { return nil }
+        let terminalDevice = UInt64(UInt32(bitPattern: terminal.st_rdev))
+        let foreground = tcgetpgrp(pty.masterFD)
+        guard shellPID > 0, foreground > 0 else { return nil }
+        let byPID = Dictionary(records.map { (number($0, "pid"), $0) }, uniquingKeysWith: { a, _ in a })
+        func belongsToShell(_ process: Record) -> Bool {
+            var pid = number(process, "pid")
+            var visited: Set<UInt64> = []
+            while pid > 1, visited.insert(pid).inserted {
+                if pid == UInt64(shellPID) { return true }
+                guard let parent = byPID[pid] else { return false }
+                pid = number(parent, "ppid")
+            }
+            return false
+        }
+        let clients = records.filter {
+            number($0, "tty") == terminalDevice
+                && number($0, "pgid") == UInt64(foreground)
+                && $0["sockets"] != nil && belongsToShell($0)
+                && paths($0, "listeners").isEmpty
+        }
+        var attachments: [LocalMultiplexerAttachment] = []
+        for client in clients {
+            guard Date() < deadline, let executable = client["executable"] as? String else { continue }
+            let kind = (executable as NSString).lastPathComponent
+            for socket in paths(client, "sockets") {
+                let servers = records.filter {
+                    ($0["executable"] as? String).map { ($0 as NSString).lastPathComponent } == kind
+                        && number($0, "pid") != number(client, "pid")
+                        && paths($0, "listeners").contains(socket)
+                }
+                guard servers.count == 1, let server = servers.first,
+                      let identity = socketIdentity(socket) else { continue }
+                var attachment = LocalMultiplexerAttachment(
+                    kind: kind, controlMode: false, executable: executable, socketPath: socket,
+                    socketDevice: identity.device, socketInode: identity.inode,
+                    serverPID: Int32(number(server, "pid")), serverStartedAt: number(server, "startedAt"),
+                    sessionName: (socket as NSString).lastPathComponent, environment: client["environment"] as? [String: String] ?? [:])
+                if kind == "tmux" {
+                    guard let output = cache.run(executable, ["-S", socket, "list-clients", "-F",
+                        "#{client_pid}\t#{session_id}\t#{session_created}\t#{client_control_mode}\t#{q:session_name}"],
+                        environment: [:], deadline: deadline),
+                          let fields = tmuxRows(output).first(where: { $0.first == String(number(client, "pid")) }),
+                          fields.count == 5, fields[1].hasPrefix("$"),
+                          let id = Int(fields[1].dropFirst()), let created = UInt64(fields[2]) else { continue }
+                    attachment.sessionID = id
+                    attachment.sessionCreatedAt = created
+                    attachment.controlMode = fields[3] == "1"
+                    attachment.sessionName = fields[4]
+                } else if kind == "herdr" {
+                    guard (socket as NSString).lastPathComponent == "herdr-client.sock" else { continue }
+                    let directory = (socket as NSString).deletingLastPathComponent as NSString
+                    let parent = directory.deletingLastPathComponent as NSString
+                    attachment.sessionName = parent.lastPathComponent == "sessions" ? directory.lastPathComponent : "default"
+                    // Preserve a custom API socket only when this same server
+                    // owns it; otherwise verify the usual sibling API socket.
+                    let apiSocket = attachment.environment["HERDR_SOCKET_PATH"]
+                        ?? directory.appendingPathComponent("herdr.sock")
+                    guard paths(server, "listeners").contains(canonical(apiSocket)) else { continue }
+                    attachment.environment["HERDR_SOCKET_PATH"] = canonical(apiSocket)
+                }
+                guard attachment.isValid, namespaceIsLive(attachment, deadline: deadline, cache: cache) else { continue }
+                attachments.append(attachment)
+            }
+        }
+        guard let first = attachments.first, attachments.allSatisfy({ $0 == first }) else { return nil }
+        return first
+    }
+
+    static func isAvailable(_ attachment: LocalMultiplexerAttachment) -> Bool {
+        guard attachment.isValid, FileManager.default.isExecutableFile(atPath: attachment.executable),
+              let socket = socketIdentity(attachment.socketPath),
+              socket.device == attachment.socketDevice, socket.inode == attachment.socketInode,
+              processes().contains(where: {
+                  number($0, "pid") == UInt64(attachment.serverPID)
+                    && number($0, "startedAt") == attachment.serverStartedAt
+                    && paths($0, "listeners").contains(canonical(attachment.socketPath))
+              }) else { return false }
+        let deadline = Date().addingTimeInterval(6)
+        if attachment.kind == "tmux" {
+            guard let output = run(attachment.executable,
+                ["-S", attachment.socketPath, "list-sessions", "-F", "#{session_id}\t#{session_created}"],
+                environment: attachment.launchEnvironment, deadline: deadline) else { return false }
+            return tmuxRows(output).contains { $0 == ["$\(attachment.sessionID ?? -1)", String(attachment.sessionCreatedAt ?? 0)] }
+        }
+        return namespaceIsLive(attachment, deadline: deadline)
+    }
+
+    /// Verifies the CLI namespace before an attach that can create/resurrect.
+    /// The socket/server identity check above excludes a replacement session.
+    static func namespaceIsLive(_ attachment: LocalMultiplexerAttachment, deadline: Date,
+                                cache: ProbeCache = ProbeCache()) -> Bool {
+        switch attachment.kind {
+        case "tmux": return true
+        case "zmx":
+            guard let output = cache.run(attachment.executable, ["list", "--short"], environment: attachment.launchEnvironment, deadline: deadline) else { return false }
+            return output.split(separator: "\n").contains(Substring(attachment.sessionName))
+        case "zellij":
+            guard let output = cache.run(attachment.executable, ["list-sessions", "--no-formatting", "--short"], environment: attachment.launchEnvironment, deadline: deadline) else { return false }
+            // A live server owning this exact socket was already established.
+            // Short output checks CLI namespace without parsing localized prose.
+            return output.split(separator: "\n").contains(Substring(attachment.sessionName))
+        case "herdr":
+            guard let output = cache.run(attachment.executable, ["session", "list", "--json"], environment: attachment.launchEnvironment, deadline: deadline),
+                  let data = output.data(using: .utf8), let json = try? JSONSerialization.jsonObject(with: data) else { return false }
+            let rows = (json as? [[String: Any]]) ?? ((json as? [String: Any])?["sessions"] as? [[String: Any]]) ?? []
+            guard let apiSocket = attachment.launchEnvironment["HERDR_SOCKET_PATH"] else { return false }
+            return rows.contains {
+                ($0["name"] as? String) == attachment.sessionName && ($0["running"] as? Bool) == true
+                    && ($0["socket_path"] as? String).map(canonical) == canonical(apiSocket)
+            }
+        default: return false
+        }
+    }
+
+    static func tmuxRows(_ output: String) -> [[String]] {
+        var rows: [[String]] = [], row: [String] = [], field = "", escaped = false
+        for c in output {
+            if escaped { field.append(c); escaped = false }
+            else if c == "\\" { escaped = true }
+            else if c == "\t" { row.append(field); field = "" }
+            else if c == "\n" { row.append(field); rows.append(row); row = []; field = "" }
+            else { field.append(c) }
+        }
+        if escaped { return [] }
+        if !row.isEmpty || !field.isEmpty { row.append(field); rows.append(row) }
+        return rows
+    }
+
+    /// Direct exec avoids shell startup scripts changing namespaces or emitting
+    /// output. Bound both time and bytes; callers share one census deadline.
+    static func run(_ executable: String, _ arguments: [String], environment: [String: String], deadline: Date) -> String? {
+        guard Date() < deadline else { return nil }
+        let task = Process(), pipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = arguments
+        task.environment = EnvironmentBuilder().build()
+            .merging(environment) { _, new in new }
+        task.standardInput = FileHandle.nullDevice
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        do { try task.run() } catch { return nil }
+        pipe.fileHandleForWriting.closeFile()
+        let fd = pipe.fileHandleForReading.fileDescriptor
+        _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK)
+        defer { pipe.fileHandleForReading.closeFile() }
+        var data = Data(), buffer = [UInt8](repeating: 0, count: 4096)
+        var failed = false
+        while true {
+            let count = read(fd, &buffer, buffer.count)
+            if count > 0 { data.append(contentsOf: buffer.prefix(count)) }
+            if count == 0, !task.isRunning { break }
+            if count < 0 && errno != EAGAIN && errno != EINTR { failed = true; break }
+            if Date() >= deadline || data.count > 65536 { failed = true; break }
+            if count <= 0 { usleep(10_000) }
+        }
+        if failed, task.isRunning { kill(task.processIdentifier, SIGKILL) }
+        task.waitUntilExit()
+        guard !failed, task.terminationStatus == 0 else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/rootshell-helper/Sources/ProcessSpawner.h
+++ b/rootshell-helper/Sources/ProcessSpawner.h
@@ -26,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Custom command to run (nil = launch login shell)
 @property (nonatomic, copy, nullable) NSArray<NSString *> *command;
 
+/// Verified recovery command, executed once before the configured login shell.
+@property (nonatomic, copy, nullable) NSString *recoveryCommand;
+
 /// Environment variables to set
 @property (nonatomic, copy) NSDictionary<NSString *, NSString *> *environment;
 
@@ -74,6 +77,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Sends a signal to a process
 + (BOOL)killProcess:(pid_t)pid signal:(int)signal error:(NSError **)error;
+
+/// Available process ancestry plus same-user multiplexer/socket identities.
+/// Environment output contains only namespaceKeys, never the full environment.
++ (NSArray<NSDictionary<NSString *, id> *> *)localMultiplexerProcesses:(NSArray<NSString *> *)namespaceKeys;
 
 @end
 

--- a/rootshell-helper/Sources/ProcessSpawner.m
+++ b/rootshell-helper/Sources/ProcessSpawner.m
@@ -13,6 +13,9 @@
 #import <pwd.h>
 #import <signal.h>
 #import <unistd.h>
+#import <libproc.h>
+#import <sys/sysctl.h>
+#import <sys/un.h>
 
 static NSString * const RootShellFallbackShell = @"/bin/zsh -f";
 
@@ -100,6 +103,15 @@ static NSString * const RootShellFallbackShell = @"/bin/zsh -f";
         // Use /usr/bin/login to get proper login shell behavior
         // This matches macOS Ghostty and ensures proper session/foreground setup
         args = [self buildLoginCommandWithUsername:username shell:shell];
+        if (config.recoveryCommand.length > 0) {
+            NSMutableArray *recoveryArgs = [args mutableCopy];
+            // login establishes the controlling terminal before this wrapper.
+            // Keep the shell integration environment for the eventual shell,
+            // but let the attachment command use its own scoped environment.
+            recoveryArgs[recoveryArgs.count - 1] = [NSString stringWithFormat:
+                @"%@\n%@", config.recoveryCommand, args.lastObject];
+            args = recoveryArgs;
+        }
         NSLog(@"Launching via /usr/bin/login: %@", shell);
     }
 
@@ -504,6 +516,97 @@ static NSString * const RootShellFallbackShell = @"/bin/zsh -f";
 }
 
 #pragma mark - Helper Methods
+
++ (NSArray<NSDictionary<NSString *, id> *> *)localMultiplexerProcesses:(NSArray<NSString *> *)namespaceKeys {
+    int bytes = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
+    if (bytes <= 0) return @[];
+    NSMutableData *pids = [NSMutableData dataWithLength:(NSUInteger)bytes + 4096];
+    bytes = proc_listpids(PROC_ALL_PIDS, 0, pids.mutableBytes, (int)pids.length);
+    NSMutableArray *result = [NSMutableArray array];
+    NSSet *kinds = [NSSet setWithArray:@[@"tmux", @"zellij", @"herdr", @"zmx"]];
+    NSSet *allowed = [NSSet setWithArray:namespaceKeys];
+    for (int index = 0; index < bytes / sizeof(pid_t); index++) {
+        pid_t pid = ((pid_t *)pids.bytes)[index];
+        struct proc_bsdinfo info = {0};
+        if (pid <= 0 || proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, sizeof(info)) != sizeof(info)) continue;
+        // login retains a privileged parent above the user's shell. Keep its
+        // ancestry/TTY record even when we cannot inspect its executable.
+        NSMutableDictionary *record = [@{
+            @"pid": @(pid), @"ppid": @(info.pbi_ppid), @"pgid": @(info.pbi_pgid),
+            @"tty": @(info.e_tdev), @"foreground": @(info.e_tpgid),
+            @"startedAt": @(info.pbi_start_tvsec * 1000000 + info.pbi_start_tvusec)
+        } mutableCopy];
+        // Ownership gates executable, environment, and socket inspection,
+        // independently of the ancestry records needed to find local clients.
+        NSString *executable = nil;
+        if (info.pbi_uid == getuid()) {
+            char path[PROC_PIDPATHINFO_MAXSIZE] = {0};
+            if (proc_pidpath(pid, path, sizeof(path)) > 0) {
+                executable = [NSString stringWithUTF8String:path];
+                if (executable) record[@"executable"] = executable;
+            }
+        }
+        if (executable && [kinds containsObject:executable.lastPathComponent]) {
+            // KERN_PROCARGS2 preserves argument boundaries (ps does not).
+            int mib[] = {CTL_KERN, KERN_PROCARGS2, pid};
+            size_t length = 1024 * 1024;
+            NSMutableData *buffer = [NSMutableData dataWithLength:length];
+            NSMutableDictionary *environment = [NSMutableDictionary dictionary];
+            if (sysctl(mib, 3, buffer.mutableBytes, &length, NULL, 0) == 0 && length > sizeof(int)) {
+                const char *cursor = buffer.bytes, *end = cursor + length;
+                int argc = 0; memcpy(&argc, cursor, sizeof(argc)); cursor += sizeof(argc);
+                size_t count = strnlen(cursor, end - cursor); cursor += count;
+                while (cursor < end && *cursor == '\0') cursor++;
+                for (int arg = 0; arg < argc && cursor < end; arg++) {
+                    count = strnlen(cursor, end - cursor);
+                    if (cursor + count >= end) break;
+                    cursor += count + 1;
+                }
+                while (cursor < end) {
+                    count = strnlen(cursor, end - cursor);
+                    if (cursor + count >= end) break;
+                    NSString *value = [[NSString alloc] initWithBytes:cursor length:count encoding:NSUTF8StringEncoding];
+                    NSRange equals = [value rangeOfString:@"="];
+                    if (value && equals.location != NSNotFound) {
+                        NSString *key = [value substringToIndex:equals.location];
+                        if ([allowed containsObject:key]) environment[key] = [value substringFromIndex:equals.location + 1];
+                    }
+                    cursor += count + 1;
+                }
+            }
+            record[@"environment"] = environment;
+            NSMutableSet *sockets = [NSMutableSet set];
+            NSMutableSet *listeners = [NSMutableSet set];
+            int fdBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+            if (fdBytes > 0 && fdBytes < 16 * 1024 * 1024) {
+                NSMutableData *fds = [NSMutableData dataWithLength:fdBytes + 1024];
+                fdBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds.mutableBytes, (int)fds.length);
+                for (int fdIndex = 0; fdIndex < fdBytes / sizeof(struct proc_fdinfo); fdIndex++) {
+                    struct proc_fdinfo fd = ((struct proc_fdinfo *)fds.bytes)[fdIndex];
+                    if (fd.proc_fdtype != PROX_FDTYPE_SOCKET) continue;
+                    struct socket_fdinfo socket = {0};
+                    if (proc_pidfdinfo(pid, fd.proc_fd, PROC_PIDFDSOCKETINFO, &socket, sizeof(socket)) != sizeof(socket)
+                        || socket.psi.soi_kind != SOCKINFO_UN) continue;
+                    struct un_sockinfo un = socket.psi.soi_proto.pri_un;
+                    const char *paths[] = {un.unsi_addr.ua_sun.sun_path, un.unsi_caddr.ua_sun.sun_path};
+                    for (int p = 0; p < 2; p++) {
+                        size_t n = strnlen(paths[p], sizeof(un.unsi_addr.ua_sun.sun_path));
+                        if (n == 0 || paths[p][0] != '/' || n == sizeof(un.unsi_addr.ua_sun.sun_path)) continue;
+                        NSString *name = [[NSString alloc] initWithBytes:paths[p] length:n encoding:NSUTF8StringEncoding];
+                        if (name) {
+                            if (p == 1) [sockets addObject:name];
+                            if (p == 0 && (socket.psi.soi_options & SO_ACCEPTCONN)) [listeners addObject:name];
+                        }
+                    }
+                }
+            }
+            record[@"sockets"] = sockets.allObjects;
+            record[@"listeners"] = listeners.allObjects;
+        }
+        [result addObject:record];
+    }
+    return result;
+}
 
 + (char **)convertToCStringArray:(NSArray<NSString *> *)strings {
     if (!strings) return NULL;

--- a/rootshell-helper/Sources/SocketCommandServer.swift
+++ b/rootshell-helper/Sources/SocketCommandServer.swift
@@ -257,6 +257,22 @@ class SocketCommandServer {
             return handleResizeShell(request)
         case .killShell:
             return handleKillShell(request)
+        case .inspectLocalMultiplexers:
+            let records = LocalMultiplexerRecovery.processes()
+            let cache = LocalMultiplexerRecovery.ProbeCache()
+            let deadline = Date().addingTimeInterval(6)
+            var attachments: [String: LocalMultiplexerAttachment?] = [:]
+            // A single process census serves all this app's local PTYs.
+            for id in SessionManager.shared.listSessions() {
+                guard let session = SessionManager.shared.getSession(id), session.clientPID == clientPID else { continue }
+                guard Date() < deadline, !records.isEmpty else { continue }
+                let attachment = LocalMultiplexerRecovery.inspect(
+                    shellPID: session.pid, pty: session.pty, records: records, deadline: deadline, cache: cache)
+                // Missing key means unobserved (deadline/failed census); an
+                // explicit null means this PTY has no verified attachment.
+                if Date() < deadline { attachments.updateValue(attachment, forKey: id.uuidString) }
+            }
+            return SocketResponse(success: true, payload: try? JSONEncoder().encode(attachments))
         case .ping:
             return SocketResponse(success: true)
         case .executeCommand:
@@ -314,6 +330,20 @@ class SocketCommandServer {
                 resourcesDir: createRequest.resourcesDir
             )
 
+            let recoveryAccepted = createRequest.recoveryAttachment.map(LocalMultiplexerRecovery.isAvailable) ?? false
+            if let attachment = createRequest.recoveryAttachment, recoveryAccepted {
+                spawnConfig.recoveryCommand = attachment.attachCommand
+                    + " || /usr/bin/printf '%s\\n' 'Could not restore the multiplexer session; returned to shell.'"
+            }
+            if createRequest.recoveryAttachment != nil {
+                // A deleted old CWD must not prevent the recovery/fallback PTY.
+                var isDirectory: ObjCBool = false
+                if let cwd = spawnConfig.workingDirectory,
+                   !FileManager.default.fileExists(atPath: cwd, isDirectory: &isDirectory) || !isDirectory.boolValue {
+                    spawnConfig.workingDirectory = nil
+                }
+            }
+
             // Spawn shell process (creates PTY internally)
             let spawnResult = try ProcessSpawner.spawnShell(with: spawnConfig)
             let pid = spawnResult.pid
@@ -325,7 +355,8 @@ class SocketCommandServer {
             // Send response immediately with socket path
             // Catalyst app will create a server socket and wait for us to connect
             NSLog("Sending response to client with socket path: \(socketPath)")
-            let response = CreateShellResponse(sessionID: sessionID, socketPath: socketPath)
+            let response = CreateShellResponse(sessionID: sessionID, socketPath: socketPath,
+                recoverySupported: true, recoveryAccepted: recoveryAccepted)
             let responseData = try JSONEncoder().encode(response)
 
             // Send the PTY FD to the Catalyst app asynchronously

--- a/rootshell-helper/Sources/SocketProtocol.swift
+++ b/rootshell-helper/Sources/SocketProtocol.swift
@@ -13,6 +13,7 @@ enum SocketCommand: String, Codable {
     case killShell
     case ping
     case executeCommand
+    case inspectLocalMultiplexers
 }
 
 // MARK: - Request/Response Messages
@@ -62,11 +63,14 @@ struct CreateShellRequest: Codable {
     /// Stable TerminalView UUID exported as LC_ROOTSHELL_PANE. Optional for
     /// compatibility with older app builds.
     let paneToken: String?
+    var recoveryAttachment: LocalMultiplexerAttachment? = nil
 }
 
 struct CreateShellResponse: Codable {
     let sessionID: UUID
     let socketPath: String
+    var recoverySupported: Bool? = nil
+    var recoveryAccepted: Bool? = nil
 }
 
 struct ResizeShellRequest: Codable {

--- a/rootshell-helper/Tests/LocalMultiplexerRecoveryTests.swift
+++ b/rootshell-helper/Tests/LocalMultiplexerRecoveryTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+
+final class LocalMultiplexerRecoveryTests: XCTestCase {
+    private struct SavedLeaf: Codable {
+        var title: String
+        @LossyLocalMultiplexerAttachment var attachment: LocalMultiplexerAttachment? = nil
+    }
+
+    private func fixture(kind: String = "tmux") -> LocalMultiplexerAttachment {
+        LocalMultiplexerAttachment(
+            kind: kind, controlMode: kind == "tmux", executable: "/opt/homebrew/bin/\(kind)",
+            socketPath: "/tmp/recovery socket", socketDevice: 1, socketInode: 2,
+            serverPID: 123, serverStartedAt: 456, sessionName: "work ' $HOME `echo unsafe`",
+            sessionID: kind == "tmux" ? 7 : nil, sessionCreatedAt: kind == "tmux" ? 1234 : nil,
+            environment: [:])
+    }
+
+    func testOldAndUnknownRecordsDoNotDiscardLeaf() throws {
+        let old = try JSONDecoder().decode(SavedLeaf.self, from: Data(#"{"title":"kept"}"#.utf8))
+        XCTAssertEqual(old.title, "kept")
+        XCTAssertNil(old.attachment)
+        for bad in [#"{"version":999}"#, #""wrong shape""#, "42", "null"] {
+            let leaf = try JSONDecoder().decode(SavedLeaf.self, from: Data("{\"title\":\"kept\",\"attachment\":\(bad)}".utf8))
+            XCTAssertEqual(leaf.title, "kept")
+            XCTAssertNil(leaf.attachment)
+        }
+        var future = fixture()
+        future.version = 2
+        let data = try JSONEncoder().encode(SavedLeaf(title: "kept", attachment: future))
+        XCTAssertNil(try JSONDecoder().decode(SavedLeaf.self, from: data).attachment)
+    }
+
+    func testPendingAttachmentRoundTrips() throws {
+        for kind in ["tmux", "zellij", "herdr", "zmx"] {
+            let leaf = SavedLeaf(title: "pending", attachment: fixture(kind: kind))
+            let encoded = try JSONEncoder().encode(leaf)
+            let decoded = try JSONDecoder().decode(SavedLeaf.self, from: encoded)
+            XCTAssertEqual(decoded.attachment, leaf.attachment)
+        }
+    }
+
+    func testRejectsIncompleteIdentityAndUnapprovedEnvironment() {
+        var value = fixture()
+        value.sessionCreatedAt = nil
+        XCTAssertFalse(value.isValid)
+        value = fixture()
+        value.environment["DYLD_INSERT_LIBRARIES"] = "/tmp/library"
+        XCTAssertFalse(value.isValid)
+        value = fixture()
+        value.socketPath = "relative/socket"
+        XCTAssertFalse(value.isValid)
+        value = fixture()
+        value.sessionName = "first\nsecond"
+        XCTAssertFalse(value.isValid)
+    }
+
+    func testAttachUsesExactTmuxIDAndClearsNestedIdentity() {
+        let value = fixture()
+        XCTAssertEqual(value.attachArguments, ["-S", value.socketPath, "-CC", "attach-session", "-t", "$7"])
+        XCTAssertFalse(value.attachCommand.contains("new-session"))
+        XCTAssertTrue(value.attachCommand.contains("'-u' 'TMUX'"))
+        let zmx = fixture(kind: "zmx")
+        XCTAssertEqual(zmx.attachArguments, ["attach", zmx.sessionName])
+        XCTAssertEqual(zmx.launchEnvironment["ZMX_DIR"], "/tmp")
+        XCTAssertTrue(zmx.attachCommand.contains("'-u' 'ZMX_SESSION'"))
+        XCTAssertTrue(zmx.attachCommand.contains("'-u' 'ZMX_SESSION_PREFIX'"))
+    }
+
+    func testQuotedNamesRemainLiteral() {
+        let name = fixture().sessionName
+        let output = LocalMultiplexerRecovery.run("/bin/sh", ["-c", "printf '%s' " + LocalMultiplexerAttachment.quote(name)],
+            environment: [:], deadline: Date().addingTimeInterval(3))
+        XCTAssertEqual(output, name)
+    }
+
+    func testHerdrUsesVerifiedSocketWithoutSessionCLIOverride() {
+        var value = fixture(kind: "herdr")
+        value.sessionName = "default"
+        value.socketPath = "/tmp/custom/herdr-client.sock"
+        value.environment["HERDR_SOCKET_PATH"] = "/tmp/custom/herdr.sock"
+        XCTAssertEqual(value.attachArguments, [])
+        XCTAssertEqual(value.launchEnvironment["HERDR_SESSION"], "default")
+        XCTAssertEqual(value.launchEnvironment["HERDR_SOCKET_PATH"], "/tmp/custom/herdr.sock")
+        XCTAssertTrue(value.attachCommand.contains("'HERDR_SOCKET_PATH=/tmp/custom/herdr.sock'"))
+    }
+
+    func testProbeUsesExistingLocalePolicy() {
+        let output = LocalMultiplexerRecovery.run("/usr/bin/env", [], environment: [:], deadline: Date().addingTimeInterval(3))
+        let expected = EnvironmentBuilder().build()["LANG"]
+        XCTAssertEqual(output?.split(separator: "\n").first(where: { $0.hasPrefix("LANG=") }).map(String.init), expected.map { "LANG=\($0)" })
+    }
+
+    func testProbeDeadlineAlsoCoversClosedStdout() {
+        let start = Date()
+        XCTAssertNil(LocalMultiplexerRecovery.run("/bin/sh", ["-c", "exec 1>&-; exec /bin/sleep 30"],
+            environment: [:], deadline: start.addingTimeInterval(0.2)))
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+    }
+
+    func testTmuxEscapedFields() {
+        XCTAssertEqual(LocalMultiplexerRecovery.tmuxRows("42\t$7\t1234\t1\twork\\ name\\\\path\n"),
+                       [["42", "$7", "1234", "1", "work name\\path"]])
+        XCTAssertTrue(LocalMultiplexerRecovery.tmuxRows("incomplete\\").isEmpty)
+    }
+
+    /// Requires an installed tmux. Every server/client belongs to an isolated
+    /// test socket; the user's default server is never queried or modified.
+    func testLiveTmuxIdentityAndFreshPTYRecovery() throws {
+        guard let executable = ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux"].first(where: FileManager.default.isExecutableFile(atPath:)) else {
+            throw XCTSkip("tmux is not installed")
+        }
+        let directory = "/tmp/rs-recovery-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let socket = directory + "/socket"
+        func tmux(_ arguments: [String]) -> String? {
+            LocalMultiplexerRecovery.run(executable, ["-S", socket] + arguments,
+                environment: [:], deadline: Date().addingTimeInterval(4))
+        }
+        defer {
+            _ = tmux(["kill-server"])
+            try? FileManager.default.removeItem(atPath: directory)
+        }
+        XCTAssertNotNil(tmux(["-f", "/dev/null", "new-session", "-d", "-s", "original", "/bin/sh"]))
+
+        for controlMode in [false, true] {
+            let config = ShellSpawnConfig()
+            config.size = PTYSize(rows: 24, cols: 80, xpixel: 0, ypixel: 0)
+            config.environment = EnvironmentBuilder().build()
+            config.shell = "/bin/zsh -f"
+            let client = try ProcessSpawner.spawnShell(with: config)
+            // Exercise the normal login parent + shell child ancestry, rather
+            // than the custom-command path that execs tmux as the stored PID.
+            let arguments = [executable, "-S", socket] + (controlMode ? ["-CC"] : []) + ["attach-session", "-t", "=original"]
+            let input = Data((arguments.map(LocalMultiplexerAttachment.quote).joined(separator: " ") + "\n").utf8)
+            let written = input.withUnsafeBytes { write(client.pty.masterFD, $0.baseAddress, $0.count) }
+            XCTAssertEqual(written, input.count)
+            let attachment = try waitForAttachment(client)
+            let records = LocalMultiplexerRecovery.processes().filter {
+                LocalMultiplexerRecovery.number($0, "pid") != UInt64(client.pid)
+            }
+            // macOS can deny BSD info for login even to its spawning helper.
+            // A readable child PPID and the owned PTY still prove attachment.
+            XCTAssertEqual(LocalMultiplexerRecovery.inspect(shellPID: client.pid, pty: client.pty,
+                records: records, deadline: Date().addingTimeInterval(4)), attachment)
+            XCTAssertNil(LocalMultiplexerRecovery.inspect(shellPID: attachment.serverPID, pty: client.pty,
+                records: records, deadline: Date().addingTimeInterval(4)))
+            XCTAssertEqual(attachment.controlMode, controlMode)
+            XCTAssertEqual(attachment.sessionName, "original")
+            XCTAssertEqual(attachment.socketPath, LocalMultiplexerRecovery.canonical(socket))
+            XCTAssertTrue(LocalMultiplexerRecovery.isAvailable(attachment))
+            var stale = attachment
+            stale.serverStartedAt += 1
+            XCTAssertFalse(LocalMultiplexerRecovery.isAvailable(stale))
+            stale = attachment
+            stale.sessionCreatedAt = 1
+            XCTAssertFalse(LocalMultiplexerRecovery.isAvailable(stale))
+            stopClient(client)
+
+            // A newly attached client supplies a normal -CC preamble; there is
+            // no tssh stream resume and the existing server is unchanged.
+            let recovery = ShellSpawnConfig()
+            recovery.size = config.size
+            recovery.environment = config.environment
+            recovery.shell = "/bin/zsh -f"
+            recovery.recoveryCommand = attachment.attachCommand
+            let resumed = try ProcessSpawner.spawnShell(with: recovery)
+            defer { stopClient(resumed) }
+            let current = try waitForAttachment(resumed)
+            XCTAssertEqual(current.serverPID, attachment.serverPID)
+            XCTAssertEqual(current.serverStartedAt, attachment.serverStartedAt)
+            XCTAssertEqual(current.sessionID, attachment.sessionID)
+            XCTAssertEqual(current.controlMode, attachment.controlMode)
+        }
+    }
+
+    private func waitForAttachment(_ client: ShellSpawnResult) throws -> LocalMultiplexerAttachment {
+        let fd = client.pty.masterFD
+        _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK)
+        let deadline = Date().addingTimeInterval(5)
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        repeat {
+            while read(fd, &buffer, buffer.count) > 0 {}
+            if let attachment = LocalMultiplexerRecovery.inspect(shellPID: client.pid, pty: client.pty,
+                records: LocalMultiplexerRecovery.processes(), deadline: deadline) { return attachment }
+            usleep(50_000)
+        } while Date() < deadline
+        stopClient(client)
+        throw NSError(domain: "LocalMultiplexerRecoveryTests", code: 1,
+                      userInfo: [NSLocalizedDescriptionKey: "No verified attachment appeared on the test PTY"])
+    }
+
+    private func stopClient(_ client: ShellSpawnResult) {
+        // Closing the PTY hangs up this client, preserving the tmux server.
+        client.pty.close()
+        _ = kill(client.pid, SIGKILL)
+        _ = ProcessSpawner.wait(forProcess: client.pid, blocking: true)
+    }
+}

--- a/rootshell.xcodeproj/project.pbxproj
+++ b/rootshell.xcodeproj/project.pbxproj
@@ -104,6 +104,11 @@
 		47ABC10F2FF50000AABB000F /* rootshell-helper/Sources/PTYManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 47ABC10D2FF50000AABB000D /* rootshell-helper/Sources/PTYManagerImpl.m */; };
 		47ABC1102FF50000AABB0010 /* rootshell-helper/Sources/ProcessSpawner.m in Sources */ = {isa = PBXBuildFile; fileRef = 47ABC10E2FF50000AABB000E /* rootshell-helper/Sources/ProcessSpawner.m */; };
 		47AE8FBE2F4BBBAA0032A651 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 47AE8FBD2F4BBBAA0032A651 /* Localizable.xcstrings */; };
+		47AEC0010000000000000001 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AEC0010000000000000010 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift */; };
+		47AEC0010000000000000002 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AEC0010000000000000010 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift */; };
+		47AEC0010000000000000003 /* rootshell-helper/Sources/LocalMultiplexerRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AEC0010000000000000011 /* rootshell-helper/Sources/LocalMultiplexerRecovery.swift */; };
+		47AEC0010000000000000004 /* rootshell-helper/Sources/EnvironmentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AEC0010000000000000014 /* rootshell-helper/Sources/EnvironmentBuilder.swift */; };
+		47AEC0010000000000000005 /* rootshell-helper/Sources/LocaleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AEC0010000000000000015 /* rootshell-helper/Sources/LocaleHelper.swift */; };
 		47B9B9322F996A6D003FFF58 /* AppIconUnderscore.icon in Resources */ = {isa = PBXBuildFile; fileRef = 47B9B9312F996A6D003FFF58 /* AppIconUnderscore.icon */; };
 		47CD00000E00000000000000 /* SwiftkubeClient in Frameworks */ = {isa = PBXBuildFile; productRef = 477408A42ED5F6B60035CE92 /* SwiftkubeClient */; };
 		47CD00000F00000000000000 /* jq_ios in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, xros, ); productRef = 47JQPKG12FB00000AABB0001 /* jq_ios */; };
@@ -528,6 +533,10 @@
 		47ABC1172FF50000AABB0017 /* Helper.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Helper.xcconfig; sourceTree = "<group>"; };
 		47ABC1182FF50000AABB0018 /* HelperTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HelperTests.xcconfig; sourceTree = "<group>"; };
 		47AE8FBD2F4BBBAA0032A651 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		47AEC0010000000000000010 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rootshell/Core/Persistence/LocalMultiplexerAttachment.swift; sourceTree = SOURCE_ROOT; };
+		47AEC0010000000000000011 /* rootshell-helper/Sources/LocalMultiplexerRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "rootshell-helper/Sources/LocalMultiplexerRecovery.swift"; sourceTree = SOURCE_ROOT; };
+		47AEC0010000000000000014 /* rootshell-helper/Sources/EnvironmentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "rootshell-helper/Sources/EnvironmentBuilder.swift"; sourceTree = SOURCE_ROOT; };
+		47AEC0010000000000000015 /* rootshell-helper/Sources/LocaleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "rootshell-helper/Sources/LocaleHelper.swift"; sourceTree = SOURCE_ROOT; };
 		47B9B9312F996A6D003FFF58 /* AppIconUnderscore.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIconUnderscore.icon; sourceTree = "<group>"; };
 		47C100012F990000BBCC0001 /* Debug-China.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Debug-China.xcconfig"; sourceTree = "<group>"; };
 		47C100022F990000BBCC0002 /* Release-China.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release-China.xcconfig"; sourceTree = "<group>"; };
@@ -1101,6 +1110,10 @@
 			children = (
 				47ABC10D2FF50000AABB000D /* rootshell-helper/Sources/PTYManagerImpl.m */,
 				47ABC10E2FF50000AABB000E /* rootshell-helper/Sources/ProcessSpawner.m */,
+				47AEC0010000000000000010 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift */,
+				47AEC0010000000000000011 /* rootshell-helper/Sources/LocalMultiplexerRecovery.swift */,
+				47AEC0010000000000000015 /* rootshell-helper/Sources/LocaleHelper.swift */,
+				47AEC0010000000000000014 /* rootshell-helper/Sources/EnvironmentBuilder.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1995,6 +2008,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				47AEC0010000000000000001 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2002,6 +2016,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				47AEC0010000000000000005 /* rootshell-helper/Sources/LocaleHelper.swift in Sources */,
+				47AEC0010000000000000004 /* rootshell-helper/Sources/EnvironmentBuilder.swift in Sources */,
+				47AEC0010000000000000002 /* rootshell/Core/Persistence/LocalMultiplexerAttachment.swift in Sources */,
+				47AEC0010000000000000003 /* rootshell-helper/Sources/LocalMultiplexerRecovery.swift in Sources */,
 				47ABC10F2FF50000AABB000F /* rootshell-helper/Sources/PTYManagerImpl.m in Sources */,
 				47ABC1102FF50000AABB0010 /* rootshell-helper/Sources/ProcessSpawner.m in Sources */,
 			);

--- a/rootshell/Core/Helper/HelperConnection.swift
+++ b/rootshell/Core/Helper/HelperConnection.swift
@@ -18,10 +18,14 @@ import os
 public struct ShellCreateResult {
     public let sessionID: UUID
     public let socketPath: String
+    public let recoverySupported: Bool
+    public let recoveryAccepted: Bool
 
-    public init(sessionID: UUID, socketPath: String) {
+    public init(sessionID: UUID, socketPath: String, recoverySupported: Bool = false, recoveryAccepted: Bool = false) {
         self.sessionID = sessionID
         self.socketPath = socketPath
+        self.recoverySupported = recoverySupported
+        self.recoveryAccepted = recoveryAccepted
     }
 }
 
@@ -113,6 +117,7 @@ public class HelperConnection {
         shell: String? = nil,
         enableShellIntegration: Bool = true,
         paneToken: String? = nil,
+        recoveryAttachment: LocalMultiplexerAttachment? = nil,
         completion: @escaping (Result<ShellCreateResult, Error>) -> Void
     ) {
         Task {
@@ -126,7 +131,7 @@ public class HelperConnection {
                 let sshAuthSock: String? = nil
                 #endif
 
-                let (sessionID, socketPath) = try await socketConnection.createShell(
+                let response = try await socketConnection.createShell(
                     rows: rows,
                     cols: cols,
                     cwd: workingDirectory,
@@ -134,15 +139,21 @@ public class HelperConnection {
                     resourcesDir: resourcesDir,
                     enableShellIntegration: enableShellIntegration,
                     sshAuthSock: sshAuthSock,
-                    paneToken: paneToken
+                    paneToken: paneToken,
+                    recoveryAttachment: recoveryAttachment
                 )
 
-                let result = ShellCreateResult(sessionID: sessionID, socketPath: socketPath)
+                let result = ShellCreateResult(sessionID: response.sessionID, socketPath: response.socketPath,
+                    recoverySupported: response.recoverySupported ?? false, recoveryAccepted: response.recoveryAccepted ?? false)
                 completion(.success(result))
             } catch {
                 completion(.failure(error))
             }
         }
+    }
+
+    func inspectLocalMultiplexers() async throws -> [String: LocalMultiplexerAttachment?] {
+        try await socketConnection.inspectLocalMultiplexers()
     }
 
     /// Resizes a shell session

--- a/rootshell/Core/Helper/SocketHelperConnection.swift
+++ b/rootshell/Core/Helper/SocketHelperConnection.swift
@@ -13,6 +13,7 @@ import Foundation
 @available(macCatalyst 14.0, *)
 class SocketHelperConnection {
 
+    private static let inspectionQueue = DispatchQueue(label: "com.rootshell.helper.inspection", qos: .utility)
     private static let ioQueue = DispatchQueue(label: "com.rootshell.helper.socket", qos: .userInitiated)
 
     // MARK: - Public Interface
@@ -26,8 +27,9 @@ class SocketHelperConnection {
         resourcesDir: String? = nil,
         enableShellIntegration: Bool = true,
         sshAuthSock: String? = nil,
-        paneToken: String? = nil
-    ) async throws -> (sessionID: UUID, socketPath: String) {
+        paneToken: String? = nil,
+        recoveryAttachment: LocalMultiplexerAttachment? = nil
+    ) async throws -> CreateShellResponse {
         let request = CreateShellRequest(
             rows: rows,
             cols: cols,
@@ -39,7 +41,8 @@ class SocketHelperConnection {
             appVersion: TerminalIdentity.shortVersion,
             appVersionWithBuild: TerminalIdentity.version,
             termType: TerminalTypeSettings.local,
-            paneToken: paneToken
+            paneToken: paneToken,
+            recoveryAttachment: recoveryAttachment
         )
         let payload = try JSONEncoder().encode(request)
 
@@ -50,7 +53,13 @@ class SocketHelperConnection {
         }
 
         let createResponse = try JSONDecoder().decode(CreateShellResponse.self, from: responsePayload)
-        return (createResponse.sessionID, createResponse.socketPath)
+        return createResponse
+    }
+
+    func inspectLocalMultiplexers() async throws -> [String: LocalMultiplexerAttachment?] {
+        let response = try await sendCommand(.inspectLocalMultiplexers)
+        guard let payload = response.payload else { throw SocketHelperError.missingResponseData }
+        return try JSONDecoder().decode([String: LocalMultiplexerAttachment?].self, from: payload)
     }
 
     /// Resizes an existing shell session
@@ -220,7 +229,8 @@ class SocketHelperConnection {
 
         let payload = payload
         return try await withCheckedThrowingContinuation { continuation in
-            Self.ioQueue.async {
+            let queue = command == .inspectLocalMultiplexers ? Self.inspectionQueue : Self.ioQueue
+            queue.async {
             do {
                 let response = try Self.sendCommandSync(socketPath: socketPath, command: command, payload: payload)
                 if let helperPID = response.helperPID {
@@ -245,6 +255,15 @@ class SocketHelperConnection {
 
         defer {
             close(sock)
+        }
+
+        if command == .inspectLocalMultiplexers {
+            // A stalled census must not permanently stop attachment tracking.
+            // Allow headroom above the helper's shared six-second probe budget.
+            var timeout = timeval(tv_sec: 8, tv_usec: 0)
+            let size = socklen_t(MemoryLayout<timeval>.size)
+            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, size)
+            setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, size)
         }
 
         // Connect to helper

--- a/rootshell/Core/Helper/SocketProtocol.swift
+++ b/rootshell/Core/Helper/SocketProtocol.swift
@@ -13,6 +13,7 @@ enum SocketCommand: String, Codable, Sendable {
     case killShell
     case ping
     case executeCommand
+    case inspectLocalMultiplexers
 }
 
 // MARK: - Request/Response Messages
@@ -63,11 +64,14 @@ struct CreateShellRequest: Codable, Sendable {
     /// Stable TerminalView UUID exported as LC_ROOTSHELL_PANE. Optional for
     /// wire compatibility with helpers from before pane-aware push routing.
     let paneToken: String?
+    var recoveryAttachment: LocalMultiplexerAttachment? = nil
 }
 
 struct CreateShellResponse: Codable, Sendable {
     let sessionID: UUID
     let socketPath: String
+    var recoverySupported: Bool? = nil
+    var recoveryAccepted: Bool? = nil
 }
 
 struct ResizeShellRequest: Codable, Sendable {

--- a/rootshell/Core/Persistence/LocalMultiplexerAttachment.swift
+++ b/rootshell/Core/Persistence/LocalMultiplexerAttachment.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// A verified local attachment, never a shell command to replay. Shared with
+/// the helper so validation and launch use the same allowlist and wire format.
+public nonisolated struct LocalMultiplexerAttachment: Codable, Equatable, Sendable {
+    public var version: Int = 1
+    public var kind: String
+    public var controlMode: Bool
+    public var executable: String
+    public var socketPath: String
+    public var socketDevice: UInt64
+    public var socketInode: UInt64
+    public var serverPID: Int32
+    public var serverStartedAt: UInt64
+    public var sessionName: String
+    public var sessionID: Int?
+    public var sessionCreatedAt: UInt64?
+    public var environment: [String: String]
+
+    public static let environmentKeys: Set<String> = [
+        "ZELLIJ_SOCKET_DIR", "ZELLIJ_CONFIG_DIR", "ZELLIJ_CONFIG_FILE",
+        "HERDR_CONFIG_PATH", "HERDR_SOCKET_PATH", "HERDR_SESSION",
+        "ZMX_DIR", "XDG_RUNTIME_DIR", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "TMPDIR"
+    ]
+
+    public var isValid: Bool {
+        version == 1 && ["tmux", "zellij", "herdr", "zmx"].contains(kind)
+            && (!controlMode || kind == "tmux")
+            && executable.hasPrefix("/") && socketPath.hasPrefix("/")
+            && (executable as NSString).lastPathComponent == kind
+            && socketInode > 0 && serverPID > 0 && serverStartedAt > 0
+            && !sessionName.isEmpty && sessionName.utf8.count <= 1024
+            && (kind != "tmux" || (sessionID.map { $0 >= 0 } == true && sessionCreatedAt != nil))
+            && Set(environment.keys).isSubset(of: Self.environmentKeys)
+            && ([executable, socketPath, sessionName] + Array(environment.values)).allSatisfy {
+                $0.utf8.count <= 4096 && !$0.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+            }
+    }
+
+    public static func quote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// No create flags, shell aliases, or inherited inside-multiplexer identity.
+    public var attachArguments: [String] {
+        switch kind {
+        case "tmux":
+            return ["-S", socketPath] + (controlMode ? ["-CC"] : [])
+                + ["attach-session", "-t", "$\(sessionID ?? -1)"]
+        // herdr's session subcommand rejects `--` and overrides custom socket
+        // selection. Its normal entry point honors the verified API socket.
+        case "herdr": return []
+        case "zmx": return ["attach", sessionName]
+        default: return ["attach", "--", sessionName]
+        }
+    }
+
+    public var launchEnvironment: [String: String] {
+        var result = environment
+        switch kind {
+        case "zmx":
+            result["ZMX_DIR"] = (socketPath as NSString).deletingLastPathComponent
+        case "herdr":
+            result["HERDR_SESSION"] = sessionName
+            if result["HERDR_SOCKET_PATH"] == nil {
+                result["HERDR_SOCKET_PATH"] = ((socketPath as NSString).deletingLastPathComponent as NSString)
+                    .appendingPathComponent("herdr.sock")
+            }
+        default: break
+        }
+        return result
+    }
+
+    /// One trusted startup command, run by the helper before the login shell.
+    /// All variable data are single-quoted arguments, not executable syntax.
+    public var attachCommand: String {
+        let cleared = ["TMUX", "TMUX_PANE", "ZELLIJ", "ZELLIJ_SESSION_NAME", "HERDR_ENV", "ZMX_SESSION", "ZMX_SESSION_PREFIX"]
+        return (["/usr/bin/env"] + cleared.flatMap { ["-u", $0] }
+            + launchEnvironment.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }
+            + [executable] + attachArguments).map(Self.quote).joined(separator: " ")
+    }
+}
+
+/// A bad/newer optional recovery record must not discard the entire window.
+@propertyWrapper
+nonisolated struct LossyLocalMultiplexerAttachment: Codable, Equatable, Sendable {
+    var wrappedValue: LocalMultiplexerAttachment?
+    init(wrappedValue: LocalMultiplexerAttachment? = nil) { self.wrappedValue = wrappedValue }
+    init(from decoder: Decoder) throws {
+        let value = try? LocalMultiplexerAttachment(from: decoder)
+        wrappedValue = value?.isValid == true ? value : nil
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue?.isValid == true ? wrappedValue : nil)
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode(_ type: LossyLocalMultiplexerAttachment.Type, forKey key: Key) throws -> LossyLocalMultiplexerAttachment {
+        try decodeIfPresent(type, forKey: key) ?? .init()
+    }
+}

--- a/rootshell/Core/Persistence/SerializableSplitTree.swift
+++ b/rootshell/Core/Persistence/SerializableSplitTree.swift
@@ -62,6 +62,8 @@ nonisolated struct SerializableSplitTree: Codable, Equatable, Sendable {
             /// the gateway still enters tmux-resume handling, then aborts
             /// immediately so raw control-mode output is not exposed.
             let tmuxResumeCancelRequested: Bool?
+
+            @LossyLocalMultiplexerAttachment var localMultiplexerAttachment: LocalMultiplexerAttachment? = nil
         }
 
         nonisolated struct SplitData: Codable, Equatable, Sendable {
@@ -212,28 +214,16 @@ extension SplitTree where ViewType == SplitPaneView {
                 sourceProfileID: view.sourceProfileID,
                 fontSizeOverride: view.fontSizeOverride,
                 trzszLastConnectedAt: trzszLastConnectedAt,
-                // A non-nil tmuxController means this leaf is the live tmux -CC
-                // control-mode gateway. Only a trzsz/tssh gateway survives an app
-                // restart (it keeps the remote pty + tmux -CC process alive across a
-                // reconnect, then re-enters control mode in maybeResumeTmuxControlMode).
-                // A local-shell or plain-SSH gateway's control stream dies with the
-                // connection, so never flag it for resume — its projected window tabs
-                // are dropped at serialize time too (see serializeWindowState).
-                //
-                // Also persist the flag for a RESTORED gateway that hasn't resumed
-                // yet (controller still nil during the reconnect window): the
-                // placeholder window tabs can be persisted during the reconnect
-                // window, so without this resume-pending state an autosave there
-                // would save placeholders WITHOUT their gateway resume flag —
-                // stranding them as "Reconnecting tmux…" tabs forever on the next
-                // launch. (id=tmux-resume-flag-symmetric)
+                // This flag remains specific to tssh's surviving control stream.
+                // Local clients use a fresh attach described separately below.
                 wasTmuxGateway: (
                     view.tmuxController != nil
                     || view.restoredWasTmuxGateway
                     || view.tmuxResumeRequested
                     || view.tmuxResumeCancelRequested
                 ) && view.connectionConfig.isTrzsz,
-                tmuxResumeCancelRequested: view.tmuxResumeCancelRequested ? true : nil
+                tmuxResumeCancelRequested: view.tmuxResumeCancelRequested ? true : nil,
+                localMultiplexerAttachment: view.localMultiplexerAttachmentForPersistence
             )
             return .leaf(leafData)
 

--- a/rootshell/Core/Persistence/WindowStateManager.swift
+++ b/rootshell/Core/Persistence/WindowStateManager.swift
@@ -670,6 +670,23 @@ final class WindowStateManager {
         return AppWindowState(windows: windows)
     }
 
+    /// Projected tabs can restore before their gateway's scene is created.
+    /// Only unclaimed windows count; a live gateway that failed recovery must
+    /// not remain eligible because it appeared in the original launch snapshot.
+    var pendingTmuxGatewayUUIDs: Set<UUID> {
+        guard let state = unrestoredPendingState() else { return [] }
+        return Set(state.windows.flatMap(\.tabs).flatMap { $0.splitTree.allLeaves }.compactMap { leaf in
+            let type = leaf.connectionConfig.type
+            if (type == .trzsz || type == .shellLaunchedTrzsz), leaf.wasTmuxGateway == true {
+                return leaf.terminalId
+            }
+            #if targetEnvironment(macCatalyst)
+            if type == .local, leaf.localMultiplexerAttachment?.controlMode == true { return leaf.terminalId }
+            #endif
+            return nil
+        })
+    }
+
     /// Whether any REGULAR (non-visor) saved window is still awaiting restoration.
     /// Distinct from `hasPendingRestoration`, which also counts the visor entry —
     /// the visor is claimed only when summoned (and never on App Store builds), so

--- a/rootshell/Core/Terminal/TerminalSessionController.swift
+++ b/rootshell/Core/Terminal/TerminalSessionController.swift
@@ -27,6 +27,7 @@ final class TerminalSessionController {
     private let responsePipeline: TerminalResponsePipeline
     private let reconnectionController: TerminalReconnectionController
     private let historyRecorder = TerminalConnectionHistoryRecorder()
+    private var localSessionCreateGeneration: UInt64 = 0
 
     /// The active session. Settable so existing `TerminalView.session`
     /// forwarders and the transfer-receive path can still assign through the
@@ -479,6 +480,9 @@ final class TerminalSessionController {
             return
         }
 
+        localSessionCreateGeneration &+= 1
+        let generation = localSessionCreateGeneration
+        let recovery = host.terminalLocalMultiplexerRecovery
         let shell = LocalShellSettings.command
         Ghostty.logger.info("Creating Catalyst shell session: \(surfaceSize.cols)x\(surfaceSize.rows), cwd=\(workingDirectory ?? "nil"), shell=\(shell ?? "login")")
 
@@ -488,9 +492,13 @@ final class TerminalSessionController {
             workingDirectory: workingDirectory,
             shell: shell,
             enableShellIntegration: true,
-            paneToken: host.terminalUUID.uuidString
+            paneToken: host.terminalUUID.uuidString,
+            recoveryAttachment: recovery
         ) { [weak self] result in
-            guard let self, let host = self.host else { return }
+            guard let self, let host = self.host, self.localSessionCreateGeneration == generation else {
+                if case .success(let session) = result { session.stop() }
+                return
+            }
 
             switch result {
             case .success(let session):
@@ -499,6 +507,8 @@ final class TerminalSessionController {
                 self.pty = session.pty
                 host.terminalNotifySessionDidChange()
                 self.adopt(session, pty: session.pty)
+                host.terminalLocalMultiplexerSessionCreated(
+                    supported: session.recoverySupported, accepted: session.recoveryAccepted)
                 session.startMonitoring()
                 self.responsePipeline.start(for: session)
                 // Taken now so a later restore/reconnect never re-runs it.
@@ -526,6 +536,7 @@ final class TerminalSessionController {
                 }
 
             case .failure(let error):
+                if recovery != nil { host.terminalLocalMultiplexerSessionCreated(supported: false, accepted: false) }
                 Ghostty.logger.error("Failed to create Catalyst session: \(error)")
                 Task { @MainActor in
                     self.host?.terminalSetError(error)
@@ -1085,6 +1096,7 @@ final class TerminalSessionController {
     /// close: `.sceneTeardown` keeps the server-side session alive so resume
     /// can pick it back up; `.userClose`/`.transferOut` terminate it.
     func teardown(reason: Ghostty.TerminalView.CleanupReason) {
+        localSessionCreateGeneration &+= 1
         responsePipeline.cancel()
         historyRecorder.cancel()
 

--- a/rootshell/Core/Terminal/TerminalSessionHost.swift
+++ b/rootshell/Core/Terminal/TerminalSessionHost.swift
@@ -55,6 +55,8 @@ protocol TerminalSessionControllerHost: TerminalSessionHost, TerminalResponsePip
     var terminalRestorationState: Ghostty.TerminalView.RestorationState { get set }
     var terminalRestoredTrzszLastConnectedAt: Date? { get }
     var terminalRestoredWasTmuxGateway: Bool { get }
+    var terminalLocalMultiplexerRecovery: LocalMultiplexerAttachment? { get }
+    func terminalLocalMultiplexerSessionCreated(supported: Bool, accepted: Bool)
     var terminalHasTmuxController: Bool { get }
     var terminalSurfaceAvailable: Bool { get }
     var terminalSurfaceGridSize: (rows: UInt16, cols: UInt16)? { get }

--- a/rootshell/Features/LocalShell/CatalystLocalShellSession.swift
+++ b/rootshell/Features/LocalShell/CatalystLocalShellSession.swift
@@ -20,7 +20,7 @@ public class CatalystLocalShellSession: TerminalSession {
     private static let logFrequentLayout = ProcessInfo.processInfo.environment["GHOSTTY_LOG_FREQUENT_LAYOUT"] == "1"
     private static let resizeThrottleNs: UInt64 = 50_000_000  // 50ms
 
-    private let sessionID: UUID
+    let sessionID: UUID
     private let masterFD: Int32
     private let connectionStartedAt = Date()
     private let requestedShell: String?
@@ -33,6 +33,8 @@ public class CatalystLocalShellSession: TerminalSession {
     // TerminalSession protocol requirements
     public let pty: TerminalPTY
     public var isRunning = true
+    var recoverySupported = false
+    var recoveryAccepted = false
 
     // Callback-based output pattern (matches SSHSession)
     // NOTE: These callbacks may be called from a background thread (PTY read queue).
@@ -73,6 +75,7 @@ public class CatalystLocalShellSession: TerminalSession {
         shell: String? = nil,
         enableShellIntegration: Bool = true,
         paneToken: String? = nil,
+        recoveryAttachment: LocalMultiplexerAttachment? = nil,
         completion: @escaping (Result<CatalystLocalShellSession, Error>) -> Void
     ) {
         Ghostty.logger.info("Creating Catalyst shell session: \(rows)x\(cols), cwd=\(workingDirectory ?? "nil")")
@@ -83,6 +86,7 @@ public class CatalystLocalShellSession: TerminalSession {
             shell: shell,
             enableShellIntegration: enableShellIntegration,
             paneToken: paneToken,
+            recoveryAttachment: recoveryAttachment,
             retriesRemaining: 1,
             completion: completion
         )
@@ -95,6 +99,7 @@ public class CatalystLocalShellSession: TerminalSession {
         shell: String?,
         enableShellIntegration: Bool,
         paneToken: String?,
+        recoveryAttachment: LocalMultiplexerAttachment?,
         retriesRemaining: Int,
         completion: @escaping (Result<CatalystLocalShellSession, Error>) -> Void
     ) {
@@ -107,7 +112,8 @@ public class CatalystLocalShellSession: TerminalSession {
             workingDirectory: workingDirectory,
             shell: shell,
             enableShellIntegration: enableShellIntegration,
-            paneToken: paneToken
+            paneToken: paneToken,
+            recoveryAttachment: recoveryAttachment
         ) { result in
             switch result {
             case .success(let createResult):
@@ -131,6 +137,7 @@ public class CatalystLocalShellSession: TerminalSession {
                                     shell: shell,
                                     enableShellIntegration: enableShellIntegration,
                                     paneToken: paneToken,
+                                    recoveryAttachment: recoveryAttachment,
                                     retriesRemaining: retriesRemaining - 1,
                                     completion: completion
                                 )
@@ -156,6 +163,9 @@ public class CatalystLocalShellSession: TerminalSession {
                             size: size,
                             shell: shell
                         )
+
+                        session.recoverySupported = createResult.recoverySupported
+                        session.recoveryAccepted = createResult.recoveryAccepted
 
                         // Output monitoring is started by the caller after callbacks are configured
                         completion(.success(session))

--- a/rootshell/Features/LocalShell/LocalMultiplexerRestoration.swift
+++ b/rootshell/Features/LocalShell/LocalMultiplexerRestoration.swift
@@ -1,0 +1,205 @@
+import Foundation
+import GhosttyKit
+
+extension Ghostty.TerminalView {
+    var localMultiplexerAttachmentForPersistence: LocalMultiplexerAttachment? {
+        #if targetEnvironment(macCatalyst)
+        guard case .local = connectionConfig else { return nil }
+        let value = restoredLocalMultiplexerAttachment ?? localMultiplexerAttachment
+        return value?.isValid == true ? value : nil
+        #else
+        return nil
+        #endif
+    }
+
+    /// Shared by leaf and projected-tab serialization, including autosaves
+    /// while a local attachment or tssh stream resume is still pending.
+    var hasPersistableTmuxGateway: Bool {
+        if connectionConfig.isTrzsz {
+            return tmuxController != nil || restoredWasTmuxGateway || tmuxResumeRequested || tmuxResumeCancelRequested
+        }
+        return localMultiplexerAttachmentForPersistence?.controlMode == true
+    }
+
+    var isRestoringLocalTmux: Bool { restoredLocalMultiplexerAttachment?.controlMode == true }
+
+    /// A fresh client supplies its own DCS preamble. Never synthesize tssh
+    /// resume or replay the previous gateway's ANSI into this stream.
+    func releaseLocalMultiplexerScrollbackGate() -> Bool {
+        guard restoredLocalMultiplexerAttachment != nil || skipLocalMultiplexerScrollback else { return false }
+        pendingScrollbackRestore = false
+        pendingScrollbackRestoreForLayout = false
+        scrollbackWrittenAwaitingTrailer = false
+        pendingResumeTrailer = nil
+        outputPipeline.finishScrollbackRestoreGate()
+        return true
+    }
+
+    #if targetEnvironment(macCatalyst)
+    func localMultiplexerSessionCreated(supported: Bool, accepted: Bool) {
+        LocalMultiplexerTracker.shared.watch(self)
+        guard restoredLocalMultiplexerAttachment != nil else { return }
+        _ = releaseLocalMultiplexerScrollbackGate()
+        guard supported, accepted else {
+            finishLocalMultiplexerRecovery(failed: true)
+            return
+        }
+        localMultiplexerRecoveryTask?.cancel()
+        let expectedSession = session
+        localMultiplexerRecoveryTask = Task { @MainActor [weak self, weak expectedSession] in
+            try? await Task.sleep(for: .seconds(12))
+            guard !Task.isCancelled, let self, let expectedSession,
+                  self.session === expectedSession, self.restoredLocalMultiplexerAttachment != nil else { return }
+            self.cancelLocalMultiplexerRecovery()
+        }
+    }
+
+    func finishLocalMultiplexerRecovery(failed: Bool) {
+        guard let restored = restoredLocalMultiplexerAttachment else { return }
+        localMultiplexerRecoveryTask?.cancel()
+        localMultiplexerRecoveryTask = nil
+        restoredLocalMultiplexerAttachment = nil
+        restorationState = .none
+        NotificationCenter.default.post(name: .terminalRestorationStateChanged, object: self)
+        localMultiplexerAttachment = failed ? nil : restored
+        if failed {
+            let wasSelected = TmuxWindowRegistry.selectedAwaitingWindow(ownerTerminalUUID: uuid) != nil
+            removeAwaitingTmuxPlaceholders()
+            if restored.controlMode, let gateway = TmuxWindowRegistry.gatewayTab(ownerTerminalUUID: uuid) {
+                gateway.tab.isHiddenTmuxWindow = false
+                gateway.tab.pendingHiddenTmuxGatewayRestore = false
+                if wasSelected { _ = TmuxWindowRegistry.selectGateway(ownerTerminalUUID: uuid, allowFocus: false) }
+            }
+            writeToGhostty(string: "\r\n" + String(localized: "Could not restore the multiplexer session.") + "\r\n")
+        }
+        WindowStateManager.shared.saveAllState()
+    }
+
+    func cancelLocalMultiplexerRecovery() {
+        guard restoredLocalMultiplexerAttachment != nil else { return }
+        let wasControlMode = isRestoringLocalTmux
+        // Invalidate the old callbacks before closing its PTY. No server or
+        // session kill is issued; only this startup client is discarded.
+        session?.onSessionEnd = nil
+        sessionController.teardown(reason: .sceneTeardown)
+        if wasControlMode, let surface { ghostty_surface_tmux_force_exit(surface) }
+        // The helper may have substituted home for a deleted saved directory.
+        // The replacement request has no attachment, so normalize its CWD here
+        // before clearing recovery state and persisting the ordinary shell.
+        if case .local(let cwd) = connectionConfig, let cwd {
+            var isDirectory: ObjCBool = false
+            if !FileManager.default.fileExists(atPath: cwd, isDirectory: &isDirectory) || !isDirectory.boolValue {
+                connectionConfig = .local(workingDirectory: nil)
+            }
+        }
+        finishLocalMultiplexerRecovery(failed: true)
+        _ = releaseLocalMultiplexerScrollbackGate()
+        _ = sessionController.startSession()
+    }
+    #endif
+}
+
+#if targetEnvironment(macCatalyst)
+/// One helper census for every local PTY, including tabs that are not visible.
+/// Weak ownership and session-ID checks discard replies from closed/replaced PTYs.
+@MainActor
+final class LocalMultiplexerTracker {
+    static let shared = LocalMultiplexerTracker()
+    private let terminals = NSMapTable<NSUUID, Ghostty.TerminalView>.strongToWeakObjects()
+    private var timer: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
+    private var refreshAgain = false
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {
+        for name in [Notification.Name.tmuxAttachedSessionDidChange, .tmuxControlModeDidEnd] {
+            observers.append(NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] note in
+                let ended = note.name == .tmuxControlModeDidEnd
+                let id = note.object as? UUID
+                Task { @MainActor [weak self] in
+                    if let id, let view = self?.terminals.object(forKey: id as NSUUID) {
+                        view.localMultiplexerTrackingRevision &+= 1
+                        if ended || view.restoredLocalMultiplexerAttachment == nil { view.localMultiplexerAttachment = nil }
+                    }
+                    self?.refresh()
+                }
+            })
+        }
+    }
+
+    func watch(_ terminal: Ghostty.TerminalView) {
+        guard case .local = terminal.connectionConfig,
+              let session = terminal.session as? CatalystLocalShellSession, session.recoverySupported else { return }
+        terminals.setObject(terminal, forKey: terminal.uuid as NSUUID)
+        refresh()
+        guard timer == nil else { return }
+        timer = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                guard !Task.isCancelled, let self else { return }
+                guard self.terminals.objectEnumerator()?.allObjects.isEmpty == false else {
+                    self.timer = nil
+                    return
+                }
+                self.refresh()
+            }
+        }
+    }
+
+    func refresh() {
+        guard WindowStateManager.isSessionPersistenceEnabled else { return }
+        guard refreshTask == nil else { refreshAgain = true; return }
+        let views = (terminals.objectEnumerator()?.allObjects as? [Ghostty.TerminalView] ?? []).compactMap { view -> (Ghostty.TerminalView, UUID, UInt64)? in
+            guard case .local = view.connectionConfig, let session = view.session as? CatalystLocalShellSession, session.isRunning else { return nil }
+            return (view, session.sessionID, view.localMultiplexerTrackingRevision)
+        }
+        guard !views.isEmpty else { return }
+        refreshTask = Task { @MainActor [weak self] in
+            defer {
+                self?.refreshTask = nil
+                if self?.refreshAgain == true { self?.refreshAgain = false; self?.refresh() }
+            }
+            guard let result = try? await HelperConnection.shared.inspectLocalMultiplexers() else { return }
+            var changed = false
+            for (view, id, revision) in views {
+                guard (view.session as? CatalystLocalShellSession)?.sessionID == id,
+                      view.localMultiplexerTrackingRevision == revision else { continue }
+                guard let observed = result[id.uuidString] else { continue }
+                let attachment = observed.flatMap { $0.isValid ? $0 : nil }
+                if let pending = view.restoredLocalMultiplexerAttachment {
+                    guard let attachment, attachment.kind == pending.kind,
+                          attachment.controlMode == pending.controlMode,
+                          attachment.socketPath == pending.socketPath,
+                          attachment.socketDevice == pending.socketDevice, attachment.socketInode == pending.socketInode,
+                          attachment.serverPID == pending.serverPID, attachment.serverStartedAt == pending.serverStartedAt,
+                          attachment.sessionID == pending.sessionID,
+                          attachment.sessionCreatedAt == pending.sessionCreatedAt,
+                          pending.kind == "tmux" || attachment.sessionName == pending.sessionName,
+                          !pending.controlMode || view.tmuxController != nil else { continue }
+                    view.finishLocalMultiplexerRecovery(failed: false)
+                }
+                if let attachment, !attachment.controlMode, let type = MultiplexerType(rawValue: attachment.kind) {
+                    if type.ownsAlternateScreen {
+                        if view.rawMultiplexer?.type != type || view.rawMultiplexer?.sessionName != attachment.sessionName {
+                            view.rawMultiplexer = .init(type: type, sessionName: attachment.sessionName, hasOwnedAltScreen: true)
+                            AgentAttentionCenter.shared.topologyDidChange()
+                        }
+                    } else if view.passthroughMultiplexer?.sessionName != attachment.sessionName {
+                        view.passthroughMultiplexer = .init(type: type, sessionName: attachment.sessionName, canDetachSwitch: true)
+                    }
+                }
+                if view.localMultiplexerAttachment != attachment {
+                    if attachment == nil, let previous = view.localMultiplexerAttachment {
+                        if view.rawMultiplexer?.type.rawValue == previous.kind { view.rawMultiplexer = nil }
+                        if view.passthroughMultiplexer?.type.rawValue == previous.kind { view.passthroughMultiplexer = nil }
+                        AgentAttentionCenter.shared.topologyDidChange()
+                    }
+                    view.localMultiplexerAttachment = attachment
+                    changed = true
+                }
+            }
+            if changed { WindowStateManager.shared.saveAllState() }
+        }
+    }
+}
+#endif

--- a/rootshell/Features/Tmux/TmuxController.swift
+++ b/rootshell/Features/Tmux/TmuxController.swift
@@ -4028,6 +4028,13 @@ extension Ghostty.TerminalView {
             TmuxDebugLogger.shared.marker("CONTROL MODE END gw=\(uuid.uuidString.prefix(8))")
         }
 
+        #if targetEnvironment(macCatalyst)
+        if createdController || controller.didEnd {
+            if controller.didEnd { localMultiplexerAttachment = nil }
+            LocalMultiplexerTracker.shared.refresh()
+        }
+        #endif
+
         // A fresh controller (initial attach OR a resume rebuild) starts with an
         // empty per-window size map, and the resync re-sends only the stale
         // gateway-grid global size (stream_handler re-inits the viewer from the
@@ -4240,6 +4247,12 @@ extension Ghostty.TerminalView {
     /// gateway and drops every still-awaiting projected window.
     @MainActor
     func cancelTmuxRestoreRecovery() {
+        #if targetEnvironment(macCatalyst)
+        if isRestoringLocalTmux {
+            cancelLocalMultiplexerRecovery()
+            return
+        }
+        #endif
         tmuxResumeCancelRequested = true
         if tmuxResumeRequested, let surface {
             TmuxDebugLogger.shared.event("RESUME", "cancelled by user gw=\(uuid.uuidString.prefix(8))")

--- a/rootshell/UI/Shell/MainView+Persistence.swift
+++ b/rootshell/UI/Shell/MainView+Persistence.swift
@@ -36,18 +36,11 @@ extension MainView {
 
     private func resumableTmuxGatewayUUIDs() -> Set<UUID> {
         Set(
-            terminals.flatMap { $0.splitTree.terminalLeaves }
-                .filter { view in
-                    view.connectionConfig.isTrzsz
-                    && (
-                        view.tmuxController != nil
-                        || view.restoredWasTmuxGateway
-                        || view.tmuxResumeRequested
-                        || view.tmuxResumeCancelRequested
-                    )
-                }
+            (terminals + TmuxWindowRegistry.allTabsModels().flatMap(\.tabs))
+                .flatMap { $0.splitTree.terminalLeaves }
+                .filter(\.hasPersistableTmuxGateway)
                 .map(\.uuid)
-        )
+        ).union(WindowStateManager.shared.pendingTmuxGatewayUUIDs)
     }
 
     /// Serialize current window state for persistence
@@ -65,13 +58,8 @@ extension MainView {
         // `ensureWindow` stamps them) is excluded rather than restored as a bogus
         // local shell.
         //
-        // Gateways whose tmux -CC session survives an app restart: only trzsz/tssh
-        // keeps the remote pty (and the live tmux -CC process) alive across a
-        // reconnect. A local-shell or plain-SSH gateway's tmux -CC dies with the
-        // app, so its projected window tabs must NOT be persisted — they could never
-        // be re-adopted and would linger as empty, un-closable tabs. Keyed on
-        // live OR pending tmux-gateway state so an autosave during the resume
-        // window keeps placeholders only for the gateway that can adopt them.
+        // tssh can resume its stream; verified local gateways can attach a new
+        // client to the same server/session. Both can re-adopt these placeholders.
         let resumableGatewayUUIDs = resumableTmuxGatewayUUIDs()
 
         var persisted: [(tab: TabModel, serialized: SerializableTab)] = []
@@ -83,7 +71,7 @@ extension MainView {
                 // adopted placeholder only has `pendingTmuxWindowId`. Fall back to
                 // it so an autosave during the reconnect window doesn't silently
                 // drop the placeholder (which would lose its tab position). Only
-                // persist placeholders owned by a resumable (trzsz) gateway.
+                // persist placeholders owned by a recoverable gateway.
                 guard let tmuxWindowId = tab.tmuxWindowId ?? tab.pendingTmuxWindowId,
                       let owner = tab.owningGatewayTerminalUUID,
                       resumableGatewayUUIDs.contains(owner) else { continue }
@@ -107,9 +95,8 @@ extension MainView {
                     windowId: windowId,
                     // A hidden GATEWAY tab persists its flag so the hide
                     // survives an app restart — but only when the gateway can
-                    // actually resume (trzsz, mirroring wasTmuxGateway at
-                    // SerializableSplitTree); otherwise the restored pending
-                    // flag could never be consumed. The pending-restore bit
+                    // actually recover (mirroring leaf serialization); otherwise
+                    // the restored pending flag could never be consumed. The pending-restore bit
                     // counts too: during the reconnect window (restored, not
                     // yet resumed) the live flags are still false, and an
                     // autosave must not drop the preference — the same
@@ -237,14 +224,8 @@ extension MainView {
         )
         tabsModel.clearStaleGroupOverrides()
 
-        // Safety net for state saved by older builds: drop restored tmux window
-        // placeholders whose owning gateway is NOT a resumable (trzsz/tssh) session.
-        // A local-shell or plain-SSH `tmux -CC` gateway is gone after the app quits,
-        // so its projected window tabs can never be re-adopted and would otherwise
-        // linger as empty, never-reconciled tabs the user must close by hand. Current
-        // serialization already omits them, so this fires at most once per upgraded
-        // install. Runs before the selected-index restore below so its bounds check
-        // (and fallback to the gateway / tab 0) absorbs the removals.
+        // Drop orphaned or unverifiable placeholders, but retain those whose
+        // verified gateway belongs to a scene that has not restored yet.
         let resumableOwnerUUIDs = resumableTmuxGatewayUUIDs()
         terminals.removeAll { tab in
             tab.awaitingTmuxReconcile &&
@@ -502,7 +483,13 @@ extension MainView {
             terminalView.restoredTrzszLastConnectedAt = leafData.trzszLastConnectedAt
             // Remember if this leaf was a live tmux -CC gateway so the session
             // resume path can re-enter control mode (maybeResumeTmuxControlMode).
-            terminalView.restoredWasTmuxGateway = leafData.wasTmuxGateway ?? false
+            terminalView.restoredWasTmuxGateway = (leafData.wasTmuxGateway ?? false) && connectionConfig.isTrzsz
+            #if targetEnvironment(macCatalyst)
+            if case .local = connectionConfig {
+                terminalView.restoredLocalMultiplexerAttachment = leafData.localMultiplexerAttachment
+                terminalView.skipLocalMultiplexerScrollback = leafData.localMultiplexerAttachment != nil
+            }
+            #endif
             terminalView.tmuxResumeCancelRequested = leafData.tmuxResumeCancelRequested ?? false
             terminalView.restorationState = Ghostty.TerminalView.RestorationState.pendingReconnection
             terminalView.onAgentApprovalRequired = { @MainActor @Sendable request in

--- a/rootshell/UI/Terminal/TerminalView+Session.swift
+++ b/rootshell/UI/Terminal/TerminalView+Session.swift
@@ -183,6 +183,7 @@ extension Ghostty.TerminalView {
     /// their mode-restore sequences. The post-drain render+mouse-capture sync
     /// is also scheduled in that fallback path.
     func restoreScrollbackAfterAnimation(trailer: Data? = nil) {
+        if releaseLocalMultiplexerScrollbackGate() { return }
         if restoredWasTmuxGateway {
             // The gateway is hidden while its projected panes are rebuilt from
             // authoritative tmux captures. Do not replay its saved ANSI or mode
@@ -233,6 +234,7 @@ extension Ghostty.TerminalView {
     /// even when layout fires before the embedded trzsz session reaches
     /// `.running`. Other restoration paths flush the gate as before.
     func runLayoutDeferredScrollbackRestore() {
+        if releaseLocalMultiplexerScrollbackGate() { return }
         let isShellLaunchedTrzszRestore: Bool = {
             if case .shellLaunchedTrzsz = connectionConfig { return true }
             return false

--- a/rootshell/UI/Terminal/TerminalView+SessionHost.swift
+++ b/rootshell/UI/Terminal/TerminalView+SessionHost.swift
@@ -72,9 +72,19 @@ extension Ghostty.TerminalView: TerminalSessionControllerHost {
         // Cancel connection success timer if session ends prematurely.
         self.sessionController.cancelConnectionSuccessTimer()
 
+        #if targetEnvironment(macCatalyst)
+        if restoredLocalMultiplexerAttachment != nil {
+            cancelLocalMultiplexerRecovery()
+            return
+        }
+        #endif
+
         // Reconnection starts outside any picker-attached passthrough session;
         // configured bindings are restored when the new session becomes ready.
         self.passthroughMultiplexer = nil
+        self.localMultiplexerAttachment = nil
+        self.localMultiplexerRecoveryTask?.cancel()
+        self.localMultiplexerRecoveryTask = nil
 
         // Check if reconnection manager is in a state that should keep tab open
         if let state = self.sessionController.reconnectionState {
@@ -100,7 +110,7 @@ extension Ghostty.TerminalView: TerminalSessionControllerHost {
     func sessionDidBecomeReady() {
         invalidateWritingAssistance(resetDocument: true)
         // Clear restoration state if we were reconnecting from restore
-        if self.restorationState == .connectingFromRestore {
+        if self.restorationState == .connectingFromRestore, restoredLocalMultiplexerAttachment == nil {
             self.restorationState = .none
             // Notify SwiftUI to update the overlay visibility
             // (TerminalView is a class, so @State doesn't observe its property changes)
@@ -120,6 +130,10 @@ extension Ghostty.TerminalView: TerminalSessionControllerHost {
         // Record a configured multiplexer before anything reads the screen, so
         // agent detection never adopts an identity from a multi-window surface.
         self.applyConfiguredMultiplexerBinding()
+
+        // The helper is already attaching this restored local PTY. Do not
+        // present connect-time discovery over it or inject a startup command.
+        guard restoredLocalMultiplexerAttachment == nil else { return }
 
         // Send tmux auto-connect and/or launch command if configured
         self.sendLaunchCommandIfConfigured()
@@ -150,6 +164,12 @@ extension Ghostty.TerminalView {
     }
     var terminalRestoredTrzszLastConnectedAt: Date? { restoredTrzszLastConnectedAt }
     var terminalRestoredWasTmuxGateway: Bool { restoredWasTmuxGateway }
+    var terminalLocalMultiplexerRecovery: LocalMultiplexerAttachment? { restoredLocalMultiplexerAttachment }
+    func terminalLocalMultiplexerSessionCreated(supported: Bool, accepted: Bool) {
+        #if targetEnvironment(macCatalyst)
+        localMultiplexerSessionCreated(supported: supported, accepted: accepted)
+        #endif
+    }
     var terminalHasTmuxController: Bool { tmuxController != nil }
     var terminalSurfaceAvailable: Bool { surface != nil }
     var terminalSurfaceGridSize: (rows: UInt16, cols: UInt16)? {

--- a/rootshell/UI/Terminal/TerminalView.swift
+++ b/rootshell/UI/Terminal/TerminalView.swift
@@ -666,6 +666,14 @@ extension Ghostty {
         /// `maybeResumeTmuxControlMode`.
         var restoredWasTmuxGateway: Bool = false
 
+        var localMultiplexerTrackingRevision: UInt64 = 0
+        var localMultiplexerAttachment: LocalMultiplexerAttachment?
+        var restoredLocalMultiplexerAttachment: LocalMultiplexerAttachment?
+        // Remains set for this fresh PTY so late layout callbacks cannot replay
+        // stale multiplexer ANSI after the new client has already attached.
+        var skipLocalMultiplexerScrollback = false
+        var localMultiplexerRecoveryTask: Task<Void, Never>?
+
         /// True once `ghostty_surface_tmux_resume` has been fired for this
         /// restored gateway, so the resume + watchdog are armed at most once.
         var tmuxResumeRequested: Bool = false
@@ -1404,7 +1412,7 @@ extension Ghostty {
                     if let controller = self.tmuxController {
                         controller.resetForDiscard(outputLines: 0, outputBytes: droppedBytes)
                     } else if self.isTmuxGatewaySurfaceActive
-                                || self.restoredWasTmuxGateway
+                                || self.restoredWasTmuxGateway || self.isRestoringLocalTmux
                                 || self.tmuxResumeRequested {
                         // Live or resuming -CC gateway whose first reconcile
                         // hasn't created the controller yet; stash so the
@@ -1547,6 +1555,8 @@ extension Ghostty {
             activeUploader = nil
             outputMonitorTask?.cancel()
             outputMonitorTask = nil
+            localMultiplexerRecoveryTask?.cancel()
+            localMultiplexerRecoveryTask = nil
             transferAttachTask?.cancel()
             transferAttachTask = nil
             tmuxResumeGateReleaseTask?.cancel()
@@ -4656,6 +4666,13 @@ extension Ghostty.TerminalView: GhosttyActionDelegate {
     }
 
     func handleCommandFinished(exitCode: Int?, duration: TimeInterval) {
+        #if targetEnvironment(macCatalyst)
+        if session is CatalystLocalShellSession, restoredLocalMultiplexerAttachment == nil {
+            localMultiplexerTrackingRevision &+= 1
+            localMultiplexerAttachment = nil
+            LocalMultiplexerTracker.shared.refresh()
+        }
+        #endif
         // OSC 133 shell integration: exit code + wall time for the agent
         // inbox (failed/done rows, agent-exit identity clearing).
         AgentAttentionCenter.shared.commandFinished(


### PR DESCRIPTION
Persist verified local attachments and reattach them on relaunch. Preserve tmux control-mode layouts and fall back to the configured shell when recovery fails.

Use PTY identity and child ancestry without requiring privileged login process details. Add recovery regression coverage.