### PR TITLE
Fix: user-defined shell functions are unreachable from the interactive prompt

### DIFF
--- a/rootshell/Core/Shell/ShellTokenizer.swift
+++ b/rootshell/Core/Shell/ShellTokenizer.swift
@@ -86,6 +86,10 @@ nonisolated final class ShellTokenizer: @unchecked Sendable {
     /// Current line number (for error messages).
     var currentLine: Int { line }
 
+    /// Raw scan position for callers that need to preserve source spelling.
+    /// `peek()` can advance this position without consuming its cached token.
+    var sourceIndex: String.Index { index }
+
     // MARK: - Character Helpers
 
     private var isAtEnd: Bool { index >= chars.endIndex }

--- a/rootshell/Features/LocalShell/LocalShellSession+Input.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+Input.swift
@@ -592,6 +592,12 @@ extension LocalShellSession {
             return
         }
 
+        // Route user-defined shell functions to interpreter (invisible to ios_system)
+        if sharedShellEnvironment.getFunction(firstWord) != nil {
+            executeInteractiveScript(trimmedCommand)
+            return
+        }
+
         // Update tab title to show running command (truncate to 30 chars)
         let truncatedCommand = String(command.prefix(30))
         onTitleChange?(truncatedCommand)

--- a/rootshell/Features/LocalShell/LocalShellSession+Input.swift
+++ b/rootshell/Features/LocalShell/LocalShellSession+Input.swift
@@ -592,8 +592,11 @@ extension LocalShellSession {
             return
         }
 
-        // Route user-defined shell functions to interpreter (invisible to ios_system)
-        if sharedShellEnvironment.getFunction(firstWord) != nil {
+        // Function names need shell tokenization: quotes and escapes don't
+        // change the name, and operators can immediately follow it (f|cat).
+        let functionTokenizer = ShellTokenizer(source: trimmedCommand)
+        if case .word(let functionWord) = functionTokenizer.next(),
+           sharedShellEnvironment.getFunction(Self.stripPUAMarkers(functionWord)) != nil {
             executeInteractiveScript(trimmedCommand)
             return
         }
@@ -609,20 +612,22 @@ extension LocalShellSession {
         }
     }
 
-    /// Expand one leading ios_system alias before Rootshell's native-command
-    /// router runs. Without this, aliases that resolve to native commands
-    /// (`tssh`, `mosh`, `ssh`, etc.) are expanded only inside ios_system,
-    /// where those commands are not real binaries.
+    /// Expand one leading ios_system alias when native routing or a shell
+    /// function would otherwise bypass ios_system's alias expansion. The
+    /// caller's alreadyAliasExpanded flag keeps self-referential function
+    /// aliases (f='f extra') from expanding repeatedly.
     private func expandLeadingAlias(in command: String) -> String? {
         let trimmed = command.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty,
-              let split = Self.splitFirstShellWordRaw(trimmed)
+              let split = Self.splitFirstShellWordRaw(trimmed, stopAtOperators: true)
         else {
             return nil
         }
 
         let firstWord = split.word
-        guard !firstWord.hasPrefix("\\") else {
+        guard !firstWord.hasPrefix("\\"),
+              !split.remainder.trimmingCharacters(in: .whitespaces).hasPrefix("(") else {
+            // An escaped name bypasses aliases; name() defines a function.
             return nil
         }
 
@@ -635,11 +640,21 @@ extension LocalShellSession {
             return nil
         }
 
-        let remainder = split.remainder.trimmingCharacters(in: .whitespaces)
-        let expanded = Self.applyAliasArguments(aliasValue: aliasValue, remainder: remainder)
+        let aliasInput = Self.splitAliasArguments(in: trimmed)
+        var expanded = Self.applyAliasArguments(aliasValue: aliasValue, remainder: aliasInput.arguments)
             .trimmingCharacters(in: .whitespaces)
+        if !aliasInput.redirections.isEmpty {
+            expanded += " " + aliasInput.redirections
+        }
+        if !aliasInput.suffix.isEmpty {
+            expanded += " " + aliasInput.suffix
+        }
 
-        guard let expandedFirstWord = Self.splitFirstShellWordRaw(expanded)?.word else {
+        if sharedShellEnvironment.getFunction(firstWord) != nil {
+            return expanded
+        }
+
+        guard let expandedFirstWord = Self.splitFirstShellWordRaw(expanded, stopAtOperators: true)?.word else {
             return nil
         }
 
@@ -1213,7 +1228,8 @@ extension LocalShellSession {
     /// text. Quotes and backslash escapes are honored only far enough to avoid
     /// splitting inside quoted arguments; returned text keeps the user's raw
     /// quoting so native parsers and ios_system can process it normally.
-    private static func splitFirstShellWordRaw(_ command: String) -> (word: String, remainder: String)? {
+    /// Alias command names also stop at operators, including without spaces.
+    private static func splitFirstShellWordRaw(_ command: String, stopAtOperators: Bool = false) -> (word: String, remainder: String)? {
         var index = command.startIndex
         while index < command.endIndex, command[index].isWhitespace {
             index = command.index(after: index)
@@ -1252,7 +1268,9 @@ extension LocalShellSession {
                 continue
             }
 
-            if character.isWhitespace && !inSingleQuote && !inDoubleQuote {
+            if !inSingleQuote && !inDoubleQuote &&
+               (character.isWhitespace || (stopAtOperators && "|&;<>()".contains(character))) {
+                guard index > wordStart else { return nil }
                 let word = String(command[wordStart..<index])
                 let remainder = String(command[index...])
                 return (word, remainder)
@@ -1264,7 +1282,37 @@ extension LocalShellSession {
         return (String(command[wordStart..<command.endIndex]), "")
     }
 
-    /// Apply ios_system's alias argument markers to the remaining command text:
+    /// Collect all arguments of the leading command, including after redirections.
+    /// Keep redirections in their original order, separate from the arguments and
+    /// any trailing pipeline, command separator, or comment. Raw token spelling
+    /// preserves quoting, substitutions, and file-descriptor prefixes.
+    private static func splitAliasArguments(in command: String) -> (arguments: String, redirections: String, suffix: String) {
+        let tokenizer = ShellTokenizer(source: command)
+        _ = tokenizer.next() // Skip the command name.
+        var arguments: [Substring] = []
+        var redirections: [Substring] = []
+
+        while true {
+            let tokenStart = tokenizer.sourceIndex
+            let token = tokenizer.next()
+            let rawToken = command[tokenStart..<tokenizer.sourceIndex]
+                .drop(while: { $0 == " " || $0 == "\t" })
+            switch token {
+            case .word, .assignmentWord:
+                arguments.append(rawToken)
+            case .redirect:
+                redirections.append(rawToken)
+            default:
+                return (
+                    arguments.joined(separator: " "),
+                    redirections.joined(separator: " "),
+                    String(command[tokenStart...])
+                )
+            }
+        }
+    }
+
+    /// Apply ios_system's alias argument markers to arguments only:
     /// no marker appends all arguments, `!*` inserts arguments before the tail,
     /// and `!^` inserts only the first argument before the tail.
     private static func applyAliasArguments(aliasValue: String, remainder: String) -> String {
@@ -1670,8 +1718,8 @@ extension LocalShellSession {
     /// expect aliases to inherit. Most stay fully native; `git` and report-mode
     /// `mtr` may hand selected work back to ios_system after applying the same
     /// routing decisions as direct commands. Leading aliases are pre-expanded
-    /// only for this set so self-referential ios_system aliases (`ls='ls --color'`)
-    /// still expand exactly once inside ios_system.
+    /// for this set and when they shadow a shell function. Other aliases
+    /// (`ls='ls --color'`) still expand exactly once inside ios_system.
     private static let aliasPreExpansionCommandNames: Set<String> = [
         "clear", "exit", "logout",
         "ssh", "scp", "sftp", "ssh-copy-id",


### PR DESCRIPTION
A function defined in `~/.rootshellrc` (or at the prompt) is reported by `type`
as a function, but calling it from the prompt fails with `command not found`.

**Cause.** `handleCommandSubmission` in `LocalShellSession+Input.swift` sends a
command to the interpreter only when it is compound
(`ShellParser.isCompoundCommand`) or its first word is an interpreter-only
builtin (`ShellBuiltins.isInterpreterOnly`). Everything else goes to ios_system,
which can't see interpreter-level functions. `type greet` works only because
`type` is itself an interpreter-only builtin.

The bug is narrower than "functions don't work interactively". A call that
contains `$`-expansion (`greet "$1"`, `greet $HOME`) already works, because it
goes through `preExpandAndRoute`, which has an explicit guard:

```swift
// Shell functions are only visible through the interpreter. If the
// expanded command name resolves to one, we MUST NOT route to ios_system
let resolvesToFunction = sharedShellEnvironment.getFunction(commandName) != nil
```

Only expansion-free calls (`greet`, `greet a b`, `greet | grep x`) fall through
to ios_system.

**Fix.** Check `sharedShellEnvironment.getFunction(firstWord)` right after the
`isInterpreterOnly` check and before the ios_system fallthrough. It uses the
same accessor as the `preExpandAndRoute` guard. It's additive only: the new
branch sits below every native route (ssh/mosh/git/ping/…, `sh`/`bash`,
`./script`, session commands), so none of those change. There's also no new
double-routing path: `preExpandAndRoute` only re-enters `handleCommandSubmission`
for native-routed names that are *not* functions.

**Blast radius.** The app never defines shell functions itself (the only
`defineFunction` caller is the interpreter handling a user's `name() { … }`),
and the default `.rootshellrc` defines none. The change only affects users who
define functions. For them, a function that shares a name with an ios_system
command (`ls() { … }`) is now honoured on a plain prompt call too. POSIX
expects this, and it matches what already happened for `ls $HOME` and inside
scripts.

**Tests.** I didn't add a `ShellConformanceTest` case, because neither tier can
exercise this path. Both the pure and external tiers build their own
`ShellEnvironment` + `ShellInterpreter` and call `interpreter.execute`
directly, never going through `handleCommandSubmission`. The interpreter
already handles functions correctly, so any case I wrote would pass with or
without this fix.

**Tested:** `rootshell-AppStore` Debug on an iPad Pro 11-inch (M5) simulator
running iOS 26.4. Each command was typed into the local shell one at a time.
The same checks were run on `main` and on this branch:

| Command | `main` | this PR |
|---|---|---|
| `greet() { echo "hello from a function"; }`, then `type greet` | `greet is a function` | `greet is a function` |
| `greet` | `greet: command not found` | `hello from a function` |
| `argy` from `~/.rootshellrc` (auto-sourced, or after `source`), then `argy a b` | `argy: command not found` | `got:a:b` |
| `false_fn` (`return 3`), then `echo $?` on the next line | `127` | `3` |
| `hi() { echo interactive-def; }`, then `hi` | — | `interactive-def` |
| `greet \| grep -c hello` | — | `1` |

Regressions, all unchanged on this branch: `ls`, `echo hi | grep hi`,
`sleep 1`, `printf '%s\n' ok`, `sh -c 'echo subshell'`,
`git status` (still routed to git), and `./s.sh` (an executable script).
`shelltest`: 79 passed, 0 failed, 0 xfail, 0 xpass, 0 skipped. That's the pure
tier, which doesn't go through the routing layer, so it only shows nothing else broke.
Not run: `ssh` (native routes return before the new branch) and
`shelltest external`.
